### PR TITLE
feat(protocols): add PancakeSwap v2 adapter

### DIFF
--- a/.changeset/pancakeswap-v2.md
+++ b/.changeset/pancakeswap-v2.md
@@ -1,0 +1,6 @@
+---
+"@themoss/protocol-pancakeswap": minor
+"@themoss/mcp-server": minor
+---
+
+Add the self-describing PancakeSwap V2 Protocol for exact-input and target-output swaps, direct and WMON-hop routing, nested ERC-20 approvals, exhaustive Receipts, and default MCP discovery.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | ERC-20 and native MON | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `allowance`, `metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 
 ## Quickstart
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | ERC-20 与 native MON | `@themoss/erc` | `transfer`、`approve` | `balanceOf`、`allowance`、`metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 
 ## 快速开始
 

--- a/examples/simple-flow/package.json
+++ b/examples/simple-flow/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "wrap": "tsx src/wmon-wrap.ts",
     "swap": "tsx src/kuru-swap.ts",
+    "pancakeswap-v2": "tsx src/pancakeswap-v2-swap.ts",
     "typecheck": "tsc --noEmit",
     "test": "echo \"examples are exercised by e2e tests in packages\" && exit 0",
     "build": "echo \"examples are not built\" && exit 0"
@@ -14,6 +15,7 @@
     "@themoss/core": "workspace:*",
     "@themoss/erc": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
+    "@themoss/protocol-pancakeswap": "workspace:*",
     "@themoss/simulator": "workspace:*",
     "@themoss/system": "workspace:*",
     "viem": "^2.54.3"

--- a/examples/simple-flow/src/pancakeswap-v2-swap.ts
+++ b/examples/simple-flow/src/pancakeswap-v2-swap.ts
@@ -1,0 +1,42 @@
+/** Quote, build, and simulate one PancakeSwap v2 Capability. */
+import { NATIVE, Registry } from "@themoss/core";
+import * as pancakeswap from "@themoss/protocol-pancakeswap";
+import { createTraceSimulator } from "@themoss/simulator";
+import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
+
+const ACCOUNT = (process.env.MOSS_ACCOUNT ??
+  "0xcccccccccccccccccccccccccccccccccccccccc") as `0x${string}`;
+const runtime = await monadRuntime({
+  ...(process.env.MOSS_RPC_URL ? { rpcUrl: process.env.MOSS_RPC_URL } : {}),
+});
+const registry = new Registry(runtime).use(pancakeswap);
+const simulator = createTraceSimulator(runtime, {
+  receipt: (capability, changes) => registry.parseReceipt(capability, changes),
+});
+
+const quote = await registry.action("pancakeswap-v2", "quote", ACCOUNT, {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1",
+});
+if (quote.kind !== "query") throw new Error("expected a Query result");
+console.log("quote", quote.data);
+
+const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1",
+  slippage: 50,
+});
+if (capability.kind !== "capability") throw new Error("expected a Capability");
+console.log("capability", capability);
+
+const outcome = await simulator.simulate(capability);
+console.log("simulation", JSON.stringify(outcome, null, 2));
+if (outcome.halted || outcome.results.some(({ warnings }) => warnings.length > 0)) {
+  console.error("Warnings present. Stop; do not sign.");
+  process.exitCode = 1;
+} else {
+  for (const result of outcome.results) console.log(result.receipt?.text);
+  console.log("Compare every Receipt with the requested MON-to-USDC swap before signing.");
+}

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,17 +1,14 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import * as erc from "@themoss/erc";
-import * as kuru from "@themoss/protocol-kuru";
-import * as pancakeswap from "@themoss/protocol-pancakeswap";
-import * as system from "@themoss/system";
 import { monadRuntime } from "@themoss/system";
+import { defaultProtocolModules } from "./composition.js";
 import { createMossServer } from "./server.js";
 
 const rpcUrl = process.env.MOSS_RPC_URL;
 const runtime = await monadRuntime({ ...(rpcUrl ? { rpcUrl } : {}) });
 const { server, registry } = createMossServer({
   runtime,
-  protocols: [system, erc, kuru, pancakeswap],
+  protocols: defaultProtocolModules,
 });
 const catalog = registry.discover();
 console.error(

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -1,0 +1,7 @@
+import * as erc from "@themoss/erc";
+import * as kuru from "@themoss/protocol-kuru";
+import * as pancakeswap from "@themoss/protocol-pancakeswap";
+import * as system from "@themoss/system";
+
+/** Protocol modules selected by the default MCP CLI application. */
+export const defaultProtocolModules = [system, erc, kuru, pancakeswap] as const;

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -14,6 +14,7 @@ import type { SimulateOutcome } from "@themoss/simulator";
 import * as system from "@themoss/system";
 import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
 import { describe, expect, it } from "vitest";
+import { defaultProtocolModules } from "../src/composition.js";
 import { createMossServer, toAgentSimulation } from "../src/server.js";
 
 const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
@@ -23,7 +24,10 @@ async function connectedClient(simulateOutcome?: SimulateOutcome) {
 }
 
 async function connectedHarness(simulateOutcome?: SimulateOutcome) {
-  const { server, simulator } = createMossServer({ runtime, protocols: [system, erc, kuru] });
+  const { server, simulator } = createMossServer({
+    runtime,
+    protocols: defaultProtocolModules,
+  });
   if (simulateOutcome) {
     simulator.simulate = async () => simulateOutcome;
   }
@@ -65,7 +69,7 @@ describe("moss MCP server", () => {
     expect(receipt.text).toContain("Trusted(USDC)");
   });
 
-  it("discovers direct Protocol exports and loads type plus field descriptions", async () => {
+  it("discovers and loads the Protocols selected by the default CLI composition", async () => {
     const client = await connectedClient();
     const discovered = parseText(
       await client.callTool({ name: "discover", arguments: { verb: "wrap" } }),
@@ -73,10 +77,22 @@ describe("moss MCP server", () => {
     expect(discovered).toEqual([
       expect.objectContaining({ protocol: "wmon", method: "wrap", kind: "capability" }),
     ]);
+    const swaps = parseText(
+      await client.callTool({ name: "discover", arguments: { verb: "swap" } }),
+    ) as { protocol: string; method: string }[];
+    expect(swaps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: "pancakeswap-v2",
+          method: "swap",
+          kind: "capability",
+        }),
+      ]),
+    );
     const loaded = parseText(
       await client.callTool({
         name: "load",
-        arguments: { items: [{ protocol: "kuru", method: "swap" }] },
+        arguments: { items: [{ protocol: "pancakeswap-v2", method: "swap" }] },
       }),
     ) as { params: Record<string, { type: unknown; description: string }> }[];
     expect(loaded[0]?.params.slippage).toMatchObject({

--- a/packages/protocols/pancakeswap/README.md
+++ b/packages/protocols/pancakeswap/README.md
@@ -1,0 +1,50 @@
+# @themoss/protocol-pancakeswap
+
+This package contains the self-describing PancakeSwap V2 and V3 Protocols for
+Monad mainnet. It exports `PancakeSwapV2` for V2 constant-product swaps and
+`PancakeSwap` for V3 single-hop swaps. The default MCP CLI selects the module
+namespace, so `discover` and `load` expose both without import-time
+registration.
+
+## Capabilities and Queries
+
+- `quote`: quotes either a fixed human-readable `amountIn` or minimum
+  `amountOut`.
+- `swap`: builds one Router transaction. ERC-20 inputs add the explicitly
+  declared `ERC20.approve` dependency as a nested Capability.
+- direct and single-WMON-hop candidates are compared at the same quote point;
+  equal quotes select the direct path.
+- exact-input swaps maximize output. Target-output swaps minimize quoted input
+  and add the selected slippage as maximum-input headroom.
+
+Parameters use explicit token addresses or `native`; token symbols are not
+accepted. Slippage defaults to 50 bps and is capped at 5,000 bps. Transactions
+use a 20-minute deadline. Fee-on-transfer tokens are not supported.
+
+## Receipt evidence
+
+Each swap owns one `swapReceipt`. It exhaustively parses the direct
+transaction's ordered native transfers, WMON Deposit/Withdrawal events,
+ERC-20 Transfers, and dynamic Pair Sync/Swap events. Every input Change is
+retained by identity and order. The structured outcome derives the actual
+input/output assets and amounts only from this evidence; it does not read the
+planned route or call RPC.
+
+## Deployment and ABI origins
+
+The Router and Factory addresses come from PancakeSwap's official Monad v2
+deployment list. Live tests verify Router bytecode plus `factory()` and
+`WETH()` results. Router and Pair ABIs are full explorer-tier artifacts from
+verified MonadScan pages. The package's source table covers the V2 and V3
+contracts and regenerates every explorer artifact through the shared ABI tool:
+
+```bash
+pnpm --filter @themoss/protocol-pancakeswap update:abis
+```
+
+The command uses `@themoss/abi-tools` and requires `MONADSCAN_API_KEY`.
+`test/abis.test.ts` deterministically checks every committed artifact against
+the shared renderer.
+
+Run the end-to-end example from the repository root with
+`pnpm --filter @themoss/example-simple-flow pancakeswap-v2`.

--- a/packages/protocols/pancakeswap/package.json
+++ b/packages/protocols/pancakeswap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@themoss/protocol-pancakeswap",
   "version": "0.1.0",
-  "description": "Moss protocol adapter for PancakeSwap V3 single-hop swaps on Monad mainnet",
+  "description": "Moss Protocols for PancakeSwap V2 and V3 swaps on Monad mainnet",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@themoss/abi-tools": "workspace:*",
+    "@themoss/simulator": "workspace:*",
     "tsup": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "~5.9.0",

--- a/packages/protocols/pancakeswap/scripts/abis.ts
+++ b/packages/protocols/pancakeswap/scripts/abis.ts
@@ -1,6 +1,6 @@
 /**
  * The OFFLINE half of the ABI pipeline: the source-of-truth table mapping
- * each PancakeSwap V3 contract to its generated module under src/abis/.
+ * each PancakeSwap V2/V3 contract to its generated module under src/abis/.
  *
  * scripts/update-abis.ts fetches these verified ABIs from the explorer;
  * test/abis.test.ts enforces that every committed module is byte-exact
@@ -29,5 +29,15 @@ export const SOURCES: readonly AbiSource[] = [
     exportName: "factory",
     file: "factory.ts",
     address: "0x0BFbCF9fa4f9C56B0F40a671Ad40E0805A091865",
+  },
+  {
+    exportName: "pancakeV2Router",
+    file: "v2-router.ts",
+    address: "0xB1Bc24c34e88f7D43D5923034E3a14B24DaACfF9",
+  },
+  {
+    exportName: "pancakeV2Pair",
+    file: "v2-pair.ts",
+    address: "0x27aa322b3f8ba9d0041df99c33fe4f3cc135e054",
   },
 ];

--- a/packages/protocols/pancakeswap/src/abis/v2-pair.ts
+++ b/packages/protocols/pancakeswap/src/abis/v2-pair.ts
@@ -1,0 +1,718 @@
+// ABI origin: explorer (ADR 0007)
+//   Source:    https://monadscan.com/address/0x27aa322b3f8ba9d0041df99c33fe4f3cc135e054
+//   Endpoint:  Etherscan V2 (chainid=143, module=contract, action=getabi)
+//   Retrieved: 2026-07-17 (UTC)
+
+export const pancakeV2PairAbi = [
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve0",
+        "type": "uint112"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve1",
+        "type": "uint112"
+      }
+    ],
+    "name": "Sync",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "MINIMUM_LIQUIDITY",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getReserves",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "_reserve0",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint112",
+        "name": "_reserve1",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_blockTimestampLast",
+        "type": "uint32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token1",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "kLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "price0CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "price1CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "skim",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swap",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "sync",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+] as const;

--- a/packages/protocols/pancakeswap/src/abis/v2-router.ts
+++ b/packages/protocols/pancakeswap/src/abis/v2-router.ts
@@ -1,0 +1,978 @@
+// ABI origin: explorer (ADR 0007)
+//   Source:    https://monadscan.com/address/0xB1Bc24c34e88f7D43D5923034E3a14B24DaACfF9
+//   Endpoint:  Etherscan V2 (chainid=143, module=contract, action=getabi)
+//   Retrieved: 2026-07-17 (UTC)
+
+export const pancakeV2RouterAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_WETH",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "WETH",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountADesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBDesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountAMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountB",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenDesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETHMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidityETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountToken",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETH",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      }
+    ],
+    "name": "getAmountsIn",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      }
+    ],
+    "name": "getAmountsOut",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveB",
+        "type": "uint256"
+      }
+    ],
+    "name": "quote",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountB",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountAMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountB",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETHMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeLiquidityETH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountToken",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETH",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETHMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeLiquidityETHSupportingFeeOnTransferTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountETH",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETHMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "approveMax",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removeLiquidityETHWithPermit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountToken",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETH",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountETHMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "approveMax",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removeLiquidityETHWithPermitSupportingFeeOnTransferTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountETH",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountAMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "approveMax",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "removeLiquidityWithPermit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountB",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapETHForExactTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactETHForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactETHForTokensSupportingFeeOnTransferTokens",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactTokensForETH",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactTokensForETHSupportingFeeOnTransferTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactTokensForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactTokensForTokensSupportingFeeOnTransferTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountInMax",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTokensForExactETH",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountInMax",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTokensForExactTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+] as const;

--- a/packages/protocols/pancakeswap/src/index.ts
+++ b/packages/protocols/pancakeswap/src/index.ts
@@ -1,7 +1,16 @@
 export { factoryAbi } from "./abis/factory.js";
 export { swapRouterAbi } from "./abis/swap-router.js";
+export { pancakeV2PairAbi } from "./abis/v2-pair.js";
+export { pancakeV2RouterAbi } from "./abis/v2-router.js";
 export {
   PANCAKESWAP_V3_FACTORY_ADDRESS,
   PANCAKESWAP_V3_ROUTER_ADDRESS,
   PancakeSwap,
 } from "./pancakeswap.js";
+export {
+  PANCAKESWAP_V2_FACTORY_ADDRESS,
+  PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS,
+  PANCAKESWAP_V2_ROUTER_ADDRESS,
+  PancakeSwapV2,
+} from "./pancakeswap-v2.js";
+export type { PancakeV2Quote, PancakeV2SwapOutcome } from "./types-v2.js";

--- a/packages/protocols/pancakeswap/src/pancakeswap-v2.ts
+++ b/packages/protocols/pancakeswap/src/pancakeswap-v2.ts
@@ -1,0 +1,624 @@
+/** PancakeSwap v2 swaps on Monad mainnet. */
+import {
+  type ActionCtx,
+  type AddressValue,
+  BasisPoints,
+  Capability,
+  type CapabilityResult,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  NATIVE,
+  ParameterError,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  type TokenRef,
+  TokenReference,
+} from "@themoss/core";
+import { ERC20, type ERC20Outcome, WETH9Abi } from "@themoss/erc";
+import { WMON_ADDRESS } from "@themoss/system";
+import { decodeEventLog, formatUnits, getAddress, parseUnits } from "viem";
+import { pancakeV2PairAbi } from "./abis/v2-pair.js";
+import { pancakeV2RouterAbi } from "./abis/v2-router.js";
+import type { PancakeV2Quote, PancakeV2SwapOutcome, PreparedV2Swap } from "./types-v2.js";
+
+/**
+ * Official Monad mainnet deployment:
+ * https://developer.pancakeswap.finance/contracts/v2/addresses
+ * The live test verifies bytecode, factory(), and WETH().
+ */
+export const PANCAKESWAP_V2_ROUTER_ADDRESS = "0xB1Bc24c34e88f7D43D5923034E3a14B24DaACfF9" as const;
+export const PANCAKESWAP_V2_FACTORY_ADDRESS = "0x02a84c1b3BBD7401a5f7fa98a384EBC70bB5749E" as const;
+export const PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS =
+  "0x27aa322b3f8ba9d0041df99c33fe4f3cc135e054" as const;
+
+const DEFAULT_SLIPPAGE_BPS = 50;
+const DEADLINE_SECONDS = 20 * 60;
+const OptionalHumanTokenAmount = PositiveDecimalString.optional().describe(
+  'An optional positive base-10 decimal token amount, such as "1" or "1.5".',
+);
+const PancakeSlippage = BasisPoints.max(5_000)
+  .default(DEFAULT_SLIPPAGE_BPS)
+  .describe("An integer basis-point count from 0 through 5000; 1 bps equals 0.01%.");
+
+const swapParams = {
+  tokenIn: { type: TokenReference, description: "Asset offered to the swap." },
+  tokenOut: { type: TokenReference, description: "Asset requested from the swap." },
+  amountIn: {
+    type: OptionalHumanTokenAmount,
+    description: "Fixed input quantity; omit when amountOut is supplied.",
+  },
+  amountOut: {
+    type: OptionalHumanTokenAmount,
+    description: "Minimum output quantity; omit when amountIn is supplied.",
+  },
+  slippage: {
+    type: PancakeSlippage,
+    description: "Maximum adverse movement allowed between quoting and execution.",
+  },
+} satisfies ParamsSpec;
+
+type InferredSwapParams = InferParams<typeof swapParams>;
+type SwapParams = Omit<InferredSwapParams, "amountIn" | "amountOut" | "slippage"> &
+  Partial<Pick<InferredSwapParams, "amountIn" | "amountOut" | "slippage">>;
+type PancakeSwapParams = Pick<SwapParams, "tokenIn" | "tokenOut"> & {
+  slippage?: InferredSwapParams["slippage"];
+} & ({ amountIn: string; amountOut?: never } | { amountIn?: never; amountOut: string });
+
+@Protocol({
+  name: "pancakeswap-v2",
+  category: "dex",
+  description:
+    "PancakeSwap v2 constant-product AMM swaps over direct or single-WMON-hop paths on Monad.",
+  contracts: {
+    router: { abi: pancakeV2RouterAbi, addr: PANCAKESWAP_V2_ROUTER_ADDRESS },
+  },
+  labels: {
+    Router: PANCAKESWAP_V2_ROUTER_ADDRESS,
+    Factory: PANCAKESWAP_V2_FACTORY_ADDRESS,
+  },
+  protocols: { erc20: ERC20 },
+})
+export class PancakeSwapV2 {
+  declare router: Handle<typeof pancakeV2RouterAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  quote(params: PancakeSwapParams, ctx: ActionCtx): Promise<PancakeV2Quote>;
+  @Query({
+    intent: "Quote the best PancakeSwap v2 path",
+    params: swapParams,
+    tags: ["amm", "v2", "quote"],
+  })
+  async quote(params: SwapParams, _ctx: ActionCtx): Promise<PancakeV2Quote> {
+    const prepared = await this.#prepareSwap(params);
+    if (prepared.side === "amountIn") {
+      return {
+        amountSide: "amountIn",
+        amountIn: formatUnits(prepared.estimatedAmountIn, prepared.inputDecimals),
+        estimatedAmountOut: formatUnits(prepared.estimatedAmountOut, prepared.outputDecimals),
+        minimumAmountOut: formatUnits(prepared.minimumAmountOut, prepared.outputDecimals),
+        path: displayPath(prepared.path, params.tokenIn, params.tokenOut),
+      };
+    }
+    return {
+      amountSide: "amountOut",
+      estimatedAmountIn: formatUnits(prepared.estimatedAmountIn, prepared.inputDecimals),
+      maximumAmountIn: formatUnits(prepared.executionAmountIn, prepared.inputDecimals),
+      minimumAmountOut: formatUnits(prepared.minimumAmountOut, prepared.outputDecimals),
+      path: displayPath(prepared.path, params.tokenIn, params.tokenOut),
+    };
+  }
+
+  swap(params: PancakeSwapParams, ctx: ActionCtx): Promise<CapabilityResult>;
+  @Capability<PancakeSwapV2, typeof swapParams>({
+    intent: "Swap tokens through the best current PancakeSwap v2 path",
+    verb: "swap",
+    params: swapParams,
+    receipt: "swapReceipt",
+    risk: ["fundOut", "approval", "priceImpact"],
+    tags: ["amm", "v2"],
+  })
+  async swap(params: SwapParams, ctx: ActionCtx): Promise<CapabilityResult> {
+    const prepared = await this.#prepareSwap(params);
+    const children = [];
+    if (params.tokenIn !== NATIVE) {
+      children.push(
+        await this.erc20.approve({
+          token: params.tokenIn,
+          spender: this.router.address,
+          amount: prepared.executionAmountIn.toString(),
+        }),
+      );
+    }
+
+    const deadline = BigInt(Math.floor(Date.now() / 1000) + DEADLINE_SECONDS);
+    const args = [prepared.path, ctx.account, deadline] as const;
+    if (prepared.side === "amountIn") {
+      if (params.tokenIn === NATIVE) {
+        children.push(
+          this.router.swapExactETHForTokens([prepared.minimumAmountOut, ...args], {
+            value: prepared.executionAmountIn,
+          }),
+        );
+      } else if (params.tokenOut === NATIVE) {
+        children.push(
+          this.router.swapExactTokensForETH([
+            prepared.executionAmountIn,
+            prepared.minimumAmountOut,
+            ...args,
+          ]),
+        );
+      } else {
+        children.push(
+          this.router.swapExactTokensForTokens([
+            prepared.executionAmountIn,
+            prepared.minimumAmountOut,
+            ...args,
+          ]),
+        );
+      }
+    } else if (params.tokenIn === NATIVE) {
+      children.push(
+        this.router.swapETHForExactTokens([prepared.minimumAmountOut, ...args], {
+          value: prepared.executionAmountIn,
+        }),
+      );
+    } else if (params.tokenOut === NATIVE) {
+      children.push(
+        this.router.swapTokensForExactETH([
+          prepared.minimumAmountOut,
+          prepared.executionAmountIn,
+          ...args,
+        ]),
+      );
+    } else {
+      children.push(
+        this.router.swapTokensForExactTokens([
+          prepared.minimumAmountOut,
+          prepared.executionAmountIn,
+          ...args,
+        ]),
+      );
+    }
+    return children;
+  }
+
+  @Receipt()
+  swapReceipt(changes: readonly Change[]): ReceiptResult<PancakeV2SwapOutcome> {
+    const transfers: IndexedTransfer[] = [];
+    const wethEvents: WethEvent[] = [];
+    const pairEvents: PairEvent[] = [];
+    const parsed = changes.map((change, changeIndex) => {
+      if (change.kind === "event" && sameAddress(change.address, WMON_ADDRESS)) {
+        const event = tryDecodeWethEvent(change);
+        if (event?.eventName === "Deposit" || event?.eventName === "Withdrawal") {
+          const data: WethEvent = {
+            event: event.eventName,
+            account: event.eventName === "Deposit" ? event.args.dst : event.args.src,
+            amount: event.args.wad.toString(),
+            changeIndex,
+          };
+          wethEvents.push(data);
+          return {
+            kind: "change" as const,
+            change,
+            data,
+            text: `WMON ${data.event}: ${data.amount} for ${data.account}`,
+          };
+        }
+      }
+
+      if (change.kind === "event") {
+        const event = tryDecodePairEvent(change);
+        if (event?.eventName === "Sync") {
+          const data: PairEvent = {
+            event: "Sync",
+            pair: change.address,
+            reserve0: event.args.reserve0.toString(),
+            reserve1: event.args.reserve1.toString(),
+            changeIndex,
+          };
+          pairEvents.push(data);
+          return {
+            kind: "change" as const,
+            change,
+            data,
+            text: `PancakeSwap Sync: reserves ${data.reserve0}/${data.reserve1} at ${data.pair}`,
+          };
+        }
+        if (event?.eventName === "Swap") {
+          if (!sameAddress(event.args.sender, PANCAKESWAP_V2_ROUTER_ADDRESS)) {
+            throw new Error("PancakeSwap Pair Swap sender is not the Router");
+          }
+          const data: PairEvent = {
+            event: "Swap",
+            pair: change.address,
+            sender: event.args.sender,
+            to: event.args.to,
+            amount0In: event.args.amount0In.toString(),
+            amount1In: event.args.amount1In.toString(),
+            amount0Out: event.args.amount0Out.toString(),
+            amount1Out: event.args.amount1Out.toString(),
+            changeIndex,
+          };
+          pairEvents.push(data);
+          return {
+            kind: "change" as const,
+            change,
+            data,
+            text: `PancakeSwap Pair Swap: ${swapInput(data)} in and ${swapOutput(data)} out at ${data.pair}`,
+          };
+        }
+        if (event?.eventName === "Mint" || event?.eventName === "Burn") {
+          throw new Error(`Unexpected Change: PancakeSwap swap emitted Pair ${event.eventName}`);
+        }
+      }
+
+      const receipt = this.erc20.changesReceipt([change]);
+      for (const outcome of receipt.outcome) {
+        if (outcome.operation === "transfer") transfers.push({ outcome, changeIndex });
+      }
+      return receipt;
+    });
+
+    const pairLegs = validatePairEvents(pairEvents);
+    const legs = pairLegs.map(({ sync, swap }) => {
+      const input = exactlyOne(
+        transfers.filter(
+          ({ outcome }) => outcome.token !== NATIVE && sameAddress(outcome.to, swap.pair),
+        ),
+        `input transfer to Pair ${swap.pair}`,
+      );
+      const output = exactlyOne(
+        transfers.filter(
+          ({ outcome }) => outcome.token !== NATIVE && sameAddress(outcome.from, swap.pair),
+        ),
+        `output transfer from Pair ${swap.pair}`,
+      );
+      if (input.outcome.amount !== swapInput(swap) || output.outcome.amount !== swapOutput(swap)) {
+        throw new Error("PancakeSwap Receipt transfer amounts differ from Pair Swap evidence");
+      }
+      if (!sameAddress(output.outcome.to, swap.to)) {
+        throw new Error("PancakeSwap Receipt Pair output recipient differs from Swap.to");
+      }
+      if (
+        !(
+          input.changeIndex < output.changeIndex &&
+          output.changeIndex < sync.changeIndex &&
+          sync.changeIndex < swap.changeIndex
+        )
+      ) {
+        throw new Error("PancakeSwap Receipt Pair funding, output, Sync, and Swap are misordered");
+      }
+      return { input, output, swap };
+    });
+    for (let index = 0; index < legs.length - 1; index += 1) {
+      const current = legs[index];
+      const next = legs[index + 1];
+      if (!current || !next) throw new Error("PancakeSwap Receipt has a missing Pair leg");
+      if (
+        current.output.changeIndex !== next.input.changeIndex ||
+        !sameAddress(current.output.outcome.to, next.swap.pair) ||
+        !sameAddress(current.output.outcome.token, WMON_ADDRESS)
+      ) {
+        throw new Error("PancakeSwap Receipt Pair legs are not linked by one WMON transfer");
+      }
+    }
+    const firstLeg = legs[0];
+    const lastLeg = legs.at(-1);
+    if (!firstLeg || !lastLeg) throw new Error("PancakeSwap Receipt requires a Pair Swap");
+    const input = firstLeg.input.outcome;
+    const output = lastLeg.output.outcome;
+
+    const deposits = wethEvents.filter((event) => event.event === "Deposit");
+    const withdrawals = wethEvents.filter((event) => event.event === "Withdrawal");
+    if (deposits.length > 1 || withdrawals.length > 1 || (deposits.length && withdrawals.length)) {
+      throw new Error("PancakeSwap Receipt has an invalid WMON operation sequence");
+    }
+
+    let sender = input.from;
+    let tokenIn: TokenRef = input.token;
+    if (deposits[0]) {
+      if (!sameAddress(input.token, WMON_ADDRESS) || deposits[0].amount !== input.amount) {
+        throw new Error("PancakeSwap Receipt WMON deposit does not match Pair input");
+      }
+      if (!sameAddress(deposits[0].account, PANCAKESWAP_V2_ROUTER_ADDRESS)) {
+        throw new Error("PancakeSwap Receipt WMON deposit account is not the Router");
+      }
+      const funding = exactlyOne(
+        transfers.filter(
+          ({ outcome }) =>
+            outcome.token === NATIVE &&
+            sameAddress(outcome.to, PANCAKESWAP_V2_ROUTER_ADDRESS) &&
+            !sameAddress(outcome.from, WMON_ADDRESS),
+        ),
+        "native funding transfer",
+      );
+      const wrapped = exactlyOne(
+        transfers.filter(
+          ({ outcome }) =>
+            outcome.token === NATIVE &&
+            sameAddress(outcome.from, PANCAKESWAP_V2_ROUTER_ADDRESS) &&
+            sameAddress(outcome.to, WMON_ADDRESS),
+        ),
+        "native Router-to-WMON transfer",
+      );
+      if (
+        wrapped.outcome.amount !== input.amount ||
+        BigInt(funding.outcome.amount) < BigInt(input.amount) ||
+        !(
+          funding.changeIndex < wrapped.changeIndex && wrapped.changeIndex < deposits[0].changeIndex
+        ) ||
+        !(deposits[0].changeIndex < firstLeg.input.changeIndex)
+      ) {
+        throw new Error("PancakeSwap Receipt native funding does not cover the WMON deposit");
+      }
+      sender = funding.outcome.from;
+      tokenIn = NATIVE;
+    }
+
+    let recipient = output.to;
+    let tokenOut: TokenRef = output.token;
+    if (withdrawals[0]) {
+      if (!sameAddress(output.token, WMON_ADDRESS) || withdrawals[0].amount !== output.amount) {
+        throw new Error("PancakeSwap Receipt WMON withdrawal does not match Pair output");
+      }
+      if (!sameAddress(withdrawals[0].account, PANCAKESWAP_V2_ROUTER_ADDRESS)) {
+        throw new Error("PancakeSwap Receipt WMON withdrawal account is not the Router");
+      }
+      const payout = exactlyOne(
+        transfers.filter(
+          ({ outcome }) =>
+            outcome.token === NATIVE &&
+            sameAddress(outcome.from, PANCAKESWAP_V2_ROUTER_ADDRESS) &&
+            !sameAddress(outcome.to, WMON_ADDRESS),
+        ),
+        "native payout transfer",
+      );
+      const unwrapped = exactlyOne(
+        transfers.filter(
+          ({ outcome }) =>
+            outcome.token === NATIVE &&
+            sameAddress(outcome.from, WMON_ADDRESS) &&
+            sameAddress(outcome.to, PANCAKESWAP_V2_ROUTER_ADDRESS),
+        ),
+        "native WMON-to-Router transfer",
+      );
+      if (
+        payout.outcome.amount !== output.amount ||
+        unwrapped.outcome.amount !== output.amount ||
+        !(lastLeg.swap.changeIndex < unwrapped.changeIndex) ||
+        !(unwrapped.changeIndex < withdrawals[0].changeIndex) ||
+        !(withdrawals[0].changeIndex < payout.changeIndex)
+      ) {
+        throw new Error("PancakeSwap Receipt native payout differs from Pair output");
+      }
+      recipient = payout.outcome.to;
+      tokenOut = NATIVE;
+    }
+
+    const outcome: PancakeV2SwapOutcome = {
+      operation: "swap",
+      protocol: "pancakeswap-v2",
+      sender: getAddress(sender),
+      recipient: getAddress(recipient),
+      tokenIn: canonicalToken(tokenIn),
+      tokenOut: canonicalToken(tokenOut),
+      amountIn: input.amount,
+      amountOut: output.amount,
+      pairs: legs.map(({ swap }) => getAddress(swap.pair)),
+    };
+    return {
+      kind: "receipt",
+      outcome,
+      text: `PancakeSwap Swap: ${outcome.amountIn} ${outcome.tokenIn} to ${outcome.amountOut} ${outcome.tokenOut} for ${outcome.recipient}`,
+      changes: parsed,
+    };
+  }
+
+  async #prepareSwap(params: SwapParams): Promise<PreparedV2Swap> {
+    const paths = this.#paths(params.tokenIn, params.tokenOut);
+    const side = amountSide(params);
+    const [inputDecimals, outputDecimals] = await Promise.all([
+      this.#decimals(params.tokenIn),
+      this.#decimals(params.tokenOut),
+    ]);
+    const amount = parseUnits(
+      side.amount,
+      side.kind === "amountIn" ? inputDecimals : outputDecimals,
+    );
+    const quoted = await Promise.all(
+      paths.map(async (path) => {
+        try {
+          const amounts =
+            side.kind === "amountIn"
+              ? await this.router.read.getAmountsOut([amount, path])
+              : await this.router.read.getAmountsIn([amount, path]);
+          const amountIn = amounts[0];
+          const amountOut = amounts.at(-1);
+          return amountIn && amountOut ? { path, amountIn, amountOut } : undefined;
+        } catch {
+          return undefined;
+        }
+      }),
+    );
+    const routes = quoted.filter((route): route is NonNullable<typeof route> => !!route);
+    const [first] = routes;
+    if (!first) throw new Error("no liquid PancakeSwap v2 route for this token pair");
+    const best = routes.reduce((current, route) => {
+      const better =
+        side.kind === "amountIn"
+          ? route.amountOut > current.amountOut
+          : route.amountIn < current.amountIn;
+      const tied = route.amountIn === current.amountIn && route.amountOut === current.amountOut;
+      return better || (tied && route.path.length < current.path.length) ? route : current;
+    }, first);
+    const slippage = BigInt(params.slippage ?? DEFAULT_SLIPPAGE_BPS);
+    const minimumAmountOut =
+      side.kind === "amountIn" ? (best.amountOut * (10_000n - slippage)) / 10_000n : amount;
+    const executionAmountIn =
+      side.kind === "amountIn" ? amount : (best.amountIn * (10_000n + slippage) + 9_999n) / 10_000n;
+    if (minimumAmountOut <= 0n || executionAmountIn <= 0n) {
+      throw new Error("PancakeSwap quote produced a zero execution bound");
+    }
+    return {
+      side: side.kind,
+      path: best.path,
+      estimatedAmountIn: best.amountIn,
+      executionAmountIn,
+      estimatedAmountOut: best.amountOut,
+      minimumAmountOut,
+      inputDecimals,
+      outputDecimals,
+    };
+  }
+
+  #paths(tokenIn: TokenRef, tokenOut: TokenRef): AddressValue[][] {
+    const input = toRouterToken(tokenIn);
+    const output = toRouterToken(tokenOut);
+    if (sameAddress(input, output)) {
+      throw new ParameterError("tokenIn and tokenOut resolve to the same router token");
+    }
+    const paths = [[input, output]];
+    if (!sameAddress(input, WMON_ADDRESS) && !sameAddress(output, WMON_ADDRESS)) {
+      paths.push([input, WMON_ADDRESS, output]);
+    }
+    return paths;
+  }
+
+  async #decimals(token: TokenRef): Promise<number> {
+    if (token === NATIVE) return 18;
+    const metadata = await this.erc20.metadata({ token });
+    return metadata.decimals;
+  }
+}
+
+type WethEvent = {
+  event: "Deposit" | "Withdrawal";
+  account: AddressValue;
+  amount: string;
+  changeIndex: number;
+};
+
+type TransferOutcome = Extract<ERC20Outcome, { operation: "transfer" }>;
+type IndexedTransfer = { outcome: TransferOutcome; changeIndex: number };
+
+type PairEvent =
+  | {
+      event: "Sync";
+      pair: AddressValue;
+      reserve0: string;
+      reserve1: string;
+      changeIndex: number;
+    }
+  | {
+      event: "Swap";
+      pair: AddressValue;
+      sender: AddressValue;
+      to: AddressValue;
+      amount0In: string;
+      amount1In: string;
+      amount0Out: string;
+      amount1Out: string;
+      changeIndex: number;
+    };
+type PairSync = Extract<PairEvent, { event: "Sync" }>;
+type PairSwap = Extract<PairEvent, { event: "Swap" }>;
+
+function validatePairEvents(events: readonly PairEvent[]): { sync: PairSync; swap: PairSwap }[] {
+  if (events.length === 0 || events.length > 4 || events.length % 2 !== 0) {
+    throw new Error("PancakeSwap Receipt requires one Sync before every Pair Swap");
+  }
+  const legs: { sync: PairSync; swap: PairSwap }[] = [];
+  const pairs = new Set<string>();
+  for (let index = 0; index < events.length; index += 2) {
+    const sync = events[index];
+    const swap = events[index + 1];
+    if (sync?.event !== "Sync" || swap?.event !== "Swap" || !sameAddress(sync.pair, swap.pair)) {
+      throw new Error("PancakeSwap Receipt Pair events are not ordered Sync/Swap pairs");
+    }
+    const pair = swap.pair.toLowerCase();
+    if (pairs.has(pair)) throw new Error("PancakeSwap Receipt repeats a Pair leg");
+    pairs.add(pair);
+    legs.push({ sync, swap });
+  }
+  return legs;
+}
+
+function exactlyOne<T>(values: readonly T[], description: string): T {
+  const [value] = values;
+  if (!value || values.length !== 1) {
+    throw new Error(`PancakeSwap Receipt requires exactly one ${description}`);
+  }
+  return value;
+}
+
+function swapInput(swap: PairSwap): string {
+  return (BigInt(swap.amount0In) + BigInt(swap.amount1In)).toString();
+}
+
+function swapOutput(swap: PairSwap): string {
+  return (BigInt(swap.amount0Out) + BigInt(swap.amount1Out)).toString();
+}
+
+function amountSide(params: SwapParams) {
+  if (params.amountIn !== undefined && params.amountOut === undefined) {
+    return { kind: "amountIn", amount: params.amountIn } as const;
+  }
+  if (params.amountOut !== undefined && params.amountIn === undefined) {
+    return { kind: "amountOut", amount: params.amountOut } as const;
+  }
+  throw new ParameterError("provide exactly one of amountIn or amountOut");
+}
+
+function toRouterToken(token: TokenRef): AddressValue {
+  return token === NATIVE ? WMON_ADDRESS : token;
+}
+
+function displayPath(
+  path: readonly AddressValue[],
+  tokenIn: TokenRef,
+  tokenOut: TokenRef,
+): readonly TokenRef[] {
+  return path.length === 2 ? [tokenIn, tokenOut] : [tokenIn, NATIVE, tokenOut];
+}
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function canonicalToken(token: TokenRef): TokenRef {
+  return token === NATIVE ? NATIVE : getAddress(token);
+}
+
+function tryDecodePairEvent(change: Extract<Change, { kind: "event" }>) {
+  try {
+    return decodeEventLog({
+      abi: pancakeV2PairAbi,
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function tryDecodeWethEvent(change: Extract<Change, { kind: "event" }>) {
+  try {
+    return decodeEventLog({
+      abi: WETH9Abi,
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/protocols/pancakeswap/src/types-v2.ts
+++ b/packages/protocols/pancakeswap/src/types-v2.ts
@@ -1,0 +1,40 @@
+import type { AddressValue, TokenRef } from "@themoss/core";
+
+export type PancakeV2Quote =
+  | {
+      amountSide: "amountIn";
+      amountIn: string;
+      estimatedAmountOut: string;
+      minimumAmountOut: string;
+      path: readonly TokenRef[];
+    }
+  | {
+      amountSide: "amountOut";
+      estimatedAmountIn: string;
+      maximumAmountIn: string;
+      minimumAmountOut: string;
+      path: readonly TokenRef[];
+    };
+
+export type PreparedV2Swap = {
+  side: "amountIn" | "amountOut";
+  path: readonly AddressValue[];
+  estimatedAmountIn: bigint;
+  executionAmountIn: bigint;
+  estimatedAmountOut: bigint;
+  minimumAmountOut: bigint;
+  inputDecimals: number;
+  outputDecimals: number;
+};
+
+export type PancakeV2SwapOutcome = {
+  operation: "swap";
+  protocol: "pancakeswap-v2";
+  sender: AddressValue;
+  recipient: AddressValue;
+  tokenIn: TokenRef;
+  tokenOut: TokenRef;
+  amountIn: string;
+  amountOut: string;
+  pairs: readonly AddressValue[];
+};

--- a/packages/protocols/pancakeswap/test/abis.test.ts
+++ b/packages/protocols/pancakeswap/test/abis.test.ts
@@ -6,6 +6,10 @@ import {
   PANCAKESWAP_V3_FACTORY_ADDRESS,
   PANCAKESWAP_V3_ROUTER_ADDRESS,
 } from "../src/pancakeswap.js";
+import {
+  PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS,
+  PANCAKESWAP_V2_ROUTER_ADDRESS,
+} from "../src/pancakeswap-v2.js";
 
 // The provenance chain, enforced: every committed src/abis module must be
 // byte-exact renderAbiModule output for its SOURCES entry — same address,
@@ -41,6 +45,8 @@ describe("explorer ABI derivation (ADR 0007)", () => {
     expect(SOURCES.map((s) => s.address)).toEqual([
       PANCAKESWAP_V3_ROUTER_ADDRESS,
       PANCAKESWAP_V3_FACTORY_ADDRESS,
+      PANCAKESWAP_V2_ROUTER_ADDRESS,
+      PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS,
     ]);
   });
 });

--- a/packages/protocols/pancakeswap/test/pancakeswap-v2.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap-v2.test.ts
@@ -1,0 +1,531 @@
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  NATIVE,
+  type ReceiptResult,
+  Registry,
+} from "@themoss/core";
+import { ERC20Abi, WETH9Abi } from "@themoss/erc";
+import { createTraceSimulator } from "@themoss/simulator";
+import { AUSD_ADDRESS, monadRuntime, USDC_ADDRESS, WMON_ADDRESS } from "@themoss/system";
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  getAddress,
+  type PublicClient,
+} from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { pancakeV2PairAbi } from "../src/abis/v2-pair.js";
+import { pancakeV2RouterAbi } from "../src/abis/v2-router.js";
+import {
+  PANCAKESWAP_V2_FACTORY_ADDRESS,
+  PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS,
+  PANCAKESWAP_V2_ROUTER_ADDRESS,
+  PancakeSwapV2,
+} from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const PAIR = getAddress("0x1111111111111111111111111111111111111111");
+const SECOND_PAIR = getAddress("0x2222222222222222222222222222222222222222");
+
+describe("PancakeSwapV2", () => {
+  it("is self-describing and loads separate human-amount fields", async () => {
+    const { registry } = offlineRegistry();
+    expect(registry.discover({ protocol: "pancakeswap-v2" })).toMatchObject([
+      { method: "quote", kind: "query", category: "dex" },
+      { method: "swap", kind: "capability", verb: "swap", category: "dex" },
+    ]);
+    const [loaded] = registry.load([{ protocol: "pancakeswap-v2", method: "swap" }]);
+    expect(loaded).toMatchObject({
+      risk: ["fundOut", "approval", "priceImpact"],
+      tags: ["amm", "v2"],
+      params: {
+        amountIn: { description: expect.stringContaining("Fixed input") },
+        amountOut: { description: expect.stringContaining("Minimum output") },
+        slippage: { type: { default: 50, maximum: 5_000 } },
+      },
+    });
+  });
+
+  it("requires exactly one amount side and rejects MON/WMON before router reads", async () => {
+    const { registry, client } = offlineRegistry();
+    for (const params of [
+      { tokenIn: NATIVE, tokenOut: USDC_ADDRESS },
+      { tokenIn: NATIVE, tokenOut: USDC_ADDRESS, amountIn: "1", amountOut: "1" },
+    ]) {
+      await expect(registry.action("pancakeswap-v2", "quote", ACCOUNT, params)).rejects.toThrow(
+        "provide exactly one of amountIn or amountOut",
+      );
+    }
+    await expect(
+      registry.action("pancakeswap-v2", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: WMON_ADDRESS,
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("resolve to the same router token");
+    expect(client.readContract).not.toHaveBeenCalled();
+  });
+
+  it("quotes exact input by maximizing output and target output by minimizing input", async () => {
+    const { registry } = offlineRegistry();
+    const exactInput = await registry.action("pancakeswap-v2", "quote", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+      slippage: 100,
+    });
+    expect(exactInput).toMatchObject({
+      kind: "query",
+      data: {
+        amountSide: "amountIn",
+        estimatedAmountOut: "0.03",
+        minimumAmountOut: "0.0297",
+        path: [USDC_ADDRESS, NATIVE, AUSD_ADDRESS],
+      },
+    });
+
+    const targetOutput = await registry.action("pancakeswap-v2", "quote", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountOut: "0.03",
+      slippage: 50,
+    });
+    expect(targetOutput).toMatchObject({
+      kind: "query",
+      data: {
+        amountSide: "amountOut",
+        estimatedAmountIn: "0.02",
+        maximumAmountIn: "0.0201",
+        minimumAmountOut: "0.03",
+        path: [USDC_ADDRESS, NATIVE, AUSD_ADDRESS],
+      },
+    });
+  });
+
+  it("prefers the direct path when quotes are equal", async () => {
+    const { registry } = offlineRegistry({ equalQuotes: true });
+    const quote = await registry.action("pancakeswap-v2", "quote", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    expect(quote).toMatchObject({
+      kind: "query",
+      data: { path: [USDC_ADDRESS, AUSD_ADDRESS] },
+    });
+  });
+
+  it("owns one native-input transaction", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const executable = flattenCapabilityTree(capability);
+    expect(executable).toHaveLength(1);
+    expect(executable[0]?.transaction).toMatchObject({
+      from: ACCOUNT,
+      to: PANCAKESWAP_V2_ROUTER_ADDRESS,
+      value: `0x${(10n ** 18n).toString(16)}`,
+    });
+    const decoded = decodeFunctionData({
+      abi: pancakeV2RouterAbi,
+      data: executable[0]?.transaction.data ?? "0x",
+    });
+    expect(decoded.functionName).toBe("swapExactETHForTokens");
+  });
+
+  it("nests approval before one target-output swap transaction", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountOut: "0.03",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    expect(capability.children[0]).toMatchObject({
+      kind: "capability",
+      protocol: "erc20",
+      method: "approve",
+      params: {
+        token: USDC_ADDRESS,
+        spender: PANCAKESWAP_V2_ROUTER_ADDRESS,
+        amount: "20100",
+      },
+    });
+    const executable = flattenCapabilityTree(capability);
+    expect(executable).toHaveLength(2);
+    const decoded = decodeFunctionData({
+      abi: pancakeV2RouterAbi,
+      data: executable[1]?.transaction.data ?? "0x",
+    });
+    expect(decoded.functionName).toBe("swapTokensForExactTokens");
+    expect(decoded.args?.slice(0, 3)).toEqual([
+      30_000n,
+      20_100n,
+      [USDC_ADDRESS, WMON_ADDRESS, AUSD_ADDRESS],
+    ]);
+  });
+
+  it("parses every direct token swap Change in exact order", async () => {
+    const { registry } = offlineRegistry({ equalQuotes: true });
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const changes = [
+      transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n),
+      transferChange(AUSD_ADDRESS, PAIR, ACCOUNT, 20_000n),
+      syncChange(PAIR, 10_000_000n, 20_000_000n),
+      swapChange(PAIR, 1_000_000n, 0n, 0n, 20_000n, ACCOUNT),
+    ] as const;
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toEqual({
+      operation: "swap",
+      protocol: "pancakeswap-v2",
+      sender: ACCOUNT,
+      recipient: ACCOUNT,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1000000",
+      amountOut: "20000",
+      pairs: [PAIR],
+    });
+    expect(flattenReceiptChanges(receipt)).toEqual(changes);
+  });
+
+  it("derives native input only from ordered wrap and Pair evidence", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const amount = 10n ** 18n;
+    const changes = [
+      nativeChange(ACCOUNT, PANCAKESWAP_V2_ROUTER_ADDRESS, amount),
+      nativeChange(PANCAKESWAP_V2_ROUTER_ADDRESS, WMON_ADDRESS, amount),
+      wethChange("Deposit", PANCAKESWAP_V2_ROUTER_ADDRESS, amount),
+      transferChange(WMON_ADDRESS, PANCAKESWAP_V2_ROUTER_ADDRESS, PAIR, amount),
+      transferChange(USDC_ADDRESS, PAIR, ACCOUNT, 20_000n),
+      syncChange(PAIR, amount, 20_000n),
+      swapChange(PAIR, amount, 0n, 0n, 20_000n, ACCOUNT),
+    ] as const;
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toMatchObject({
+      sender: ACCOUNT,
+      recipient: ACCOUNT,
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: amount.toString(),
+      amountOut: "20000",
+    });
+    expect(flattenReceiptChanges(receipt)).toEqual(changes);
+  });
+
+  it("parses a two-Pair WMON hop in execution order", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const changes = [
+      transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n),
+      transferChange(WMON_ADDRESS, PAIR, SECOND_PAIR, 500_000n),
+      syncChange(PAIR, 1_000_000n, 500_000n),
+      swapChange(PAIR, 1_000_000n, 0n, 0n, 500_000n, SECOND_PAIR),
+      transferChange(AUSD_ADDRESS, SECOND_PAIR, ACCOUNT, 20_000n),
+      syncChange(SECOND_PAIR, 500_000n, 20_000n),
+      swapChange(SECOND_PAIR, 500_000n, 0n, 0n, 20_000n, ACCOUNT),
+    ] as const;
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toMatchObject({
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1000000",
+      amountOut: "20000",
+      pairs: [PAIR, SECOND_PAIR],
+    });
+    expect(flattenReceiptChanges(receipt)).toEqual(changes);
+  });
+
+  it("derives native output from ordered withdrawal and payout evidence", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: NATIVE,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const amountOut = 2n * 10n ** 18n;
+    const changes = [
+      transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n),
+      transferChange(WMON_ADDRESS, PAIR, PANCAKESWAP_V2_ROUTER_ADDRESS, amountOut),
+      syncChange(PAIR, 1_000_000n, amountOut),
+      swapChange(PAIR, 1_000_000n, 0n, 0n, amountOut, PANCAKESWAP_V2_ROUTER_ADDRESS),
+      nativeChange(WMON_ADDRESS, PANCAKESWAP_V2_ROUTER_ADDRESS, amountOut),
+      wethChange("Withdrawal", PANCAKESWAP_V2_ROUTER_ADDRESS, amountOut),
+      nativeChange(PANCAKESWAP_V2_ROUTER_ADDRESS, ACCOUNT, amountOut),
+    ] as const;
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toMatchObject({
+      sender: ACCOUNT,
+      recipient: ACCOUNT,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: NATIVE,
+      amountIn: "1000000",
+      amountOut: amountOut.toString(),
+    });
+    expect(flattenReceiptChanges(receipt)).toEqual(changes);
+  });
+
+  it("rejects missing or reordered Pair evidence", async () => {
+    const { registry } = offlineRegistry({ equalQuotes: true });
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const input = transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n);
+    const output = transferChange(AUSD_ADDRESS, PAIR, ACCOUNT, 20_000n);
+    const sync = syncChange(PAIR, 10_000_000n, 20_000_000n);
+    const swap = swapChange(PAIR, 1_000_000n, 0n, 0n, 20_000n, ACCOUNT);
+    expect(() => registry.parseReceipt(capability, [input, sync, swap])).toThrow("output transfer");
+    expect(() => registry.parseReceipt(capability, [input, output, swap, sync])).toThrow(
+      "ordered Sync/Swap",
+    );
+  });
+
+  it("rejects disconnected or internally inconsistent Pair legs", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+
+    const base = [
+      transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n),
+      transferChange(WMON_ADDRESS, PAIR, SECOND_PAIR, 500_000n),
+      syncChange(PAIR, 1_000_000n, 500_000n),
+      swapChange(PAIR, 1_000_000n, 0n, 0n, 500_000n, SECOND_PAIR),
+      transferChange(AUSD_ADDRESS, SECOND_PAIR, ACCOUNT, 20_000n),
+      syncChange(SECOND_PAIR, 500_000n, 20_000n),
+      swapChange(SECOND_PAIR, 500_000n, 0n, 0n, 20_000n, ACCOUNT),
+    ] as const;
+
+    const wrongIntermediateAmount = [...base];
+    wrongIntermediateAmount[3] = swapChange(PAIR, 1_000_000n, 0n, 0n, 600_000n, SECOND_PAIR);
+    expect(() => registry.parseReceipt(capability, wrongIntermediateAmount)).toThrow(
+      "transfer amounts differ",
+    );
+
+    const wrongNextPair = [...base];
+    wrongNextPair[3] = swapChange(PAIR, 1_000_000n, 0n, 0n, 500_000n, ACCOUNT);
+    expect(() => registry.parseReceipt(capability, wrongNextPair)).toThrow(
+      "output recipient differs",
+    );
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("PancakeSwapV2 Monad mainnet", () => {
+  it("verifies the official Router deployment and quotes both amount sides", {
+    timeout: 90_000,
+  }, async () => {
+    const runtime = await monadRuntime();
+    expect(
+      (await runtime.client.getCode({ address: PANCAKESWAP_V2_ROUTER_ADDRESS }))?.length,
+    ).toBeGreaterThan(2);
+    expect(
+      (await runtime.client.getCode({ address: PANCAKESWAP_V2_FACTORY_ADDRESS }))?.length,
+    ).toBeGreaterThan(2);
+    expect(
+      (await runtime.client.getCode({ address: PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS }))?.length,
+    ).toBeGreaterThan(2);
+    expect(
+      await runtime.client.readContract({
+        address: PANCAKESWAP_V2_ROUTER_ADDRESS,
+        abi: pancakeV2RouterAbi,
+        functionName: "factory",
+      }),
+    ).toBe(PANCAKESWAP_V2_FACTORY_ADDRESS);
+    expect(
+      await runtime.client.readContract({
+        address: PANCAKESWAP_V2_ROUTER_ADDRESS,
+        abi: pancakeV2RouterAbi,
+        functionName: "WETH",
+      }),
+    ).toBe(WMON_ADDRESS);
+    expect(
+      await runtime.client.readContract({
+        address: PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS,
+        abi: pancakeV2PairAbi,
+        functionName: "factory",
+      }),
+    ).toBe(PANCAKESWAP_V2_FACTORY_ADDRESS);
+    expect(
+      new Set(
+        await Promise.all(
+          (["token0", "token1"] as const).map((functionName) =>
+            runtime.client.readContract({
+              address: PANCAKESWAP_V2_PAIR_ABI_SOURCE_ADDRESS,
+              abi: pancakeV2PairAbi,
+              functionName,
+            }),
+          ),
+        ),
+      ),
+    ).toEqual(new Set([WMON_ADDRESS, USDC_ADDRESS]));
+    const registry = new Registry(runtime).use(PancakeSwapV2);
+    for (const amount of [{ amountIn: "1" }, { amountOut: "0.01" }]) {
+      const quote = await registry.action("pancakeswap-v2", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        ...amount,
+      });
+      if (quote.kind !== "query") throw new Error("expected Query");
+      expect(quote.data).toMatchObject({ path: [NATIVE, USDC_ADDRESS] });
+    }
+  });
+
+  it("simulates a native swap into an exhaustive typed Receipt", { timeout: 180_000 }, async () => {
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(PancakeSwapV2);
+    const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results[0]?.warnings).toEqual([]);
+    expect(outcome.results[0]?.receipt?.outcome).toMatchObject({
+      operation: "swap",
+      protocol: "pancakeswap-v2",
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+    });
+  });
+});
+
+function offlineRegistry(options: { equalQuotes?: boolean } = {}) {
+  const client = {
+    readContract: vi.fn(
+      async ({ functionName, args }: { functionName: string; args?: readonly unknown[] }) => {
+        if (functionName === "decimals") return 6;
+        if (functionName === "name") return "Mock token";
+        if (functionName === "symbol") return "MOCK";
+        const path = args?.[1] as readonly AddressValue[] | undefined;
+        const amount = (args?.[0] as bigint | undefined) ?? 0n;
+        if (!path) throw new Error(`unexpected read ${functionName}`);
+        if (functionName === "getAmountsOut") {
+          const output = options.equalQuotes || path.length === 2 ? 20_000n : 30_000n;
+          return path.length === 2 ? [amount, output] : [amount, 25_000n, output];
+        }
+        if (functionName === "getAmountsIn") {
+          const input = options.equalQuotes || path.length === 2 ? 30_000n : 20_000n;
+          return path.length === 2 ? [input, amount] : [input, 25_000n, amount];
+        }
+        throw new Error(`unexpected read ${functionName}`);
+      },
+    ),
+  } as unknown as PublicClient;
+  return {
+    client: client as PublicClient & { readContract: ReturnType<typeof vi.fn> },
+    registry: new Registry({ rpcUrl: "http://offline", client }).use(PancakeSwapV2),
+  };
+}
+
+type AddressValue = `0x${string}`;
+
+function nativeChange(from: AddressValue, to: AddressValue, value: bigint): Change {
+  return { kind: "nativeTransfer", from, to, value: value.toString() };
+}
+
+function transferChange(
+  token: AddressValue,
+  from: AddressValue,
+  to: AddressValue,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: token,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      args: { from, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function syncChange(pair: AddressValue, reserve0: bigint, reserve1: bigint): Change {
+  return {
+    kind: "event",
+    address: pair,
+    topics: encodeEventTopics({ abi: pancakeV2PairAbi, eventName: "Sync" }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint112" }, { type: "uint112" }], [reserve0, reserve1]),
+  };
+}
+
+function swapChange(
+  pair: AddressValue,
+  amount0In: bigint,
+  amount1In: bigint,
+  amount0Out: bigint,
+  amount1Out: bigint,
+  to: AddressValue,
+): Change {
+  return {
+    kind: "event",
+    address: pair,
+    topics: encodeEventTopics({
+      abi: pancakeV2PairAbi,
+      eventName: "Swap",
+      args: { sender: PANCAKESWAP_V2_ROUTER_ADDRESS, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }, { type: "uint256" }, { type: "uint256" }],
+      [amount0In, amount1In, amount0Out, amount1Out],
+    ),
+  };
+}
+
+function wethChange(
+  eventName: "Deposit" | "Withdrawal",
+  account: AddressValue,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: WMON_ADDRESS,
+    topics: encodeEventTopics({
+      abi: WETH9Abi,
+      eventName,
+      args: eventName === "Deposit" ? { dst: account } : { src: account },
+    } as never) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function flattenReceiptChanges(receipt: ReceiptResult): Change[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.change] : flattenReceiptChanges(entry),
+  );
+}

--- a/packages/protocols/pancakeswap/test/types-v2.fixture.ts
+++ b/packages/protocols/pancakeswap/test/types-v2.fixture.ts
@@ -1,0 +1,28 @@
+import { type ActionCtx, NATIVE } from "@themoss/core";
+import { USDC_ADDRESS } from "@themoss/system";
+import type { PancakeSwapV2 } from "../src/index.js";
+
+declare const pancakeswap: PancakeSwapV2;
+declare const ctx: ActionCtx;
+
+void pancakeswap.swap({ tokenIn: NATIVE, tokenOut: USDC_ADDRESS, amountIn: "1" }, ctx);
+void pancakeswap.quote({ tokenIn: NATIVE, tokenOut: USDC_ADDRESS, amountOut: "1" }, ctx);
+
+// @ts-expect-error exactly one amount side is required
+const missingAmount: Parameters<PancakeSwapV2["swap"]>[0] = {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+};
+void pancakeswap.swap(missingAmount, ctx);
+
+// @ts-expect-error amountIn and amountOut are mutually exclusive
+const conflictingAmounts: Parameters<PancakeSwapV2["quote"]>[0] = {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1",
+  amountOut: "1",
+};
+void pancakeswap.quote(conflictingAmounts, ctx);
+
+// @ts-expect-error Package-authored ReceiptResult has no Core-owned Protocol provenance.
+void (null as unknown as ReturnType<PancakeSwapV2["swapReceipt"]>).protocol;

--- a/packages/protocols/pancakeswap/vitest.config.ts
+++ b/packages/protocols/pancakeswap/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+      "@themoss/erc": fileURLToPath(new URL("../../erc/src/index.ts", import.meta.url)),
+      "@themoss/simulator": fileURLToPath(new URL("../../simulator/src/index.ts", import.meta.url)),
+      "@themoss/system": fileURLToPath(new URL("../../system/src/index.ts", import.meta.url)),
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../../packages/protocols/kuru
+      '@themoss/protocol-pancakeswap':
+        specifier: workspace:*
+        version: link:../../packages/protocols/pancakeswap
       '@themoss/simulator':
         specifier: workspace:*
         version: link:../../packages/simulator
@@ -254,6 +257,9 @@ importers:
       '@themoss/abi-tools':
         specifier: workspace:*
         version: link:../../abi-tools
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)


### PR DESCRIPTION
## What & why

Closes #6.

Adds a self-describing PancakeSwap V2 Protocol for Monad mainnet, adapted to coexist with the PancakeSwap V3 Protocol already present on `main`.

The package now exports two independent Protocols:

- `PancakeSwap` / `pancakeswap` — existing V3 single-hop implementation
- `PancakeSwapV2` / `pancakeswap-v2` — new V2 constant-product implementation

PancakeSwap V2 supports:

- Exact-input swaps
- Target-output swaps with maximum-input protection
- Native MON ↔ ERC-20 swaps
- ERC-20 ↔ ERC-20 swaps
- Direct and single-WMON-hop route comparison
- Nested ERC-20 approval Capabilities
- One direct V2 Router transaction per swap Capability
- Typed, exhaustive Receipts derived from ordered simulation Changes
- Default MCP CLI discovery and loading

The V2 Receipt validates every Pair leg, including Transfer amounts, `Swap.to`, Sync/Swap ordering, intermediate WMON transfers, native wrapping/unwrapping, and the complete Change sequence.

## Type of change

- [x] New protocol adapter / capability / query
- [x] Core / MCP server change
- [x] Docs / examples
- [ ] Bugfix

## Architecture

This uses the current self-describing Protocol framework:

- Decorated `@Protocol`, `@Query`, `@Capability`, and `@Receipt` methods
- Explicit injected `ERC20` dependency
- One direct transaction and one named Receipt per Capability
- ERC-20 approvals represented as nested Capabilities
- Pure Receipt parsing without RPC calls or planned-route reconstruction
- Complete Change identity, length, and order preservation
- V2 and V3 exported from the same `@themoss/protocol-pancakeswap` package under distinct Protocol names

The default MCP CLI composition is now defined in one reusable module shared by the CLI and its discover/load tests.

## ABI origin

The V2 Router and Pair ABIs are full explorer-tier artifacts:

- V2 Router: `0xB1Bc24c34e88f7D43D5923034E3a14B24DaACfF9`
- V2 Pair reference: `0x27aa322b3f8ba9d0041df99c33fe4f3cc135e054`

They are integrated into the shared `@themoss/abi-tools` workflow introduced by #29:

```bash
MONADSCAN_API_KEY=... pnpm --filter @themoss/protocol-pancakeswap update:abis

The package’s ABI test verifies every committed V2/V3 artifact byte-for-byte against the shared deterministic renderer.
Checklist

pnpm lint passes

pnpm build passes

pnpm typecheck passes

pnpm test passes with live Monad access

Includes a changeset

intent, params, semantic types, verb, risk, and tags are declared

Every Capability owns exactly one direct transaction and one named Receipt

Additional approval transactions are nested Capabilities

Receipt parsing retains every Change in exact identity and order

Discoverable and loadable through the default MCP CLI

Compile-time parameter and Receipt fixtures are included

A live discover → load → action → simulate path is covered

Happy-path simulation produces no warnings
Evidence
Verified from a clean Git snapshot based on the latest main:
pnpm lint — passed
pnpm build — passed
pnpm typecheck — passed
pnpm test — passed with live Monad RPC access
Shared ABI tooling tests — 68 passed
PancakeSwap ABI drift tests — 5 passed
PancakeSwap offline tests — 28 passed
MCP server tests — 10 passed
Live V2 Router, Factory, Pair, quote, and simulation checks passed
Existing PancakeSwap V3 tests continue to pass
The live tests use read-only calls and simulation. No transaction is signed or broadcast.
MONADSCAN_API_KEY was not available during final verification, so the online ABI refresh command was not rerun. The committed ABIs passed the shared byte-exact deterministic drift tests.
Changeset impact
@themoss/protocol-pancakeswap: minor
@themoss/mcp-server: minor