### PR TITLE
docs: add beginner tips section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,11 @@ Moss's guarantees, boundaries, and how to report vulnerabilities: [SECURITY.md](
 ## License
 
 [MIT](./LICENSE)
+## Beginner Tips
+
+If you are using Moss for the first time, it is recommended to:
+
+- Read the README completely before installation.
+- Prepare your API keys in advance.
+- Start with the simplest example before building your own Agent.
+- Refer to the official documentation when configuring models and tools.


### PR DESCRIPTION
## Summary

This PR adds a short "Beginner Tips" section to the README.

### Changes

- Add a few suggestions for first-time users.
- Improve the onboarding experience.
- Help new contributors get started more easily.

Thank you for reviewing!