### PR TITLE
fix: preserve LF line endings across checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Moss compares generated source and runs formatter checks in every contributor checkout.
+# Keep text files on LF so Git's core.autocrlf setting cannot change test inputs.
+* text=auto eol=lf


### PR DESCRIPTION
## What & why

Fixes #18.

The Kuru ABI provenance test compares the checked-in generated TypeScript file with the generator output. The generator emits LF, but Git can check out text as CRLF when a Windows contributor uses `core.autocrlf=true`; that makes the test fail despite identical generated content. The same checkout conversion also makes Biome report formatting differences for other text files.

This adds a root `.gitattributes` rule to check out text as LF while leaving binary files under Git's normal text detection. It preserves the existing byte-level provenance assertion and makes formatter/test inputs stable across contributor platforms.

## Type of change

- [x] Bugfix

## Checklist

- [x] `MOSS_SKIP_E2E=1 pnpm test` passes in a fresh `core.autocrlf=true` checkout
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] No changeset needed: this only changes repository checkout behavior, not published package APIs

## Evidence

Before the change, a fresh `core.autocrlf=true` checkout had 2365 CRLF line endings in `packages/protocols/kuru/src/abis/kuru.ts`, and the Kuru ABI provenance test failed as described in #18. With this change, that generated file, `biome.json`, and `pnpm-lock.yaml` all check out with LF; the offline test suite and all local checks above pass.