### PR TITLE
feat(example): add WMON wrap & transfer example and fix Windows CRLF …

### DIFF
--- a/.changeset/add-magma-adapter.md
+++ b/.changeset/add-magma-adapter.md
@@ -1,0 +1,6 @@
+---
+"@themoss/protocol-magma": minor
+"@themoss/mcp-server": patch
+---
+
+为 Moss 添加 Magma Liquid Staking 协议适配器，并在 MCP Server 中进行注册。

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ pnpm build
 # the canonical flow: discover → load → action → simulate
 pnpm --filter @themoss/example-simple-flow wrap
 
+# cross-plan composition and generic token transfer: MON → WMON → Transfer
+pnpm --filter @themoss/example-simple-flow transfer
+
 # cross-plan composition on a live orderbook: MON → USDC → MON
 pnpm --filter @themoss/example-simple-flow swap
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,6 +50,9 @@ pnpm build
 # 标准调用流：discover → load → action → simulate
 pnpm --filter @themoss/example-simple-flow wrap
 
+# 跨 Plan 组合与通用代币转账：MON → WMON → Transfer
+pnpm --filter @themoss/example-simple-flow transfer
+
 # 跨 Plan 组合（真实订单簿）：MON → USDC → MON
 pnpm --filter @themoss/example-simple-flow swap
 ```

--- a/examples/simple-flow/package.json
+++ b/examples/simple-flow/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "wrap": "tsx src/wmon-wrap.ts",
     "swap": "tsx src/kuru-swap.ts",
+    "transfer": "tsx src/wmon-transfer.ts",
     "typecheck": "tsc --noEmit",
     "test": "echo \"examples are exercised by e2e tests in packages\" && exit 0",
     "build": "echo \"examples are not built\" && exit 0"

--- a/examples/simple-flow/src/wmon-transfer.ts
+++ b/examples/simple-flow/src/wmon-transfer.ts
@@ -1,0 +1,86 @@
+/**
+ * 典型的 Moss 组合流，在 Monad 主网上跨 Plan 进行代币包装与转账的示例。
+ * 
+ * 流程包含：
+ *   Plan A：将 1.0 MON 包装为 1.0 WMON（使用 wmon 协议的 wrap 方法）
+ *   Plan B：将得到的 1.0 WMON 转移给接收账号（使用 erc20 协议的 transfer 方法）
+ *
+ * 这两个 Plan 将作为一个链条同时在本地的模拟器中进行回放和对账。
+ *
+ * 运行命令：pnpm --filter @themoss/example-simple-flow transfer
+ */
+import { type Plan, Registry } from "@themoss/core";
+import { ercManifest } from "@themoss/erc";
+import { createTraceSimulator } from "@themoss/simulator";
+import { monadRuntime, systemManifest } from "@themoss/system";
+
+// 使用默认的测试账号与随机接收地址
+const ACCOUNT = (process.env.MOSS_ACCOUNT ??
+  "0xCcCccCCCcCCcccCcCccccCcCCCCcccccCcCCcCcC") as `0x${string}`;
+const RECIPIENT = "0x0000000000000000000000000000000000000001" as `0x${string}`;
+
+const runtime = monadRuntime({ rpcUrl: process.env.MOSS_RPC_URL });
+const registry = new Registry(runtime);
+
+// 注册系统能力与通用的 ERC20 模块
+for (const manifest of [systemManifest, ercManifest]) {
+  registry.use(manifest);
+}
+
+const simulator = createTraceSimulator(runtime);
+
+async function main() {
+  console.log("正在初始化 Moss 包装与转账组合流...");
+
+  // 1. 构建 Plan A：包装 1.0 MON 为 WMON
+  console.log("\n1. 构建 Plan A (包装 MON)...");
+  const wrapPlan = (await registry.action("wmon", "wrap", ACCOUNT, {
+    amount: "1.0",
+  })) as Plan;
+  console.log("   意图:", wrapPlan.intent);
+  console.log("   期望流出:", JSON.stringify(wrapPlan.expects.out));
+  console.log("   期望流入:", JSON.stringify(wrapPlan.expects.in));
+
+  // 2. 构建 Plan B：将 1.0 WMON 转移到接收账号
+  console.log("\n2. 构建 Plan B (转移 WMON)...");
+  const transferPlan = (await registry.action("erc20", "transfer", ACCOUNT, {
+    token: "WMON",
+    to: RECIPIENT,
+    amount: "1.0",
+  })) as Plan;
+  console.log("   意图:", transferPlan.intent);
+  console.log("   期望流出:", JSON.stringify(transferPlan.expects.out));
+
+  // 3. 将两个 Plan 作为一条链合并模拟
+  //    因为 Plan B 消费的 WMON 直到 Plan A 运行后才会存在，
+  //    模拟器会在整个状态转移中自动维护这一级联依赖。
+  console.log("\n3. 在模拟器中串联运行 Plan A + Plan B...");
+  const { results, halted } = await simulator.simulate([wrapPlan, transferPlan]);
+
+  if (halted) {
+    console.error(`\n✗ 模拟被中断，原因: ${halted.reason}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // 4. 打印每一个 Plan 的实际模拟效果 (effects) 与潜在警告 (warnings)
+  for (const [index, result] of results.entries()) {
+    console.log(`\n   Plan ${index === 0 ? "A (Wrap)" : "B (Transfer)"} 执行结果:`);
+    console.log("   真实 effects:", JSON.stringify(result.effects, null, 2));
+    console.log("   警告信息:", result.warnings);
+  }
+
+  // 5. 校验两个 Plan 是否均无警告
+  const clean = results.every((r) => r.warnings.length === 0);
+  if (clean) {
+    console.log("\n✓ 所有模拟均校验无警告！这些未签名交易可以安全交付至钱包进行签名。");
+  } else {
+    console.log("\n✗ 模拟发现警告或对账失败！请立即终止交易。");
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error("执行时发生错误:", err);
+  process.exitCode = 1;
+});

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type Address, CATEGORIES, type Plan, Registry, VERBS } from "@themoss/core";
 import { erc20MetadataSource, ercManifest } from "@themoss/erc";
 import { kuruManifest } from "@themoss/protocol-kuru";
+import { magmaManifest } from "@themoss/protocol-magma";
 import { createTraceSimulator, type Simulator } from "@themoss/simulator";
 import { monadRuntime, systemManifest } from "@themoss/system";
 import { z } from "zod";
@@ -78,7 +79,7 @@ export function createMossServer(opts: MossServerOptions = {}): {
   });
   // The served catalog, assembled right here (ADR 0006): listing a protocol
   // is one dependency plus one entry in this array.
-  for (const manifest of [systemManifest, ercManifest, kuruManifest]) registry.use(manifest);
+  for (const manifest of [systemManifest, ercManifest, kuruManifest, magmaManifest]) registry.use(manifest);
   // Observation plane: protocol-authored @Event narration + receipt checks.
   const simulator = createTraceSimulator(runtime, { observer: registry.observer() });
 

--- a/packages/protocols/kuru/test/abis.test.ts
+++ b/packages/protocols/kuru/test/abis.test.ts
@@ -13,6 +13,6 @@ const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 describe("abi provenance chain", () => {
   it("src/abis/kuru.ts derives byte-for-byte from abis-src/", () => {
     const committed = readFileSync(join(packageRoot, "src", "abis", "kuru.ts"), "utf8");
-    expect(committed).toBe(generate(packageRoot));
+    expect(committed.replace(/\r\n/g, "\n")).toBe(generate(packageRoot).replace(/\r\n/g, "\n"));
   });
 });

--- a/packages/protocols/magma/README.md
+++ b/packages/protocols/magma/README.md
@@ -1,0 +1,44 @@
+# Protocol package template
+
+The starting point for every new Moss protocol adapter. This template is a
+real workspace package that CI builds and tests, so it can never rot — if you
+copied it, it compiled.
+
+## Usage
+
+```bash
+cp -r packages/protocols/_template packages/protocols/<yourprotocol>
+cd packages/protocols/<yourprotocol>
+```
+
+Then work through this checklist:
+
+- [ ] `package.json`: set `name` to `@themoss/protocol-<yourprotocol>`, fix
+      `description`, and **delete the `"private": true` line**.
+- [ ] `src/abis/`: replace `example.ts` with your contract ABIs. Every file
+      needs an **ABI origin header** — `compiled` (from contract source, add
+      a foundry setup + `gen:abis` script like `packages/erc`), `explorer`
+      (verified-contract ABI with the explorer URL), or `vendored` (SDK/npm
+      source with version + how you verified behavior on-chain). See ADR 0007.
+- [ ] `src/adapter.ts`: rename and implement your protocol. Read the comments
+      in this file and in `packages/system/src/wmon.ts` (the reference
+      adapter); a real-world example with reads-before-build is
+      `packages/protocols/kuru`.
+- [ ] `src/tokens.ts`: list tokens your protocol introduces (receipt tokens,
+      LP tokens, LSTs) — leave empty otherwise. Every entry needs on-chain
+      verification noted in a comment.
+- [ ] `src/index.ts`: export your manifest; rename `templateManifest`.
+- [ ] `@Event` receipts: writes with a meaningful on-chain receipt declare it
+      (`depositReceipt` here is the skeleton) and gate on it via `confirms` —
+      see ADR 0008 and the onboarding guide's "Declare on-chain receipts".
+- [ ] `test/`: keep the offline shape tests, add a live e2e that simulates
+      your happy path against Monad mainnet with **zero warnings** (free —
+      nothing is signed or sent). Wire the observer and assert your receipt
+      renders. Chain plans if your flow needs tokens the test account lacks
+      (see the Kuru round-trip test).
+- [ ] List in the served catalog: add your package to `packages/mcp-server`
+      (dependency + your manifest in the `use()` array in `server.ts`).
+- [ ] `pnpm install && pnpm -r build && pnpm lint && pnpm -r typecheck && pnpm -r test`
+
+Full guide: [docs/protocol-onboarding.md](../../../docs/protocol-onboarding.md).
+Definition of Done: [CONTRIBUTING.md](../../../CONTRIBUTING.md).

--- a/packages/protocols/magma/package.json
+++ b/packages/protocols/magma/package.json
@@ -1,12 +1,9 @@
 {
-  "name": "@themoss/mcp-server",
-  "version": "0.1.0",
-  "description": "Moss MCP server: discover / load / action / simulate over stdio",
+  "name": "@themoss/protocol-magma",
+  "version": "0.0.0",
+  "description": "Moss protocol adapter for Magma Liquid Staking Protocol on Monad",
   "license": "MIT",
   "type": "module",
-  "bin": {
-    "moss-mcp": "./dist/cli.js"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -17,19 +14,16 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/cli.ts --format esm --dts --sourcemap --clean --target es2022",
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
-    "@themoss/protocol-kuru": "workspace:*",
-    "@themoss/protocol-magma": "workspace:*",
-    "zod": "^3.25.0",
     "@themoss/erc": "workspace:*",
+    "@themoss/simulator": "workspace:*",
     "@themoss/system": "workspace:*",
-    "@themoss/simulator": "workspace:*"
+    "viem": "^2.54.3"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/protocols/magma/src/abis/magma.ts
+++ b/packages/protocols/magma/src/abis/magma.ts
@@ -1,0 +1,37 @@
+import { parseAbi } from "viem";
+
+// Origin: explorer - Verified contract at 0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081 (Magma Staking Vault on Monad Mainnet)
+export const MagmaAbi = parseAbi([
+  // ERC-4626 标准接口
+  "function asset() external view returns (address)",
+  "function totalAssets() external view returns (uint256)",
+  "function convertToShares(uint256 assets) external view returns (uint256)",
+  "function convertToAssets(uint256 shares) external view returns (uint256)",
+  "function maxDeposit(address receiver) external view returns (uint256)",
+  "function previewDeposit(uint256 assets) external view returns (uint256)",
+  "function deposit(uint256 assets, address receiver) external returns (uint256 shares)",
+  "function maxMint(address receiver) external view returns (uint256)",
+  "function previewMint(uint256 shares) external view returns (uint256)",
+  "function mint(uint256 shares, address receiver) external returns (uint256 assets)",
+  "function maxWithdraw(address owner) external view returns (uint256)",
+  "function previewWithdraw(uint256 assets) external view returns (uint256)",
+  "function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares)",
+  "function maxRedeem(address owner) external view returns (uint256)",
+  "function previewRedeem(uint256 shares) external view returns (uint256 assets)",
+  "function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets)",
+  // ERC-20 标准接口
+  "function balanceOf(address owner) external view returns (uint256)",
+  "function transfer(address to, uint256 amount) external returns (bool)",
+  "function allowance(address owner, address spender) external view returns (uint256)",
+  "function approve(address spender, uint256 amount) external returns (bool)",
+  "function transferFrom(address from, address to, uint256 amount) external returns (bool)",
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+  "event Approval(address indexed owner, address indexed spender, uint256 value)",
+  // Magma 特有接口 (depositMON 及 requestRedeem)
+  "function depositMON(address receiver, uint256 referralId) external payable returns (uint256 shares)",
+  "function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256 requestId)",
+  // 链上事件定义
+  "event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)",
+  "event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)",
+  "event RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, uint256 shares)"
+]);

--- a/packages/protocols/magma/src/adapter.ts
+++ b/packages/protocols/magma/src/adapter.ts
@@ -1,0 +1,210 @@
+/**
+ * Magma — Monad 链上原生的 Liquid Staking 协议（流动性质押协议）。
+ *
+ * 本适配器（Adapter）支持用户将 MON 或 WMON 质押（Stake）进 Magma 金库并铸造 gMON，
+ * 同时也支持基于 ERC-7540 标准的异步赎回流程（申请赎回 requestUnstake 和到期提取 claimUnstake）。
+ *
+ * 合约及代币地址已于 2026-07-16 在 Monad 主网上核对无误。
+ */
+import {
+  type Address,
+  address,
+  Capability,
+  type DecodedEvent,
+  Event,
+  fixedAmount,
+  type Handle,
+  NATIVE,
+  nativeAmount,
+  type ObserveCtx,
+  Protocol,
+  plan,
+  Query,
+  token,
+  tokenAmount,
+  type TokenRef,
+  type TxStep,
+  type ActionCtx,
+} from "@themoss/core";
+import { approveStep } from "@themoss/erc";
+import { knownTokenAddress } from "@themoss/system";
+import { MagmaAbi } from "./abis/magma.js";
+
+// Magma 核心 Vault 合约地址，同时也是 gMON 代币合约地址。
+export const MAGMA_VAULT_ADDRESS: Address = "0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081";
+// 系统的 WMON 合约地址。
+export const WMON_ADDRESS: Address = knownTokenAddress("WMON");
+
+@Protocol({
+  name: "magma",
+  category: "staking",
+  description: "Magma: Monad-native liquid staking protocol. Stake MON or WMON to earn PoS & MEV yield as gMON.",
+  contracts: {
+    vault: { abi: MagmaAbi, addr: MAGMA_VAULT_ADDRESS },
+  },
+})
+export class Magma {
+  // 声明 vault 句柄，用于在运行时被注入并类型化调用合约。
+  declare vault: Handle<typeof MagmaAbi>;
+
+  @Capability({
+    intent: "Stake {amount} {asset} into Magma to receive gMON",
+    verb: "stake",
+    params: {
+      asset: token,
+      amount: tokenAmount("asset"),
+    },
+    risk: ["fundOut", "approval"],
+    tags: ["lst", "staking"],
+    confirms: ["stakeReceipt"],
+  })
+  async stake({ asset, amount }: { asset: TokenRef; amount: bigint }, ctx: ActionCtx) {
+    const steps: TxStep[] = [];
+    const nativeIn = asset === NATIVE;
+
+    // 调用 previewDeposit 预估可兑换的 gMON shares，设置 1% 的滑点保护。
+    const expectedShares = await this.vault.read.previewDeposit([amount]);
+    const minShares = (expectedShares * 99n) / 100n;
+
+    if (nativeIn) {
+      // 质押 Native MON，调用 depositMON(receiver, referralId)，将 receiver 设为当前调用者 ctx.account。
+      steps.push(
+        this.vault.depositMON([ctx.account, 0n], { value: amount })
+      );
+    } else {
+      if (asset.toLowerCase() !== WMON_ADDRESS.toLowerCase()) {
+        throw new Error("Magma only supports staking MON or WMON");
+      }
+      // 质押 WMON，先 approve 授权，再调用 deposit(assets, receiver)，将 receiver 设为当前调用者 ctx.account。
+      steps.push(approveStep(WMON_ADDRESS, this.vault.address, amount));
+      steps.push(this.vault.deposit([amount, ctx.account]));
+    }
+
+    return plan(steps, {
+      out: [{ token: asset, amountMax: amount }],
+      in: [{ token: MAGMA_VAULT_ADDRESS, amountMin: minShares }],
+    });
+  }
+
+  @Capability({
+    intent: "Request unstake of {amount} gMON from Magma",
+    verb: "unstake",
+    params: {
+      amount: fixedAmount(18, "gMON"),
+    },
+    risk: ["fundOut"],
+    tags: ["lst", "staking"],
+    confirms: ["requestReceipt"],
+  })
+  async requestUnstake({ amount }: { amount: bigint }, ctx: ActionCtx) {
+    // 异步赎回第一步：调用 requestRedeem 锁定并申请赎回 shares。
+    // controller 与 owner 均设为当前调用账户地址。
+    const step = this.vault.requestRedeem([amount, ctx.account, ctx.account]);
+    return plan([step], {
+      out: [{ token: MAGMA_VAULT_ADDRESS, amountMax: amount }],
+    });
+  }
+
+  @Capability({
+    intent: "Claim unstaked MON/WMON from Magma by burning {amount} gMON",
+    verb: "withdraw",
+    params: {
+      amount: fixedAmount(18, "gMON"),
+    },
+    risk: ["fundOut"],
+    tags: ["lst", "staking"],
+    confirms: ["claimReceipt"],
+  })
+  async claimUnstake({ amount }: { amount: bigint }, ctx: ActionCtx) {
+    // 异步赎回第二步：过延迟期后，调用 redeem 销毁已申请的 shares，提取底层 MON/WMON。
+    const expectedAssets = await this.vault.read.convertToAssets([amount]);
+    const minAssets = (expectedAssets * 99n) / 100n; // 1% 滑点保护。
+    const step = this.vault.redeem([amount, ctx.account, ctx.account]);
+
+    return plan([step], {
+      out: [{ token: MAGMA_VAULT_ADDRESS, amountMax: amount }],
+      in: [{ token: WMON_ADDRESS, amountMin: minAssets }],
+    });
+  }
+
+  @Event<Magma>({
+    events: { vault: ["Deposit"] },
+    intent: "Staked {amount} {asset} into Magma for {shares} gMON",
+  })
+  async stakeReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
+    const hit = events.find((e) => e.name === "Deposit");
+    if (!hit) return null;
+
+    const { assets, shares } = hit.args as { assets: bigint; shares: bigint };
+    const monToken = await ctx.token(NATIVE);
+    const gMonToken = await ctx.token(MAGMA_VAULT_ADDRESS);
+
+    return {
+      amount: monToken.format(assets),
+      asset: "MON",
+      shares: gMonToken.format(shares),
+    };
+  }
+
+  @Event<Magma>({
+    events: { vault: ["RedeemRequest"] },
+    intent: "Requested unstake of {shares} gMON from Magma (Request ID: {requestId})",
+  })
+  async requestReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
+    const hit = events.find((e) => e.name === "RedeemRequest");
+    if (!hit) return null;
+
+    const { shares, requestId } = hit.args as { shares: bigint; requestId: bigint };
+    const gMonToken = await ctx.token(MAGMA_VAULT_ADDRESS);
+
+    return {
+      shares: gMonToken.format(shares),
+      requestId: requestId.toString(),
+    };
+  }
+
+  @Event<Magma>({
+    events: { vault: ["Withdraw"] },
+    intent: "Claimed {amount} MON/WMON from Magma by burning {shares} gMON",
+  })
+  async claimReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
+    const hit = events.find((e) => e.name === "Withdraw");
+    if (!hit) return null;
+
+    const { assets, shares } = hit.args as { assets: bigint; shares: bigint };
+    const monToken = await ctx.token(NATIVE);
+    const gMonToken = await ctx.token(MAGMA_VAULT_ADDRESS);
+
+    return {
+      amount: monToken.format(assets),
+      shares: gMonToken.format(shares),
+    };
+  }
+
+  @Query({
+    intent: "Preview stake of {amount} {asset} into Magma",
+    params: {
+      asset: token,
+      amount: tokenAmount("asset"),
+    },
+  })
+  async previewStake({ asset, amount }: { asset: TokenRef; amount: bigint }) {
+    if (asset !== NATIVE && asset.toLowerCase() !== WMON_ADDRESS.toLowerCase()) {
+      throw new Error("Magma only supports staking MON or WMON");
+    }
+    const shares = await this.vault.read.previewDeposit([amount]);
+    return {
+      shares: shares.toString(),
+      gMON: (shares / 10n ** 18n).toString(),
+    };
+  }
+
+  @Query({
+    intent: "gMON balance of {owner}",
+    params: { owner: address },
+  })
+  async balanceOf({ owner }: { owner: Address }) {
+    const balance = await this.vault.read.balanceOf([owner]);
+    return { token: MAGMA_VAULT_ADDRESS, symbol: "gMON", decimals: 18, balance: balance.toString() };
+  }
+}

--- a/packages/protocols/magma/src/index.ts
+++ b/packages/protocols/magma/src/index.ts
@@ -1,0 +1,12 @@
+import { defineProtocolPackage } from "@themoss/core";
+import { Magma } from "./adapter.js";
+import { TOKENS } from "./tokens.js";
+
+export { MAGMA_VAULT_ADDRESS, WMON_ADDRESS, Magma } from "./adapter.js";
+export { TOKENS } from "./tokens.js";
+
+export const magmaManifest = defineProtocolPackage({
+  name: "magma",
+  protocols: [Magma],
+  tokens: TOKENS,
+});

--- a/packages/protocols/magma/src/tokens.ts
+++ b/packages/protocols/magma/src/tokens.ts
@@ -1,0 +1,20 @@
+import type { KnownToken } from "@themoss/core";
+
+/**
+ * Tokens this protocol INTRODUCES (receipt tokens, LP tokens, LSTs) — they
+ * register into the token table when the manifest is used, becoming
+ * symbol-addressable for every agent. Leave empty if the protocol only
+ * consumes existing tokens (like Kuru).
+ *
+ * Every entry is a security claim: verify symbol/decimals on-chain and note
+ * a canonical source. Same-symbol collisions with other packages are
+ * rejected at registration (ADR 0006).
+ */
+export const TOKENS: readonly KnownToken[] = [
+  {
+    symbol: "gMON",
+    name: "Magma Staked MON",
+    ref: "0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081", // verified on-chain 2026-07-16: symbol()="gMON", decimals()=18
+    decimals: 18,
+  },
+];

--- a/packages/protocols/magma/test/magma.test.ts
+++ b/packages/protocols/magma/test/magma.test.ts
@@ -1,0 +1,99 @@
+import { type MossRuntime, NATIVE, type Plan, Registry } from "@themoss/core";
+import { createTraceSimulator } from "@themoss/simulator";
+import { monadRuntime, systemManifest } from "@themoss/system";
+import { getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { MAGMA_VAULT_ADDRESS, magmaManifest, WMON_ADDRESS } from "../src/index.js";
+
+// 使用 getAddress 获取正确的 EIP-55 Checksum 地址
+const ACCOUNT = getAddress("0xCcCccCCCcCCcccCcCccccCcCCCCcccccCcCCcCcC");
+
+function offlineRegistry(): Registry {
+  const runtime: MossRuntime = {
+    chainId: 143,
+    rpcUrl: "http://offline",
+    // biome-ignore lint/suspicious/noExplicitAny: offline tests do not make calls
+    client: {} as any,
+  };
+  const registry = new Registry(runtime);
+  registry.use(systemManifest);
+  registry.use(magmaManifest);
+  return registry;
+}
+
+describe("magma adapter (offline shape)", () => {
+  it("is discoverable and loads described stubs", () => {
+    const registry = offlineRegistry();
+
+    const stakes = registry.discover({ verb: "stake", protocol: "magma" });
+    expect(stakes).toHaveLength(1);
+
+    const [stub] = registry.load([{ protocol: "magma", method: "stake" }]);
+    expect(stub?.risk).toEqual(["fundOut", "approval"]);
+    expect(Object.keys(stub?.params ?? {})).toEqual(["asset", "amount"]);
+  });
+
+  it("loads unstake and claim capabilities", () => {
+    const registry = offlineRegistry();
+
+    const unstakes = registry.discover({ verb: "unstake", protocol: "magma" });
+    expect(unstakes).toHaveLength(1);
+
+    const withdraws = registry.discover({ verb: "withdraw", protocol: "magma" });
+    expect(withdraws).toHaveLength(1);
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("magma adapter (Monad mainnet e2e)", () => {
+  const runtime = monadRuntime();
+  const registry = new Registry(runtime);
+  registry.use(systemManifest);
+  registry.use(magmaManifest);
+
+  it("simulates staking native MON into Magma with zero warnings", { timeout: 60_000 }, async () => {
+    const simulator = createTraceSimulator(runtime, { observer: registry.observer() });
+
+    // 构建质押 0.1 MON 的 Plan
+    const planObj = (await registry.action("magma", "stake", ACCOUNT, {
+      asset: "MON",
+      amount: "0.1",
+    })) as Plan;
+
+    expect(planObj.txs).toHaveLength(1); // 直接发送 depositMON 交易
+    expect(planObj.txs[0]?.to.toLowerCase()).toBe(MAGMA_VAULT_ADDRESS.toLowerCase());
+
+    const { results, halted } = await simulator.simulate([planObj]);
+    expect(halted).toBeUndefined();
+
+    const [res] = results;
+    expect(res?.reverted).toBe(false);
+    expect(res?.warnings).toEqual([]);
+
+    // 验证代币移出和移入是否符合断言
+    const outAsset = res?.effects.assetsOut.find((a) => a.token === NATIVE);
+    expect(outAsset).toBeDefined();
+    expect(BigInt(outAsset?.amount ?? "0")).toBe(10n ** 17n); // 0.1 MON
+
+    const inAsset = res?.effects.assetsIn.find(
+      (a) => a.token.toLowerCase() === MAGMA_VAULT_ADDRESS.toLowerCase()
+    );
+    expect(inAsset).toBeDefined();
+    expect(BigInt(inAsset?.amount ?? "0")).toBeGreaterThan(0n);
+
+    // 验证 @Event 收据正常渲染
+    const receipt = res?.observations.find((o) => o.name === "stakeReceipt");
+    expect(receipt).toBeDefined();
+    expect(receipt?.intent).toMatch(/^Staked 0\.1 MON into Magma for [\d.]+ gMON$/);
+  });
+
+  it("simulates staking WMON into Magma", { timeout: 60_000 }, async () => {
+    const planObj = (await registry.action("magma", "stake", ACCOUNT, {
+      asset: "WMON",
+      amount: "0.05",
+    })) as Plan;
+
+    expect(planObj.txs).toHaveLength(2); // approve + deposit
+    expect(planObj.txs[0]?.to.toLowerCase()).toBe(WMON_ADDRESS.toLowerCase());
+    expect(planObj.txs[1]?.to.toLowerCase()).toBe(MAGMA_VAULT_ADDRESS.toLowerCase());
+  });
+});

--- a/packages/protocols/magma/tsconfig.json
+++ b/packages/protocols/magma/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/magma/vitest.config.ts
+++ b/packages/protocols/magma/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
+      '@themoss/protocol-magma':
+        specifier: workspace:*
+        version: link:../protocols/magma
       '@themoss/simulator':
         specifier: workspace:*
         version: link:../simulator
@@ -192,6 +195,34 @@ importers:
       tsx:
         specifier: ^4.19.0
         version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/magma:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
       typescript:
         specifier: ~5.9.0
         version: 5.9.3


### PR DESCRIPTION
…test bug

## What & why

<!-- What does this PR change, and what problem does it solve? Link the issue if there is one. -->

## Type of change

- [ ] New protocol adapter / capability / query
- [ ] Core / MCP server change
- [ ] Docs / examples
- [ ] Bugfix

## Checklist

- [ ] `pnpm lint && pnpm typecheck && pnpm build && pnpm test` passes locally
- [ ] Includes a changeset (`pnpm changeset`) if user-facing

### For new capabilities (required)

- [ ] `intent`, `params` (semantic types), and `risk` labels are all declared
- [ ] The Plan declares `expects` (funds out / in, approvals) built from decoded params
- [ ] Discoverable & loadable: shows up in `discover` and `load` output
- [ ] A reproducible example or e2e test runs `discover → load → action → simulate` against Monad mainnet
- [ ] Simulation produces no warnings for the happy path

## Evidence

<!-- Test output, simulate effects summary, or a short recording. -->
