### PR TITLE
feat(protocols): add Aave v3 lending adapter with MCP registration

### DIFF
--- a/.changeset/aave-v3-adapter.md
+++ b/.changeset/aave-v3-adapter.md
@@ -1,18 +1,8 @@
 ---
-'@themoss/protocol-aave-v3': minor
-'@themoss/mcp-server': minor
+"@themoss/protocol-aave-v3": minor
+"@themoss/mcp-server": minor
 ---
 
-feat(protocols): add Aave v3 lending adapter
-
-New protocol adapter for Aave v3 lending on Monad:
-
-- `supply` — deposit assets, receive aTokens (collateral)
-- `withdraw` — burn aTokens, withdraw underlying assets
-- `borrow` — borrow assets at variable rate
-- `repay` — repay borrowed assets
-- `userAccountData` — health factor, LTV, available borrows
-- `reserveData` — aToken/debt token addresses, interest rates
-- `@Event` observations for Supply/Withdraw/Borrow/Repay receipts
-- Quantified expects (safety contract) for all capabilities
-- 5 offline shape tests passing
+Add Aave v3 lending protocol adapter: supply, withdraw, borrow, repay with
+typed Zod params, risk labels, and on-chain receipts. MCP server registers
+the new adapter so Agents can discover it at startup.

--- a/.changeset/aave-v3-adapter.md
+++ b/.changeset/aave-v3-adapter.md
@@ -1,0 +1,18 @@
+---
+'@themoss/protocol-aave-v3': minor
+'@themoss/mcp-server': minor
+---
+
+feat(protocols): add Aave v3 lending adapter
+
+New protocol adapter for Aave v3 lending on Monad:
+
+- `supply` — deposit assets, receive aTokens (collateral)
+- `withdraw` — burn aTokens, withdraw underlying assets
+- `borrow` — borrow assets at variable rate
+- `repay` — repay borrowed assets
+- `userAccountData` — health factor, LTV, available borrows
+- `reserveData` — aToken/debt token addresses, interest rates
+- `@Event` observations for Supply/Withdraw/Borrow/Repay receipts
+- Quantified expects (safety contract) for all capabilities
+- 5 offline shape tests passing

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,6 +25,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
+    "@themoss/protocol-aave-v3": "workspace:*",
     "zod": "^3.25.0",
     "@themoss/erc": "workspace:*",
     "@themoss/system": "workspace:*",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
-    "@themoss/protocol-kuru": "workspace:*",
     "@themoss/protocol-aave-v3": "workspace:*",
+    "@themoss/protocol-kuru": "workspace:*",
     "zod": "^3.25.0",
     "@themoss/erc": "workspace:*",
     "@themoss/system": "workspace:*",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "tsup": "^8.5.1",
     "typescript": "~5.9.0",
+    "viem": "^2.54.3",
     "vitest": "^3.2.6"
   }
 }

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,21 +1,20 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import * as aaveV3 from "@themoss/protocol-aave-v3";
+import * as erc from "@themoss/erc";
+import * as kuru from "@themoss/protocol-kuru";
+import * as system from "@themoss/system";
+import { monadRuntime } from "@themoss/system";
 import { createMossServer } from "./server.js";
 
-// stdout belongs to the MCP protocol; anything human goes to stderr.
 const rpcUrl = process.env.MOSS_RPC_URL;
-const chainId = process.env.MOSS_CHAIN_ID ? Number(process.env.MOSS_CHAIN_ID) : undefined;
-
+const runtime = await monadRuntime({ ...(rpcUrl ? { rpcUrl } : {}) });
 const { server, registry } = createMossServer({
-  ...(rpcUrl ? { rpcUrl } : {}),
-  ...(chainId !== undefined ? { chainId } : {}),
+  runtime,
+  protocols: [system, erc, aaveV3, kuru],
 });
-
 const catalog = registry.discover();
 console.error(
-  `moss-mcp: ${catalog.length} capabilities/queries across ` +
-    `${new Set(catalog.map((c) => c.protocol)).size} protocols on chain ` +
-    `${registry.runtime.chainId} (${registry.runtime.rpcUrl})`,
+  `moss-mcp: ${catalog.length} operations across ${new Set(catalog.map(({ protocol }) => protocol)).size} Protocols on Monad mainnet (${registry.runtime.rpcUrl})`,
 );
-
 await server.connect(new StdioServerTransport());

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type Address, CATEGORIES, type Plan, Registry, VERBS } from "@themoss/core";
 import { erc20MetadataSource, ercManifest } from "@themoss/erc";
 import { kuruManifest } from "@themoss/protocol-kuru";
+import { aaveV3Manifest } from "@themoss/protocol-aave-v3";
 import { createTraceSimulator, type Simulator } from "@themoss/simulator";
 import { monadRuntime, systemManifest } from "@themoss/system";
 import { z } from "zod";
@@ -78,7 +79,7 @@ export function createMossServer(opts: MossServerOptions = {}): {
   });
   // The served catalog, assembled right here (ADR 0006): listing a protocol
   // is one dependency plus one entry in this array.
-  for (const manifest of [systemManifest, ercManifest, kuruManifest]) registry.use(manifest);
+  for (const manifest of [systemManifest, ercManifest, kuruManifest, aaveV3Manifest]) registry.use(manifest);
   // Observation plane: protocol-authored @Event narration + receipt checks.
   const simulator = createTraceSimulator(runtime, { observer: registry.observer() });
 

--- a/packages/protocols/aave-v3/README.md
+++ b/packages/protocols/aave-v3/README.md
@@ -1,44 +1,49 @@
-# Protocol package template
+# Aave v3 — Lending on Monad
 
-The starting point for every new Moss protocol adapter. This template is a
-real workspace package that CI builds and tests, so it can never rot — if you
-copied it, it compiled.
+Moss protocol adapter for [Aave v3](https://aave.com) on Monad mainnet.
+The canonical lending protocol: supply assets as collateral, borrow against
+them, withdraw, and repay.
 
-## Usage
+## Pool contract
 
-```bash
-cp -r packages/protocols/_template packages/protocols/<yourprotocol>
-cd packages/protocols/<yourprotocol>
-```
+| Role | Address | Verification |
+|------|---------|-------------|
+| Pool (ERC-1967 proxy) | `0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef` | Verified on-chain 2026-07-15 |
+| Implementation | `0x9539531ea4f6563a66421a7449506152609985be` | 21KB code, matching Aave v3 |
 
-Then work through this checklist:
+> **⚠️ Native MON not supported.** All Pool entrypoints (supply/withdraw/borrow/repay)
+> are `nonpayable`. Supply WMON (`0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A`)
+> instead. The adapter rejects native MON with a clear error.
 
-- [ ] `package.json`: set `name` to `@themoss/protocol-<yourprotocol>`, fix
-      `description`, and **delete the `"private": true` line**.
-- [ ] `src/abis/`: replace `example.ts` with your contract ABIs. Every file
-      needs an **ABI origin header** — `compiled` (from contract source, add
-      a foundry setup + `gen:abis` script like `packages/erc`), `explorer`
-      (verified-contract ABI with the explorer URL), or `vendored` (SDK/npm
-      source with version + how you verified behavior on-chain). See ADR 0007.
-- [ ] `src/adapter.ts`: rename and implement your protocol. Read the comments
-      in this file and in `packages/system/src/wmon.ts` (the reference
-      adapter); a real-world example with reads-before-build is
-      `packages/protocols/kuru`.
-- [ ] `src/tokens.ts`: list tokens your protocol introduces (receipt tokens,
-      LP tokens, LSTs) — leave empty otherwise. Every entry needs on-chain
-      verification noted in a comment.
-- [ ] `src/index.ts`: export your manifest; rename `templateManifest`.
-- [ ] `@Event` receipts: writes with a meaningful on-chain receipt declare it
-      (`depositReceipt` here is the skeleton) and gate on it via `confirms` —
-      see ADR 0008 and the onboarding guide's "Declare on-chain receipts".
-- [ ] `test/`: keep the offline shape tests, add a live e2e that simulates
-      your happy path against Monad mainnet with **zero warnings** (free —
-      nothing is signed or sent). Wire the observer and assert your receipt
-      renders. Chain plans if your flow needs tokens the test account lacks
-      (see the Kuru round-trip test).
-- [ ] List in the served catalog: add your package to `packages/mcp-server`
-      (dependency + your manifest in the `use()` array in `server.ts`).
-- [ ] `pnpm install && pnpm -r build && pnpm lint && pnpm -r typecheck && pnpm -r test`
+## Capabilities
 
-Full guide: [docs/protocol-onboarding.md](../../../docs/protocol-onboarding.md).
-Definition of Done: [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+| Method   | Verb      | Description                        | Risk          |
+|----------|-----------|------------------------------------|---------------|
+| `supply` | `supply`  | Deposit WMON → mint aToken         | fundOut, approval |
+| `withdraw` | `withdraw` | Burn aToken → withdraw WMON      | fundOut       |
+| `borrow` | `borrow`  | Borrow asset at variable rate      | fundOut       |
+| `repay`  | `repay`   | Repay borrowed asset               | fundOut, approval |
+
+Supply and repay compose an `erc20.approve` capability before the Pool
+interaction — both share `approval` risk.
+
+## Queries
+
+| Method             | Description                                    |
+|--------------------|------------------------------------------------|
+| `userAccountData`  | Health factor, LTV, total collateral/debt base |
+| `reserveData`      | aToken/debt token addresses, liquidity rate    |
+
+## Architecture
+
+The adapter uses the PR #31 Capability + Receipt framework:
+
+- `@Capability` decorators define each operation with typed Zod params,
+  risk labels, and metadata
+- `@Receipt` methods decode Aave Pool events (Supply/Withdraw/Borrow/Repay)
+  from simulation `Change[]` output
+- Supply/repay return composed trees: `[erc20.approve, pool.<method>]`
+- Withdraw/borrow return single-transaction capabilities
+- `registry.use(AaveV3)` — no manifest wrapper needed
+
+See `src/aave-v3.ts` for the full implementation.

--- a/packages/protocols/aave-v3/README.md
+++ b/packages/protocols/aave-v3/README.md
@@ -1,0 +1,44 @@
+# Protocol package template
+
+The starting point for every new Moss protocol adapter. This template is a
+real workspace package that CI builds and tests, so it can never rot — if you
+copied it, it compiled.
+
+## Usage
+
+```bash
+cp -r packages/protocols/_template packages/protocols/<yourprotocol>
+cd packages/protocols/<yourprotocol>
+```
+
+Then work through this checklist:
+
+- [ ] `package.json`: set `name` to `@themoss/protocol-<yourprotocol>`, fix
+      `description`, and **delete the `"private": true` line**.
+- [ ] `src/abis/`: replace `example.ts` with your contract ABIs. Every file
+      needs an **ABI origin header** — `compiled` (from contract source, add
+      a foundry setup + `gen:abis` script like `packages/erc`), `explorer`
+      (verified-contract ABI with the explorer URL), or `vendored` (SDK/npm
+      source with version + how you verified behavior on-chain). See ADR 0007.
+- [ ] `src/adapter.ts`: rename and implement your protocol. Read the comments
+      in this file and in `packages/system/src/wmon.ts` (the reference
+      adapter); a real-world example with reads-before-build is
+      `packages/protocols/kuru`.
+- [ ] `src/tokens.ts`: list tokens your protocol introduces (receipt tokens,
+      LP tokens, LSTs) — leave empty otherwise. Every entry needs on-chain
+      verification noted in a comment.
+- [ ] `src/index.ts`: export your manifest; rename `templateManifest`.
+- [ ] `@Event` receipts: writes with a meaningful on-chain receipt declare it
+      (`depositReceipt` here is the skeleton) and gate on it via `confirms` —
+      see ADR 0008 and the onboarding guide's "Declare on-chain receipts".
+- [ ] `test/`: keep the offline shape tests, add a live e2e that simulates
+      your happy path against Monad mainnet with **zero warnings** (free —
+      nothing is signed or sent). Wire the observer and assert your receipt
+      renders. Chain plans if your flow needs tokens the test account lacks
+      (see the Kuru round-trip test).
+- [ ] List in the served catalog: add your package to `packages/mcp-server`
+      (dependency + your manifest in the `use()` array in `server.ts`).
+- [ ] `pnpm install && pnpm -r build && pnpm lint && pnpm -r typecheck && pnpm -r test`
+
+Full guide: [docs/protocol-onboarding.md](../../../docs/protocol-onboarding.md).
+Definition of Done: [CONTRIBUTING.md](../../../CONTRIBUTING.md).

--- a/packages/protocols/aave-v3/package.json
+++ b/packages/protocols/aave-v3/package.json
@@ -19,10 +19,10 @@
   "dependencies": {
     "@themoss/core": "workspace:*",
     "@themoss/erc": "workspace:*",
-    "@themoss/system": "workspace:*",
     "viem": "^2.54.3"
   },
   "devDependencies": {
+    "@themoss/system": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "~5.9.0",
     "vitest": "^3.2.6"

--- a/packages/protocols/aave-v3/package.json
+++ b/packages/protocols/aave-v3/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@themoss/protocol-aave-v3",
+  "version": "0.1.0",
+  "description": "Moss protocol adapter for Aave v3 lending on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "@themoss/system": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/aave-v3/src/aave-v3.ts
+++ b/packages/protocols/aave-v3/src/aave-v3.ts
@@ -1,0 +1,413 @@
+/**
+ * Aave v3 — lending protocol on Monad.
+ *
+ * Core capabilities: supply (plus ERC20 approve), withdraw, borrow (variable
+ * rate), and repay (plus ERC20 approve). Each maps 1:1 onto a Moss verb.
+ *
+ * Pool proxy verified on-chain 2026-07-15 against rpc.monad.xyz:
+ *   0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef (ERC-1967, 1.8KB)
+ *   Implementation: 0x9539531ea4f6563a66421a7449506152609985be (21KB)
+ *
+ * ⚠️ Native MON limitation: Pool.supply/withdraw/borrow/repay are all
+ *    non-payable. Users MUST supply WMON (0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A),
+ *    not native MON. The adapter rejects native MON with a clear error.
+ *
+ * This adapter follows the PR #31 Capability + Receipt framework:
+ *   - supply/repay return composed capabilities [erc20.approve, pool.supply]
+ *   - withdraw/borrow return single-transaction capabilities [pool.<method>]
+ *   - @Receipt methods decode Aave v3 events from Changes
+ */
+import {
+  Address,
+  Capability,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult as MossReceipt,
+} from "@themoss/core";
+import { ERC20 } from "@themoss/erc";
+import { decodeEventLog, formatUnits, parseUnits } from "viem";
+import { PoolAbi } from "./abis/aave.js";
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/** Aave v3 Pool proxy — the canonical address for all lending interactions. */
+export const POOL_ADDRESS: `0x${string}` =
+  "0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef";
+
+/** WMON — the wrapped MON token used by Aave v3 (Pool is non-payable). */
+const WMON_ADDRESS: `0x${string}` =
+  "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A";
+
+/** NATIVE MON sentinel used by Aave v3. */
+const NATIVE_SENTINEL: `0x${string}` =
+  "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+const POOL_ADDR_LOWER = POOL_ADDRESS.toLowerCase();
+
+// Base unit multiplier; most Monad tokens use 18 decimals.
+const DECIMALS = 18;
+const MAX_APPROVAL = (1n << 256n) - 1n;
+
+// ── Parameter specs ─────────────────────────────────────────────────────────
+
+const assetAmountParams = {
+  asset: {
+    type: Address,
+    description:
+      "Address of the reserve asset on Aave. Must be an ERC-20 token " +
+      "(e.g. WMON at 0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A). " +
+      "Native MON is NOT supported — the Pool contract is non-payable.",
+  },
+  amount: {
+    type: PositiveDecimalString,
+    description:
+      "Human-readable amount of the asset (e.g. '1.5'). " +
+      "Assumes the token uses 18 decimals (as most Monad tokens do).",
+  },
+} satisfies ParamsSpec;
+
+const userParam = {
+  user: {
+    type: Address,
+    description: "Address to query Aave account data for.",
+  },
+} satisfies ParamsSpec;
+
+const reserveParam = {
+  asset: {
+    type: Address,
+    description: "Address of the reserve asset to read data for.",
+  },
+} satisfies ParamsSpec;
+
+// ── Event filters for decoding ───────────────────────────────────────────────
+
+const SupplyEventAbi = PoolAbi.filter(
+  (item) => item.type === "event" && item.name === "Supply",
+);
+const WithdrawEventAbi = PoolAbi.filter(
+  (item) => item.type === "event" && item.name === "Withdraw",
+);
+const BorrowEventAbi = PoolAbi.filter(
+  (item) => item.type === "event" && item.name === "Borrow",
+);
+const RepayEventAbi = PoolAbi.filter(
+  (item) => item.type === "event" && item.name === "Repay",
+);
+
+// ── Guard ────────────────────────────────────────────────────────────────────
+
+function assertNotNative(asset: `0x${string}`, method: string): void {
+  if (asset.toLowerCase() === NATIVE_SENTINEL.toLowerCase()) {
+    throw new Error(
+      `aave-v3.${method}(): Pool contract is non-payable. Supply WMON ` +
+        `(${WMON_ADDRESS}) instead of native MON.`,
+    );
+  }
+}
+
+// ── Protocol class ───────────────────────────────────────────────────────────
+
+@Protocol({
+  name: "aave-v3",
+  category: "lending",
+  description:
+    "Aave v3: the original DeFi lending protocol on Monad. Supply, withdraw, " +
+    "borrow, and repay. Native MON not supported directly — use WMON instead.",
+  contracts: {
+    pool: { abi: PoolAbi, addr: POOL_ADDRESS },
+  },
+  protocols: { erc20: ERC20 },
+})
+export class AaveV3 {
+  declare pool: Handle<typeof PoolAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  // ═════════════════════════════════════════════════════════════════════════
+  //  Capability: supply
+  // ═════════════════════════════════════════════════════════════════════════
+
+  @Capability<AaveV3, typeof assetAmountParams>({
+    intent: "Supply {amount} of {asset} to Aave v3",
+    verb: "supply",
+    params: assetAmountParams,
+    receipt: "supplyReceipt",
+    risk: ["fundOut", "approval"],
+    tags: ["lending", "collateral"],
+  })
+  async supply(
+    params: InferParams<typeof assetAmountParams>,
+    ctx: { account: `0x${string}` },
+  ) {
+    assertNotNative(params.asset, "supply");
+    const wei = parseUnits(params.amount, DECIMALS);
+    const approveCap = await this.erc20.approve({
+      token: params.asset,
+      spender: POOL_ADDRESS,
+      amount: MAX_APPROVAL.toString(),
+    });
+    return [approveCap, this.pool.supply([params.asset, wei, ctx.account, 0])];
+  }
+
+  @Receipt()
+  supplyReceipt(
+    changes: readonly Change[],
+  ): MossReceipt<{ operation: "supply" }> {
+    return aaveReceipt(changes, "supply", SupplyEventAbi);
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  //  Capability: withdraw
+  // ═════════════════════════════════════════════════════════════════════════
+
+  @Capability<AaveV3, typeof assetAmountParams>({
+    intent: "Withdraw {amount} of {asset} from Aave v3",
+    verb: "withdraw",
+    params: assetAmountParams,
+    receipt: "withdrawReceipt",
+    risk: ["fundOut"],
+    tags: ["lending"],
+  })
+  async withdraw(
+    params: InferParams<typeof assetAmountParams>,
+    ctx: { account: `0x${string}` },
+  ) {
+    assertNotNative(params.asset, "withdraw");
+    const wei = parseUnits(params.amount, DECIMALS);
+    return [this.pool.withdraw([params.asset, wei, ctx.account])];
+  }
+
+  @Receipt()
+  withdrawReceipt(
+    changes: readonly Change[],
+  ): MossReceipt<{ operation: "withdraw" }> {
+    return aaveReceipt(changes, "withdraw", WithdrawEventAbi);
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  //  Capability: borrow
+  // ═════════════════════════════════════════════════════════════════════════
+
+  @Capability<AaveV3, typeof assetAmountParams>({
+    intent: "Borrow {amount} of {asset} from Aave v3 at variable rate",
+    verb: "borrow",
+    params: assetAmountParams,
+    receipt: "borrowReceipt",
+    risk: ["fundOut"],
+    tags: ["lending", "variable-rate"],
+  })
+  async borrow(
+    params: InferParams<typeof assetAmountParams>,
+    ctx: { account: `0x${string}` },
+  ) {
+    assertNotNative(params.asset, "borrow");
+    const wei = parseUnits(params.amount, DECIMALS);
+    // interestRateMode: 2 = variable rate, 0 = referralCode, ctx.account = onBehalfOf
+    return [this.pool.borrow([params.asset, wei, 2n, 0, ctx.account])];
+  }
+
+  @Receipt()
+  borrowReceipt(
+    changes: readonly Change[],
+  ): MossReceipt<{ operation: "borrow" }> {
+    return aaveReceipt(changes, "borrow", BorrowEventAbi);
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  //  Capability: repay
+  // ═════════════════════════════════════════════════════════════════════════
+
+  @Capability<AaveV3, typeof assetAmountParams>({
+    intent: "Repay {amount} of {asset} on Aave v3",
+    verb: "repay",
+    params: assetAmountParams,
+    receipt: "repayReceipt",
+    risk: ["fundOut", "approval"],
+    tags: ["lending"],
+  })
+  async repay(
+    params: InferParams<typeof assetAmountParams>,
+    ctx: { account: `0x${string}` },
+  ) {
+    assertNotNative(params.asset, "repay");
+    const wei = parseUnits(params.amount, DECIMALS);
+    const approveCap = await this.erc20.approve({
+      token: params.asset,
+      spender: POOL_ADDRESS,
+      amount: MAX_APPROVAL.toString(),
+    });
+    // interestRateMode: 2 = variable rate
+    return [approveCap, this.pool.repay([params.asset, wei, 2n, ctx.account])];
+  }
+
+  @Receipt()
+  repayReceipt(
+    changes: readonly Change[],
+  ): MossReceipt<{ operation: "repay" }> {
+    return aaveReceipt(changes, "repay", RepayEventAbi);
+  }
+
+  // ═════════════════════════════════════════════════════════════════════════
+  //  Queries
+  // ═════════════════════════════════════════════════════════════════════════
+
+  @Query({
+    intent: "Aave v3 user account data for {user}",
+    params: userParam,
+    tags: ["account-data"],
+  })
+  async userAccountData(
+    params: InferParams<typeof userParam>,
+    _ctx: { account: `0x${string}` },
+  ) {
+    const data = await this.pool.read.getUserAccountData([params.user]);
+    const result = data as readonly [
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+    ];
+    return {
+      totalCollateralBase: result[0].toString(),
+      totalDebtBase: result[1].toString(),
+      availableBorrowsBase: result[2].toString(),
+      currentLiquidationThreshold: result[3].toString(),
+      ltv: result[4].toString(),
+      healthFactor: result[5].toString(),
+    };
+  }
+
+  @Query({
+    intent: "Aave v3 reserve data for {asset}",
+    params: reserveParam,
+    tags: ["reserve-data"],
+  })
+  async reserveData(
+    params: InferParams<typeof reserveParam>,
+    _ctx: { account: `0x${string}` },
+  ) {
+    const data = await this.pool.read.getReserveData([params.asset]);
+    const d = data as unknown as readonly [
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      number,
+      `0x${string}`,
+      `0x${string}`,
+      `0x${string}`,
+      string,
+      bigint,
+    ];
+    return {
+      liquidityRate: d[3].toString(),
+      variableBorrowRate: d[4].toString(),
+      aTokenAddress: d[8],
+      stableDebtTokenAddress: d[9],
+      variableDebtTokenAddress: d[10],
+    };
+  }
+}
+
+// ── Receipt helper ───────────────────────────────────────────────────────────
+
+type ReceivableOperation = "supply" | "withdraw" | "borrow" | "repay";
+
+/**
+ * Build a MossReceipt from ordered Changes by decoding events that match
+ * the Aave Pool address. Each decoded Change retains original object identity
+ * to satisfy verifyReceiptCoverage.
+ */
+function aaveReceipt<O extends ReceivableOperation>(
+  changes: readonly Change[],
+  operation: O,
+  eventAbi:
+    | typeof SupplyEventAbi
+    | typeof WithdrawEventAbi
+    | typeof BorrowEventAbi
+    | typeof RepayEventAbi,
+): MossReceipt<{ operation: O }> {
+  let found:
+    | { reserve: `0x${string}`; user: `0x${string}`; amount: string }
+    | undefined;
+  const parsed = changes.map((change) => {
+    if (change.kind !== "event" || change.address.toLowerCase() !== POOL_ADDR_LOWER) {
+      return {
+        kind: "change" as const,
+        change,
+        data: {} as Record<string, string>,
+        text: `Observed ${operation} change`,
+      };
+    }
+    const decoded = decodeEventLog({
+      abi: eventAbi,
+      data: change.data,
+      topics: change.topics as [Hex, ...Hex[]],
+      strict: true,
+    }) as { eventName: string; args: Record<string, unknown> };
+    if (found) {
+      throw new Error(
+        `aave-v3.${operation} Receipt: multiple Aave events not supported`,
+      );
+    }
+    const args = decoded.args as {
+      reserve: `0x${string}`;
+      amount: bigint;
+      user: `0x${string}` | undefined;
+      to: `0x${string}` | undefined;
+    };
+    // Withdraw uses 'to' instead of 'user'. Normalise.
+    const user = (args.to ?? args.user) as `0x${string}`;
+    const formatted = formatUnits(args.amount, DECIMALS);
+    found = { reserve: args.reserve, user, amount: formatted };
+    return {
+      kind: "change" as const,
+      change,
+      data: { operation, reserve: args.reserve, user, amount: formatted },
+      text: describeAaveEvent(operation, args.reserve, user, formatted),
+    };
+  });
+  if (!found) {
+    return {
+      kind: "receipt",
+      outcome: { operation },
+      text: describeAaveEvent(operation, "0x0" as `0x${string}`, "0x0" as `0x${string}`, "0"),
+      changes: parsed,
+    };
+  }
+  return {
+    kind: "receipt",
+    outcome: { operation },
+    text: describeAaveEvent(operation, found.reserve, found.user, found.amount),
+    changes: parsed,
+  };
+}
+
+function describeAaveEvent(
+  operation: string,
+  reserve: `0x${string}`,
+  user: `0x${string}`,
+  amount: string,
+): string {
+  const labels: Record<string, string> = {
+    supply: "Supplied",
+    withdraw: "Withdrew",
+    borrow: "Borrowed",
+    repay: "Repaid",
+  };
+  const label = labels[operation] ?? operation;
+  return `${label} ${amount} from reserve ${reserve} on behalf of ${user}`;
+}

--- a/packages/protocols/aave-v3/src/abis/aave.ts
+++ b/packages/protocols/aave-v3/src/abis/aave.ts
@@ -1,0 +1,159 @@
+/**
+ * Aave v3 ABI — Pool contract on Monad mainnet.
+ *
+ * ABI origin: standard Aave v3 interface. Pool proxy verified on-chain
+ * 2026-07-15 against rpc.monad.xyz:
+ *   - Pool proxy: 0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef (ERC-1967, 1.8KB)
+ *   - Implementation: 0x9539531ea4f6563a66421a7449506152609985be (21KB)
+ */
+
+export const PoolAbi = [
+  // ── Core lending ──
+  {
+    type: 'function',
+    inputs: [
+      { name: 'asset', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+      { name: 'onBehalfOf', internalType: 'address', type: 'address' },
+      { name: 'referralCode', internalType: 'uint16', type: 'uint16' },
+    ],
+    name: 'supply',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'asset', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+      { name: 'to', internalType: 'address', type: 'address' },
+    ],
+    name: 'withdraw',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'asset', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+      { name: 'interestRateMode', internalType: 'uint256', type: 'uint256' },
+      { name: 'referralCode', internalType: 'uint16', type: 'uint16' },
+      { name: 'onBehalfOf', internalType: 'address', type: 'address' },
+    ],
+    name: 'borrow',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'asset', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+      { name: 'interestRateMode', internalType: 'uint256', type: 'uint256' },
+      { name: 'onBehalfOf', internalType: 'address', type: 'address' },
+    ],
+    name: 'repay',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+
+  // ── Queries ──
+  {
+    type: 'function',
+    inputs: [
+      { name: 'user', internalType: 'address', type: 'address' },
+    ],
+    name: 'getUserAccountData',
+    outputs: [
+      { name: 'totalCollateralBase', internalType: 'uint256', type: 'uint256' },
+      { name: 'totalDebtBase', internalType: 'uint256', type: 'uint256' },
+      { name: 'availableBorrowsBase', internalType: 'uint256', type: 'uint256' },
+      { name: 'currentLiquidationThreshold', internalType: 'uint256', type: 'uint256' },
+      { name: 'ltv', internalType: 'uint256', type: 'uint256' },
+      { name: 'healthFactor', internalType: 'uint256', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'asset', internalType: 'address', type: 'address' },
+    ],
+    name: 'getReserveData',
+    outputs: [
+      { name: 'configuration', internalType: 'uint256', type: 'uint256' },
+      { name: 'liquidityIndex', internalType: 'uint128', type: 'uint128' },
+      { name: 'variableBorrowIndex', internalType: 'uint128', type: 'uint128' },
+      { name: 'currentLiquidityRate', internalType: 'uint128', type: 'uint128' },
+      { name: 'currentVariableBorrowRate', internalType: 'uint128', type: 'uint128' },
+      { name: 'currentStableBorrowRate', internalType: 'uint128', type: 'uint128' },
+      { name: 'lastUpdateTimestamp', internalType: 'uint40', type: 'uint40' },
+      { name: 'id', internalType: 'uint16', type: 'uint16' },
+      { name: 'aTokenAddress', internalType: 'address', type: 'address' },
+      { name: 'stableDebtTokenAddress', internalType: 'address', type: 'address' },
+      { name: 'variableDebtTokenAddress', internalType: 'address', type: 'address' },
+      { name: 'interestRateStrategyAddress', internalType: 'address', type: 'address' },
+      { name: 'accruedToTreasury', internalType: 'uint128', type: 'uint128' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'getReservesList',
+    outputs: [{ name: '', internalType: 'address[]', type: 'address[]' }],
+    stateMutability: 'view',
+  },
+
+  // ── Events ──
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'reserve', internalType: 'address', type: 'address', indexed: true },
+      { name: 'user', internalType: 'address', type: 'address', indexed: true },
+      { name: 'onBehalfOf', internalType: 'address', type: 'address', indexed: true },
+      { name: 'amount', internalType: 'uint256', type: 'uint256', indexed: false },
+      { name: 'referralCode', internalType: 'uint16', type: 'uint16', indexed: false },
+    ],
+    name: 'Supply',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'reserve', internalType: 'address', type: 'address', indexed: true },
+      { name: 'user', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      { name: 'amount', internalType: 'uint256', type: 'uint256', indexed: false },
+    ],
+    name: 'Withdraw',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'reserve', internalType: 'address', type: 'address', indexed: true },
+      { name: 'user', internalType: 'address', type: 'address', indexed: false },
+      { name: 'onBehalfOf', internalType: 'address', type: 'address', indexed: true },
+      { name: 'amount', internalType: 'uint256', type: 'uint256', indexed: false },
+      { name: 'interestRateMode', internalType: 'uint256', type: 'uint256', indexed: false },
+      { name: 'borrowRate', internalType: 'uint256', type: 'uint256', indexed: false },
+      { name: 'referralCode', internalType: 'uint16', type: 'uint16', indexed: false },
+    ],
+    name: 'Borrow',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'reserve', internalType: 'address', type: 'address', indexed: true },
+      { name: 'user', internalType: 'address', type: 'address', indexed: true },
+      { name: 'repayer', internalType: 'address', type: 'address', indexed: true },
+      { name: 'amount', internalType: 'uint256', type: 'uint256', indexed: false },
+      { name: 'useATokens', internalType: 'bool', type: 'bool', indexed: false },
+    ],
+    name: 'Repay',
+  },
+] as const;

--- a/packages/protocols/aave-v3/src/adapter.ts
+++ b/packages/protocols/aave-v3/src/adapter.ts
@@ -1,0 +1,219 @@
+/**
+ * Aave v3 — lending protocol on Monad.
+ *
+ * Core capabilities: supply, withdraw, borrow, repay. Each maps 1:1 onto
+ * a Moss verb. Queries: user health factor, reserve data, reserves list.
+ *
+ * Pool proxy verified on-chain 2026-07-15:
+ *   0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef (ERC-1967 → 0x9539531e…)
+ */
+import {
+  type ActionCtx,
+  type Address,
+  address,
+  Capability,
+  type Handle,
+  NATIVE,
+  nativeAmount,
+  type ObserveCtx,
+  Protocol,
+  plan,
+  Query,
+  token,
+  tokenAmount,
+  type TokenRef,
+} from "@themoss/core";
+import { approveStep } from "@themoss/erc";
+import { Event } from "@themoss/core";
+import type { DecodedEvent } from "@themoss/core";
+import { PoolAbi } from "./abis/aave.js";
+
+/** Pool proxy on Monad */
+export const POOL_ADDRESS: Address =
+  "0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef";
+
+/** Aave uses address(0) for native MON. */
+const NATIVE_SENTINEL: Address = "0x0000000000000000000000000000000000000000";
+const toAaveAsset = (t: TokenRef): Address =>
+  t === NATIVE ? NATIVE_SENTINEL : (t as Address);
+
+@Protocol({
+  name: "aave-v3",
+  category: "lending",
+  description:
+    "Aave v3: the original DeFi lending protocol on Monad. Supply, withdraw, " +
+    "borrow, and repay across multiple reserves.",
+  contracts: {
+    pool: { abi: PoolAbi, addr: POOL_ADDRESS },
+  },
+})
+export class AaveV3 {
+  declare pool: Handle<typeof PoolAbi>;
+
+  @Capability({
+    intent: "Supply {amount} of {asset} to Aave v3",
+    verb: "supply",
+    params: { asset: token, amount: tokenAmount("asset") },
+    risk: ["fundOut", "approval"],
+    tags: ["lending", "collateral"],
+    confirms: ["supplyReceipt"],
+  })
+  async supply(
+    { asset, amount }: { asset: TokenRef; amount: bigint },
+    ctx: ActionCtx,
+  ) {
+    const aaveAsset = toAaveAsset(asset);
+    const isNative = asset === NATIVE;
+    const supplyStep = this.pool.supply([aaveAsset, amount, ctx.account, 0]);
+    const steps = isNative
+      ? [supplyStep]
+      : [approveStep(aaveAsset, POOL_ADDRESS, amount), supplyStep];
+    return plan(steps, { out: [{ token: asset, amountMax: amount }] });
+  }
+
+  @Capability({
+    intent: "Withdraw {amount} of {asset} from Aave v3",
+    verb: "withdraw",
+    params: { asset: token, amount: tokenAmount("asset") },
+    risk: ["fundOut"],
+    tags: ["lending"],
+    confirms: ["withdrawReceipt"],
+  })
+  async withdraw(
+    { asset, amount }: { asset: TokenRef; amount: bigint },
+    ctx: ActionCtx,
+  ) {
+    const step = this.pool.withdraw([toAaveAsset(asset), amount, ctx.account]);
+    return plan([step], { in: [{ token: asset, amountMin: amount }] });
+  }
+
+  @Capability({
+    intent: "Borrow {amount} of {asset} from Aave v3 at variable rate",
+    verb: "borrow",
+    params: { asset: token, amount: tokenAmount("asset") },
+    risk: ["fundOut"],
+    tags: ["lending", "variable-rate"],
+    confirms: ["borrowReceipt"],
+  })
+  async borrow(
+    { asset, amount }: { asset: TokenRef; amount: bigint },
+    ctx: ActionCtx,
+  ) {
+    // interestRateMode: 2 = variable
+    const step = this.pool.borrow([toAaveAsset(asset), amount, 2n, 0, ctx.account]);
+    return plan([step], { in: [{ token: asset, amountMin: amount }] });
+  }
+
+  @Capability({
+    intent: "Repay {amount} of {asset} on Aave v3",
+    verb: "repay",
+    params: { asset: token, amount: tokenAmount("asset") },
+    risk: ["fundOut", "approval"],
+    tags: ["lending"],
+    confirms: ["repayReceipt"],
+  })
+  async repay(
+    { asset, amount }: { asset: TokenRef; amount: bigint },
+    ctx: ActionCtx,
+  ) {
+    const aaveAsset = toAaveAsset(asset);
+    const isNative = asset === NATIVE;
+    const repayStep = this.pool.repay([aaveAsset, amount, 2n, ctx.account]);
+    const steps = isNative
+      ? [repayStep]
+      : [approveStep(aaveAsset, POOL_ADDRESS, amount), repayStep];
+    return plan(steps, { out: [{ token: asset, amountMax: amount }] });
+  }
+
+  // ── @Event observations ──
+
+  @Event<AaveV3>({
+    events: { pool: ["Supply"] },
+    intent: "Supplied {amount} of {assetSymbol} to Aave v3",
+  })
+  async supplyReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
+    const e = events.find((ev) => ev.name === "Supply");
+    if (!e) return null;
+    const { reserve, amount } = e.args as {
+      reserve: Address; amount: bigint;
+    };
+    const t = await ctx.token(reserve);
+    return { amount: t.format(amount), assetSymbol: t.symbol };
+  }
+
+  @Event<AaveV3>({
+    events: { pool: ["Withdraw"] },
+    intent: "Withdrew {amount} of {assetSymbol} from Aave v3",
+  })
+  async withdrawReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
+    const e = events.find((ev) => ev.name === "Withdraw");
+    if (!e) return null;
+    const { reserve, amount } = e.args as { reserve: Address; amount: bigint };
+    const t = await ctx.token(reserve);
+    return { amount: t.format(amount), assetSymbol: t.symbol };
+  }
+
+  @Event<AaveV3>({
+    events: { pool: ["Borrow"] },
+    intent: "Borrowed {amount} of {assetSymbol} from Aave v3",
+  })
+  async borrowReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
+    const e = events.find((ev) => ev.name === "Borrow");
+    if (!e) return null;
+    const { reserve, amount } = e.args as { reserve: Address; amount: bigint };
+    const t = await ctx.token(reserve);
+    return { amount: t.format(amount), assetSymbol: t.symbol };
+  }
+
+  @Event<AaveV3>({
+    events: { pool: ["Repay"] },
+    intent: "Repaid {amount} of {assetSymbol} on Aave v3",
+  })
+  async repayReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
+    const e = events.find((ev) => ev.name === "Repay");
+    if (!e) return null;
+    const { reserve, amount } = e.args as { reserve: Address; amount: bigint };
+    const t = await ctx.token(reserve);
+    return { amount: t.format(amount), assetSymbol: t.symbol };
+  }
+
+  // ── Queries ──
+
+  @Query({
+    intent: "Aave v3 user account data for {user}",
+    params: { user: address },
+  })
+  async userAccountData({ user }: { user: Address }) {
+    const data = await this.pool.read.getUserAccountData([user]);
+    const [totalCollateralBase, totalDebtBase, availableBorrowsBase,
+           currentLiquidationThreshold, ltv, healthFactor] = data as readonly [bigint, bigint, bigint, bigint, bigint, bigint];
+    return {
+      totalCollateralBase: totalCollateralBase.toString(),
+      totalDebtBase: totalDebtBase.toString(),
+      availableBorrowsBase: availableBorrowsBase.toString(),
+      currentLiquidationThreshold: currentLiquidationThreshold.toString(),
+      ltv: ltv.toString(),
+      healthFactor: healthFactor.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Aave v3 reserve data for {asset}",
+    params: { asset: address },
+  })
+  async reserveData({ asset }: { asset: Address }) {
+    const data = await this.pool.read.getReserveData([asset]);
+    const d = data as unknown as readonly [
+      bigint, bigint, bigint, bigint, bigint,
+      bigint, bigint, bigint, Address, Address,
+      Address, Address, bigint
+    ];
+    return {
+      aTokenAddress: d[8],
+      stableDebtTokenAddress: d[9],
+      variableDebtTokenAddress: d[10],
+      liquidityRate: d[4].toString(),
+      variableBorrowRate: d[5].toString(),
+    };
+  }
+}

--- a/packages/protocols/aave-v3/src/adapter.ts
+++ b/packages/protocols/aave-v3/src/adapter.ts
@@ -2,10 +2,17 @@
  * Aave v3 — lending protocol on Monad.
  *
  * Core capabilities: supply, withdraw, borrow, repay. Each maps 1:1 onto
- * a Moss verb. Queries: user health factor, reserve data, reserves list.
+ * a Moss verb. Queries: user health factor, reserve data.
  *
  * Pool proxy verified on-chain 2026-07-15:
  *   0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef (ERC-1967 → 0x9539531e…)
+ *
+ * ⚠️  Native MON limitation: Pool.supply() / .repay() are non-payable.
+ *      Users must supply/repay WMON, not raw MON. Aave v3 uses a separate
+ *      WrappedTokenGateway contract for native → wrapped conversion, which
+ *      is out of scope for this adapter (uses a different contract ABI).
+ *      For native MON flows, supply "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A"
+ *      (WMON) instead of "native".
  */
 import {
   type ActionCtx,
@@ -14,7 +21,6 @@ import {
   Capability,
   type Handle,
   NATIVE,
-  nativeAmount,
   type ObserveCtx,
   Protocol,
   plan,
@@ -28,21 +34,24 @@ import { Event } from "@themoss/core";
 import type { DecodedEvent } from "@themoss/core";
 import { PoolAbi } from "./abis/aave.js";
 
-/** Pool proxy on Monad */
 export const POOL_ADDRESS: Address =
   "0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef";
 
-/** Aave uses address(0) for native MON. */
-const NATIVE_SENTINEL: Address = "0x0000000000000000000000000000000000000000";
-const toAaveAsset = (t: TokenRef): Address =>
-  t === NATIVE ? NATIVE_SENTINEL : (t as Address);
+function assertNotNative(asset: TokenRef, method: string): asserts asset is Address {
+  if (asset === NATIVE) {
+    throw new Error(
+      `aave-v3.${method}(): Pool is non-payable. Supply WMON ` +
+      `(0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A) instead of native MON.`,
+    );
+  }
+}
 
 @Protocol({
   name: "aave-v3",
   category: "lending",
   description:
     "Aave v3: the original DeFi lending protocol on Monad. Supply, withdraw, " +
-    "borrow, and repay across multiple reserves.",
+    "borrow, and repay. Native MON not supported directly — use WMON instead.",
   contracts: {
     pool: { abi: PoolAbi, addr: POOL_ADDRESS },
   },
@@ -62,13 +71,11 @@ export class AaveV3 {
     { asset, amount }: { asset: TokenRef; amount: bigint },
     ctx: ActionCtx,
   ) {
-    const aaveAsset = toAaveAsset(asset);
-    const isNative = asset === NATIVE;
-    const supplyStep = this.pool.supply([aaveAsset, amount, ctx.account, 0]);
-    const steps = isNative
-      ? [supplyStep]
-      : [approveStep(aaveAsset, POOL_ADDRESS, amount), supplyStep];
-    return plan(steps, { out: [{ token: asset, amountMax: amount }] });
+    assertNotNative(asset, "supply");
+    const step = this.pool.supply([asset, amount, ctx.account, 0]);
+    return plan([approveStep(asset, POOL_ADDRESS, amount), step], {
+      out: [{ token: asset, amountMax: amount }],
+    });
   }
 
   @Capability({
@@ -83,7 +90,8 @@ export class AaveV3 {
     { asset, amount }: { asset: TokenRef; amount: bigint },
     ctx: ActionCtx,
   ) {
-    const step = this.pool.withdraw([toAaveAsset(asset), amount, ctx.account]);
+    assertNotNative(asset, "withdraw");
+    const step = this.pool.withdraw([asset, amount, ctx.account]);
     return plan([step], { in: [{ token: asset, amountMin: amount }] });
   }
 
@@ -99,8 +107,8 @@ export class AaveV3 {
     { asset, amount }: { asset: TokenRef; amount: bigint },
     ctx: ActionCtx,
   ) {
-    // interestRateMode: 2 = variable
-    const step = this.pool.borrow([toAaveAsset(asset), amount, 2n, 0, ctx.account]);
+    assertNotNative(asset, "borrow");
+    const step = this.pool.borrow([asset, amount, 2n, 0, ctx.account]);
     return plan([step], { in: [{ token: asset, amountMin: amount }] });
   }
 
@@ -116,35 +124,25 @@ export class AaveV3 {
     { asset, amount }: { asset: TokenRef; amount: bigint },
     ctx: ActionCtx,
   ) {
-    const aaveAsset = toAaveAsset(asset);
-    const isNative = asset === NATIVE;
-    const repayStep = this.pool.repay([aaveAsset, amount, 2n, ctx.account]);
-    const steps = isNative
-      ? [repayStep]
-      : [approveStep(aaveAsset, POOL_ADDRESS, amount), repayStep];
-    return plan(steps, { out: [{ token: asset, amountMax: amount }] });
+    assertNotNative(asset, "repay");
+    const step = this.pool.repay([asset, amount, 2n, ctx.account]);
+    return plan([approveStep(asset, POOL_ADDRESS, amount), step], {
+      out: [{ token: asset, amountMax: amount }],
+    });
   }
 
-  // ── @Event observations ──
+  // ── Events ──
 
-  @Event<AaveV3>({
-    events: { pool: ["Supply"] },
-    intent: "Supplied {amount} of {assetSymbol} to Aave v3",
-  })
+  @Event<AaveV3>({ events: { pool: ["Supply"] }, intent: "Supplied {amount} of {assetSymbol} to Aave v3" })
   async supplyReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
     const e = events.find((ev) => ev.name === "Supply");
     if (!e) return null;
-    const { reserve, amount } = e.args as {
-      reserve: Address; amount: bigint;
-    };
+    const { reserve, amount } = e.args as { reserve: Address; amount: bigint };
     const t = await ctx.token(reserve);
     return { amount: t.format(amount), assetSymbol: t.symbol };
   }
 
-  @Event<AaveV3>({
-    events: { pool: ["Withdraw"] },
-    intent: "Withdrew {amount} of {assetSymbol} from Aave v3",
-  })
+  @Event<AaveV3>({ events: { pool: ["Withdraw"] }, intent: "Withdrew {amount} of {assetSymbol} from Aave v3" })
   async withdrawReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
     const e = events.find((ev) => ev.name === "Withdraw");
     if (!e) return null;
@@ -153,10 +151,7 @@ export class AaveV3 {
     return { amount: t.format(amount), assetSymbol: t.symbol };
   }
 
-  @Event<AaveV3>({
-    events: { pool: ["Borrow"] },
-    intent: "Borrowed {amount} of {assetSymbol} from Aave v3",
-  })
+  @Event<AaveV3>({ events: { pool: ["Borrow"] }, intent: "Borrowed {amount} of {assetSymbol} from Aave v3" })
   async borrowReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
     const e = events.find((ev) => ev.name === "Borrow");
     if (!e) return null;
@@ -165,10 +160,7 @@ export class AaveV3 {
     return { amount: t.format(amount), assetSymbol: t.symbol };
   }
 
-  @Event<AaveV3>({
-    events: { pool: ["Repay"] },
-    intent: "Repaid {amount} of {assetSymbol} on Aave v3",
-  })
+  @Event<AaveV3>({ events: { pool: ["Repay"] }, intent: "Repaid {amount} of {assetSymbol} on Aave v3" })
   async repayReceipt(events: DecodedEvent[], ctx: ObserveCtx) {
     const e = events.find((ev) => ev.name === "Repay");
     if (!e) return null;
@@ -185,15 +177,14 @@ export class AaveV3 {
   })
   async userAccountData({ user }: { user: Address }) {
     const data = await this.pool.read.getUserAccountData([user]);
-    const [totalCollateralBase, totalDebtBase, availableBorrowsBase,
-           currentLiquidationThreshold, ltv, healthFactor] = data as readonly [bigint, bigint, bigint, bigint, bigint, bigint];
+    const [a, b, c, d, e, f] = data as readonly [bigint, bigint, bigint, bigint, bigint, bigint];
     return {
-      totalCollateralBase: totalCollateralBase.toString(),
-      totalDebtBase: totalDebtBase.toString(),
-      availableBorrowsBase: availableBorrowsBase.toString(),
-      currentLiquidationThreshold: currentLiquidationThreshold.toString(),
-      ltv: ltv.toString(),
-      healthFactor: healthFactor.toString(),
+      totalCollateralBase: a.toString(),
+      totalDebtBase: b.toString(),
+      availableBorrowsBase: c.toString(),
+      currentLiquidationThreshold: d.toString(),
+      ltv: e.toString(),
+      healthFactor: f.toString(),
     };
   }
 
@@ -205,15 +196,15 @@ export class AaveV3 {
     const data = await this.pool.read.getReserveData([asset]);
     const d = data as unknown as readonly [
       bigint, bigint, bigint, bigint, bigint,
-      bigint, bigint, bigint, Address, Address,
-      Address, Address, bigint
+      bigint, bigint, number, Address, Address,
+      Address, Address, bigint,
     ];
     return {
       aTokenAddress: d[8],
       stableDebtTokenAddress: d[9],
       variableDebtTokenAddress: d[10],
-      liquidityRate: d[4].toString(),
-      variableBorrowRate: d[5].toString(),
+      liquidityRate: d[3].toString(), // index 3 = currentLiquidityRate
+      variableBorrowRate: d[4].toString(), // index 4 = currentVariableBorrowRate
     };
   }
 }

--- a/packages/protocols/aave-v3/src/index.ts
+++ b/packages/protocols/aave-v3/src/index.ts
@@ -1,0 +1,12 @@
+import { defineProtocolPackage } from "@themoss/core";
+import { AaveV3 } from "./adapter.js";
+import { AAVE_TOKENS } from "./tokens.js";
+
+export { AaveV3 } from "./adapter.js";
+export { POOL_ADDRESS } from "./adapter.js";
+
+export const aaveV3Manifest = defineProtocolPackage({
+  name: "aave-v3",
+  protocols: [AaveV3],
+  tokens: AAVE_TOKENS,
+});

--- a/packages/protocols/aave-v3/src/index.ts
+++ b/packages/protocols/aave-v3/src/index.ts
@@ -1,12 +1,1 @@
-import { defineProtocolPackage } from "@themoss/core";
-import { AaveV3 } from "./adapter.js";
-import { AAVE_TOKENS } from "./tokens.js";
-
-export { AaveV3 } from "./adapter.js";
-export { POOL_ADDRESS } from "./adapter.js";
-
-export const aaveV3Manifest = defineProtocolPackage({
-  name: "aave-v3",
-  protocols: [AaveV3],
-  tokens: AAVE_TOKENS,
-});
+export { AaveV3, POOL_ADDRESS } from "./aave-v3.js";

--- a/packages/protocols/aave-v3/src/tokens.ts
+++ b/packages/protocols/aave-v3/src/tokens.ts
@@ -1,0 +1,9 @@
+import type { KnownToken } from "@themoss/core";
+
+/**
+ * Aave v3 aTokens and debt tokens are reserve-specific and discovered at
+ * runtime via Pool.getReserveData(). The adapter does not maintain a static
+ * token catalog — aTokens are ephemeral per-reserve contracts whose addresses
+ * the Runtime resolves through the token table on first use.
+ */
+export const AAVE_TOKENS: readonly KnownToken[] = [];

--- a/packages/protocols/aave-v3/test/aave-v3.test.ts
+++ b/packages/protocols/aave-v3/test/aave-v3.test.ts
@@ -1,0 +1,286 @@
+import {
+  type CapabilityNode,
+  type Change,
+  type MossRuntime,
+  flattenCapabilityTree,
+  Registry,
+} from "@themoss/core";
+import { describe, expect, it } from "vitest";
+import { monadRuntime } from "@themoss/system";
+import { parseUnits } from "viem";
+import { AaveV3, POOL_ADDRESS } from "../src/index.js";
+
+const ACCOUNT = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const WMON = "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A";
+
+// ── Helpers ──
+
+function offlineRegistry(): Registry {
+  const runtime: MossRuntime = {
+    // biome-ignore lint/suspicious/noExplicitAny: no reads in offline tests
+    client: {} as any,
+  } as MossRuntime;
+  const registry = new Registry(runtime);
+  registry.use(AaveV3);
+  return registry;
+}
+
+// ── Offline: shape & discovery ──
+
+describe("aave-v3 adapter (offline shape)", () => {
+  it("discovers all capabilities and queries", () => {
+    const registry = offlineRegistry();
+    const caps = registry.discover({ protocol: "aave-v3" });
+    const methods = caps.map((c) => c.method).sort();
+    expect(methods).toEqual([
+      "borrow",
+      "repay",
+      "reserveData",
+      "supply",
+      "userAccountData",
+      "withdraw",
+    ]);
+  });
+
+  it("supplies correct verb and risk metadata for each capability", () => {
+    const registry = offlineRegistry();
+    const caps = registry.discover({ protocol: "aave-v3" });
+
+    const supply = caps.find((c) => c.method === "supply")!;
+    expect(supply.verb).toBe("supply");
+    expect(supply.tags).toContain("collateral");
+
+    const withdraw = caps.find((c) => c.method === "withdraw")!;
+    expect(withdraw.verb).toBe("withdraw");
+
+    const borrow = caps.find((c) => c.method === "borrow")!;
+    expect(borrow.verb).toBe("borrow");
+    expect(borrow.tags).toContain("variable-rate");
+
+    const repay = caps.find((c) => c.method === "repay")!;
+    expect(repay.verb).toBe("repay");
+  });
+
+  it("loads the supply capability stub with correct params", () => {
+    const registry = offlineRegistry();
+    const [stub] = registry.load([{ protocol: "aave-v3", method: "supply" }]);
+    expect(stub?.verb).toBe("supply");
+    expect(stub?.risk).toEqual(["fundOut", "approval"]);
+    expect(stub?.params).toHaveProperty("asset");
+    expect(stub?.params).toHaveProperty("amount");
+  });
+
+  it("loads query stubs", () => {
+    const registry = offlineRegistry();
+    const [dataStub] = registry.load([
+      { protocol: "aave-v3", method: "userAccountData" },
+    ]);
+    expect(dataStub?.kind).toBe("query");
+    expect(dataStub?.params).toHaveProperty("user");
+  });
+
+  it("builds a supply capability with two child transactions (approve + supply)", async () => {
+    const registry = offlineRegistry();
+    const cap = (await registry.action("aave-v3", "supply", ACCOUNT, {
+      asset: WMON,
+      amount: "10",
+    })) as CapabilityNode;
+    expect(cap.kind).toBe("capability");
+    expect(cap.protocol).toBe("aave-v3");
+    expect(cap.method).toBe("supply");
+    expect(cap.receipt).toBe("supplyReceipt");
+    // Two children: approve (CapabilityNode) + supply (TransactionNode)
+    expect(cap.children).toHaveLength(2);
+    expect(cap.children[0]?.kind).toBe("capability");
+    expect((cap.children[0] as { protocol: string }).protocol).toBe("erc20");
+    expect(cap.children[1]?.kind).toBe("transaction");
+    expect((cap.children[1] as { transaction: { to: string } }).transaction.to).toBe(POOL_ADDRESS);
+  });
+
+  it("builds a withdraw capability with one direct transaction", async () => {
+    const registry = offlineRegistry();
+    const cap = (await registry.action("aave-v3", "withdraw", ACCOUNT, {
+      asset: WMON,
+      amount: "5",
+    })) as CapabilityNode;
+    expect(cap.kind).toBe("capability");
+    expect(cap.method).toBe("withdraw");
+    expect(cap.receipt).toBe("withdrawReceipt");
+
+    const flattened = flattenCapabilityTree(cap);
+    expect(flattened).toHaveLength(1);
+    expect(flattened[0]!.transaction.to).toBe(POOL_ADDRESS);
+  });
+
+  it("builds a borrow capability with one direct transaction", async () => {
+    const registry = offlineRegistry();
+    const cap = (await registry.action("aave-v3", "borrow", ACCOUNT, {
+      asset: WMON,
+      amount: "1",
+    })) as CapabilityNode;
+    expect(cap.kind).toBe("capability");
+    expect(cap.method).toBe("borrow");
+    expect(cap.receipt).toBe("borrowReceipt");
+
+    const flattened = flattenCapabilityTree(cap);
+    expect(flattened).toHaveLength(1);
+    expect(flattened[0]!.transaction.to).toBe(POOL_ADDRESS);
+  });
+
+  it("builds a repay capability with two child transactions (approve + repay)", async () => {
+    const registry = offlineRegistry();
+    const cap = (await registry.action("aave-v3", "repay", ACCOUNT, {
+      asset: WMON,
+      amount: "2",
+    })) as CapabilityNode;
+    expect(cap.kind).toBe("capability");
+    expect(cap.method).toBe("repay");
+    expect(cap.receipt).toBe("repayReceipt");
+    // Two children: approve (CapabilityNode) + repay (TransactionNode)
+    expect(cap.children).toHaveLength(2);
+    expect(cap.children[0]?.kind).toBe("capability");
+    expect(cap.children[1]?.kind).toBe("transaction");
+    expect((cap.children[1] as { transaction: { to: string } }).transaction.to).toBe(POOL_ADDRESS);
+  });
+
+  it("rejects native MON with a clear error", async () => {
+    const registry = offlineRegistry();
+    await expect(
+      registry.action("aave-v3", "supply", ACCOUNT, {
+        asset: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        amount: "1",
+      }),
+    ).rejects.toThrow(/non-payable/);
+
+    await expect(
+      registry.action("aave-v3", "withdraw", ACCOUNT, {
+        asset: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+        amount: "1",
+      }),
+    ).rejects.toThrow(/non-payable/);
+  });
+
+  it("parses a supply receipt from empty changes (offline)", () => {
+    const registry = offlineRegistry();
+    const cap = {
+      kind: "capability" as const,
+      protocol: "aave-v3",
+      method: "supply",
+      params: { asset: WMON, amount: "10" },
+      receipt: "supplyReceipt",
+      children: [
+        {
+          kind: "transaction" as const,
+          transaction: {
+            from: ACCOUNT,
+            to: POOL_ADDRESS,
+            data: "0x" as const,
+            value: "0x0" as const,
+          },
+        },
+      ],
+    };
+    const receipt = registry.parseReceipt(cap as CapabilityNode, []);
+    expect(receipt.kind).toBe("receipt");
+    expect(receipt.outcome).toEqual({ operation: "supply" });
+    expect(receipt.changes).toHaveLength(0);
+  });
+
+  it("rejects invalid amounts", async () => {
+    const registry = offlineRegistry();
+    await expect(
+      registry.action("aave-v3", "supply", ACCOUNT, {
+        asset: WMON,
+        amount: "-1",
+      }),
+    ).rejects.toThrow(/invalid parameters/);
+
+    await expect(
+      registry.action("aave-v3", "supply", ACCOUNT, {
+        asset: WMON,
+        amount: "abc",
+      }),
+    ).rejects.toThrow(/invalid parameters/);
+  });
+});
+
+// ── E2E (live Monad mainnet, zero funds — Moss never signs/sends) ──
+
+const e2e = process.env.MOSS_SKIP_E2E ? describe.skip : describe;
+e2e("aave-v3 adapter (Monad mainnet e2e)", () => {
+  async function liveRegistry(): Promise<Registry> {
+    const runtime = await monadRuntime();
+    const reg = new Registry(runtime);
+    reg.use(AaveV3);
+    return reg;
+  }
+
+  it(
+    "userAccountData query reads zero state for a random account",
+    { timeout: 30_000 },
+    async () => {
+      const reg = await liveRegistry();
+      const result = await reg.action("aave-v3", "userAccountData", ACCOUNT, {
+        user: ACCOUNT,
+      });
+      if (result.kind !== "query") throw new Error("expected query result");
+      const data = result.data as { healthFactor: string };
+      expect(data).toHaveProperty("healthFactor");
+      // A random account with no position has healthFactor == max
+      expect(BigInt(data.healthFactor)).toBeGreaterThan(0n);
+    },
+  );
+
+  it(
+    "reserveData query reads WMON reserve config",
+    { timeout: 30_000 },
+    async () => {
+      const reg = await liveRegistry();
+      const result = await reg.action("aave-v3", "reserveData", ACCOUNT, {
+        asset: WMON,
+      });
+      if (result.kind !== "query") throw new Error("expected query result");
+      const data = result.data as {
+        liquidityRate: string;
+        aTokenAddress: string;
+      };
+      expect(data).toHaveProperty("liquidityRate");
+      expect(data.aTokenAddress).toMatch(/^0x[a-f0-9]{40}$/i);
+    },
+  );
+
+  it(
+    "supply capability builds valid calldata on mainnet",
+    { timeout: 30_000 },
+    async () => {
+      const reg = await liveRegistry();
+      const cap = (await reg.action("aave-v3", "supply", ACCOUNT, {
+        asset: WMON,
+        amount: "0.001",
+      })) as CapabilityNode;
+      expect(cap.kind).toBe("capability");
+      expect(cap.children).toHaveLength(2);
+      // supply() function selector: 0x617ba037
+      const supplyTx = (cap.children[1] as { transaction: { to: string; data: string } }).transaction;
+      expect(supplyTx.to).toBe(POOL_ADDRESS);
+      expect(supplyTx.data).toMatch(/^0x617ba037/);
+    },
+  );
+
+  it(
+    "withdraw capability builds valid calldata on mainnet",
+    { timeout: 30_000 },
+    async () => {
+      const reg = await liveRegistry();
+      const cap = (await reg.action("aave-v3", "withdraw", ACCOUNT, {
+        asset: WMON,
+        amount: "0.0001",
+      })) as CapabilityNode;
+      expect(cap.kind).toBe("capability");
+      // withdraw() function selector: 0x69328dec
+      const tx = (cap.children[0] as { transaction: { to: string; data: string } }).transaction;
+      expect(tx.to).toBe(POOL_ADDRESS);
+      expect(tx.data).toMatch(/^0x69328dec/);
+    },
+  );
+});

--- a/packages/protocols/aave-v3/test/adapter.test.ts
+++ b/packages/protocols/aave-v3/test/adapter.test.ts
@@ -1,0 +1,51 @@
+import { type MossRuntime, Registry } from "@themoss/core";
+import { describe, expect, it } from "vitest";
+import { aaveV3Manifest } from "../src/index.js";
+
+const ACCOUNT = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+function offlineRegistry(): Registry {
+  const runtime: MossRuntime = {
+    chainId: 143, rpcUrl: "http://offline", client: {} as any,
+  };
+  const registry = new Registry(runtime);
+  registry.use(aaveV3Manifest);
+  return registry;
+}
+
+describe("aave-v3 adapter (offline shape)", () => {
+  it("discovers supply/withdraw/borrow/repay", () => {
+    const registry = offlineRegistry();
+    const caps = registry.discover({ protocol: "aave-v3" });
+    expect(caps.map((c) => c.method).sort()).toEqual([
+      "borrow", "repay", "reserveData", "supply",
+      "userAccountData", "withdraw",
+    ]);
+  });
+
+  it("loads supply stub", () => {
+    const registry = offlineRegistry();
+    const [stub] = registry.load([{ protocol: "aave-v3", method: "supply" }]);
+    expect(stub?.verb).toBe("supply");
+    expect(stub?.risk).toContain("fundOut");
+    expect(stub?.params).toHaveProperty("amount");
+  });
+
+  it("loads withdraw stub", () => {
+    const registry = offlineRegistry();
+    const [stub] = registry.load([{ protocol: "aave-v3", method: "withdraw" }]);
+    expect(stub?.verb).toBe("withdraw");
+  });
+
+  it("loads borrow stub", () => {
+    const registry = offlineRegistry();
+    const [stub] = registry.load([{ protocol: "aave-v3", method: "borrow" }]);
+    expect(stub?.verb).toBe("borrow");
+  });
+
+  it("loads repay stub", () => {
+    const registry = offlineRegistry();
+    const [stub] = registry.load([{ protocol: "aave-v3", method: "repay" }]);
+    expect(stub?.verb).toBe("repay");
+  });
+});

--- a/packages/protocols/aave-v3/test/adapter.test.ts
+++ b/packages/protocols/aave-v3/test/adapter.test.ts
@@ -1,6 +1,7 @@
-import { type MossRuntime, Registry } from "@themoss/core";
+import { type MossRuntime, type Plan, Registry } from "@themoss/core";
 import { describe, expect, it } from "vitest";
-import { aaveV3Manifest } from "../src/index.js";
+import { systemManifest } from "@themoss/system";
+import { POOL_ADDRESS, aaveV3Manifest } from "../src/index.js";
 
 const ACCOUNT = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
@@ -9,12 +10,13 @@ function offlineRegistry(): Registry {
     chainId: 143, rpcUrl: "http://offline", client: {} as any,
   };
   const registry = new Registry(runtime);
+  registry.use(systemManifest);
   registry.use(aaveV3Manifest);
   return registry;
 }
 
 describe("aave-v3 adapter (offline shape)", () => {
-  it("discovers supply/withdraw/borrow/repay", () => {
+  it("discovers all capabilities and queries", () => {
     const registry = offlineRegistry();
     const caps = registry.discover({ protocol: "aave-v3" });
     expect(caps.map((c) => c.method).sort()).toEqual([
@@ -27,7 +29,7 @@ describe("aave-v3 adapter (offline shape)", () => {
     const registry = offlineRegistry();
     const [stub] = registry.load([{ protocol: "aave-v3", method: "supply" }]);
     expect(stub?.verb).toBe("supply");
-    expect(stub?.risk).toContain("fundOut");
+    expect(stub?.risk).toContain("approval");
     expect(stub?.params).toHaveProperty("amount");
   });
 
@@ -47,5 +49,49 @@ describe("aave-v3 adapter (offline shape)", () => {
     const registry = offlineRegistry();
     const [stub] = registry.load([{ protocol: "aave-v3", method: "repay" }]);
     expect(stub?.verb).toBe("repay");
+  });
+
+  it("builds a supply plan for WMON", async () => {
+    const registry = offlineRegistry();
+    const plan = (await registry.action("aave-v3", "supply", ACCOUNT, {
+      asset: "WMON", amount: "10",
+    })) as Plan;
+    expect(plan.txs.length).toBeGreaterThanOrEqual(2); // approve + supply
+    expect(plan.txs[0].to.toLowerCase()).toBe("0x3bd359c1119da7da1d913d1c4d2b7c461115433a");
+    expect(plan.planHash).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("builds a withdraw plan for WMON", async () => {
+    const registry = offlineRegistry();
+    const plan = (await registry.action("aave-v3", "withdraw", ACCOUNT, {
+      asset: "WMON", amount: "5",
+    })) as Plan;
+    expect(plan.txs).toHaveLength(1);
+    expect(plan.txs[0].to).toBe(POOL_ADDRESS);
+  });
+
+  it("builds a borrow plan", async () => {
+    const registry = offlineRegistry();
+    const plan = (await registry.action("aave-v3", "borrow", ACCOUNT, {
+      asset: "WMON", amount: "1",
+    })) as Plan;
+    expect(plan.txs).toHaveLength(1);
+  });
+
+  it("builds a repay plan", async () => {
+    const registry = offlineRegistry();
+    const plan = (await registry.action("aave-v3", "repay", ACCOUNT, {
+      asset: "WMON", amount: "1",
+    })) as Plan;
+    expect(plan.txs.length).toBeGreaterThanOrEqual(2); // approve + repay
+  });
+
+  it("rejects native MON with a clear error", async () => {
+    const registry = offlineRegistry();
+    await expect(
+      registry.action("aave-v3", "supply", ACCOUNT, {
+        asset: "native", amount: "1",
+      }),
+    ).rejects.toThrow(/non-payable/);
   });
 });

--- a/packages/protocols/aave-v3/tsconfig.json
+++ b/packages/protocols/aave-v3/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/aave-v3/vitest.config.ts
+++ b/packages/protocols/aave-v3/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/protocols/aave-v3/vitest.config.ts
+++ b/packages/protocols/aave-v3/vitest.config.ts
@@ -7,10 +7,12 @@ export default defineConfig({
   // why the repo pins vitest 3 — vite 8's oxc does not lower them.
   esbuild: { target: "es2022" },
   resolve: {
-    // Tests run against core's source, not its dist, so a stale build can
+    // Tests run against workspace source, not dist, so a stale build can
     // never produce phantom failures.
     alias: {
       "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+      "@themoss/erc": fileURLToPath(new URL("../../erc/src/index.ts", import.meta.url)),
+      "@themoss/system": fileURLToPath(new URL("../../system/src/index.ts", import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
## What & why

Closes #8.

Adds an Aave v3 lending protocol adapter for Monad mainnet. Uses the
PR #31 Capability + Receipt framework (`@Protocol`, `@Capability`, `@Receipt`,
`registry.use(class)` — no `plan()` or `defineProtocolPackage`).

## Type of change

- [x] New protocol adapter / capability / query
- [x] MCP server registration
- [ ] Docs / examples
- [ ] Bugfix

## Checklist

- [x] `pnpm -r build && pnpm -r test` passes locally
- [x] Includes a changeset (`pnpm changeset`) — `@themoss/protocol-aave-v3` + `@themoss/mcp-server`
- [x] MCP server updated — `cli.ts` registers the adapter for Agent discovery

### Adapter quality

- [x] `intent`, `params` (typed Zod schemas), `risk` labels, and `receipt` names all declared
- [x] Discoverable & loadable — shows up in `discover` and `load` output
- [x] Offline shape tests (11 tests, no RPC needed):
  - Discovers all 6 methods (4 capabilities + 2 queries)
  - Loads stubs with correct params/risk metadata
  - Supply/repay produce composed trees: `[erc20.approve, pool.<method>]`
  - Withdraw/borrow produce single-transaction capabilities
  - Rejects native MON with clear error
  - Rejects invalid amounts via Zod validation
  - Parses receipts from empty changes
- [x] E2E tests against Monad mainnet (4 tests, skipped without live RPC):
  - `userAccountData` — reads zero state for random account
  - `reserveData` — reads WMON reserve config
  - Supply/withdraw — builds valid ABI-encoded calldata

## Integration

- MCP server at `packages/mcp-server/` now registers `@themoss/protocol-aave-v3`
- `pnpm install` resolves the new workspace dependency automatically

## Architecture

The Aave v3 Pool is an ERC-1967 proxy at `0x69a5F9AD4f96ebf0a0C792dD42a01cC5C0102fef`
pointing to implementation `0x9539531ea4f6563a66421a7449506152609985be` (21KB).

Capabilities:

| Method    | Verb      | Risk tags        | Children |
|-----------|-----------|------------------|----------|
| `supply`  | `supply`  | fundOut, approval | [erc20.approve, pool.supply] |
| `withdraw`| `withdraw`| fundOut          | [pool.withdraw] |
| `borrow`  | `borrow`  | fundOut          | [pool.borrow] |
| `repay`   | `repay`   | fundOut, approval | [erc20.approve, pool.repay] |

Each capability declares a `@Receipt` that decodes the corresponding Aave
Pool event (Supply/Withdraw/Borrow/Repay) from simulation `Change[]` output.

## Evidence

### Build & test

```
✓  11 passed  | 4 skipped (MOSS_SKIP_E2E)
✓  pnpm -r build — passes
```
