### PR TITLE
fix(core): reject unsafe numeric uint inputs

### DIFF
--- a/.changeset/safe-uint-inputs.md
+++ b/.changeset/safe-uint-inputs.md
@@ -1,0 +1,5 @@
+---
+"@themoss/core": patch
+---
+
+Reject unsafe JavaScript number inputs for uint parameters before precision can be lost. Pass large uint values as decimal strings for exact decoding.

--- a/packages/core/src/semantics.ts
+++ b/packages/core/src/semantics.ts
@@ -79,12 +79,20 @@ export const token: SemanticType<TokenRef> = {
   },
 };
 
-/** A non-negative integer (e.g. an NFT token id), as a decimal string or number. */
+/** A non-negative integer (e.g. an NFT token id), as a decimal string or safe integer number. */
 export const uint: SemanticType<bigint> = {
   describe: 'A non-negative integer (e.g. an NFT token id), as a decimal string like "42".',
   decode(value) {
     if (typeof value !== "string" && typeof value !== "number") {
       throw new Error(`expected an integer, got ${typeof value}`);
+    }
+    if (typeof value === "number") {
+      if (!Number.isInteger(value)) {
+        throw new Error(`expected an integer, got "${value}"`);
+      }
+      if (!Number.isSafeInteger(value)) {
+        throw new Error("unsafe integer number; pass large integers as a decimal string");
+      }
     }
     let n: bigint;
     try {

--- a/packages/core/test/core-unit.test.ts
+++ b/packages/core/test/core-unit.test.ts
@@ -9,6 +9,7 @@ import {
   slippageBps,
   token,
   tokenAmount,
+  uint,
 } from "../src/semantics.js";
 import { Token } from "../src/token.js";
 import { type KnownToken, TokenTable } from "../src/tokens.js";
@@ -40,6 +41,31 @@ describe("semantic types", () => {
     expect(decoded.a).toBe(USDC);
     await expect(decodeParams({ a: address }, { a: "0x123" }, ctx)).rejects.toThrow(
       'invalid parameter "a"',
+    );
+  });
+
+  it("rejects unsafe numeric uints and preserves exact decimal strings", async () => {
+    const maxSafe = Number.MAX_SAFE_INTEGER;
+    expect((await decodeParams({ id: uint }, { id: maxSafe }, ctx)).id).toBe(BigInt(maxSafe));
+
+    await expect(decodeParams({ id: uint }, { id: maxSafe + 1 }, ctx)).rejects.toThrow(
+      /unsafe integer.*decimal string/i,
+    );
+
+    expect((await decodeParams({ id: uint }, { id: "9007199254740992" }, ctx)).id).toBe(
+      9_007_199_254_740_992n,
+    );
+
+    const uint128Max = "340282366920938463463374607431768211455";
+    expect((await decodeParams({ id: uint }, { id: uint128Max }, ctx)).id).toBe(BigInt(uint128Max));
+  });
+
+  it("continues to reject negative and fractional uints", async () => {
+    await expect(decodeParams({ id: uint }, { id: -1 }, ctx)).rejects.toThrow(
+      "must be non-negative",
+    );
+    await expect(decodeParams({ id: uint }, { id: 1.5 }, ctx)).rejects.toThrow(
+      "expected an integer",
     );
   });
 


### PR DESCRIPTION
## Motivation

JavaScript numbers above `Number.MAX_SAFE_INTEGER` can be rounded before `BigInt` conversion. The current `uint` semantic accepts those values, which can silently build calldata for a different integer, including a different ERC-721 token ID.

## What changed

- reject non-integer and unsafe numeric uint inputs before `BigInt` conversion
- preserve safe numeric inputs
- preserve arbitrary-precision decimal-string inputs
- document the numeric safety boundary
- add a patch changeset and regression coverage

## Evidence

- TDD regression reproduced the current behavior: `maxSafe + 1` resolved as `9007199254740992n` instead of rejecting
- `pnpm lint`
- `pnpm -r build`
- `pnpm -r typecheck`
- `MOSS_SKIP_E2E=1 pnpm -r test`
- `NODE_USE_ENV_PROXY=1 pnpm -r test` (including Monad mainnet e2e)

## Scope

This PR intentionally does not change the general floating-point policy for token amounts or include unrelated framework work.

Draft PR #31 replaces this API with the string-only `UnsignedIntegerString` schema. This is intentionally a narrow safety fix for the current `main`; if #31 lands first, this PR can be treated as superseded.
