### PR TITLE
fix(example): re-simulate before wallet send

### DIFF
--- a/examples/agent-swap/README.md
+++ b/examples/agent-swap/README.md
@@ -5,7 +5,7 @@ This example separates construction and verification from signing. Moss never re
 The three roles are explicit:
 
 - `swap` records intent, builds and simulates a Kuru Capability, compares the structured Outcome, and writes unsigned JSON;
-- `wallet` validates the tree and sender, then signs and sends on the local fork;
+- `wallet` validates the tree and sender, re-simulates on the same local fork, then signs and sends;
 - an Agent may drive the same `discover → load → action → simulate` flow through MCP, but must perform intent alignment before invoking the wallet.
 
 ## Prerequisites
@@ -39,7 +39,7 @@ The script stops on every Warning. It also compares Capability parameters and th
 
 Review the printed ordered Receipts and the JSON file. Receipt text is presentation; the structured Outcomes are the evidence.
 
-Only after review, send the transactions on the local fork:
+Only after review, send the transactions on the local fork. The wallet re-simulates before broadcasting and stops if the current fork state produces any Warning, revert, missing Receipt, or result-count mismatch.
 
 ```bash
 pnpm --filter @themoss/example-agent-swap wallet -- send verified-capability.json
@@ -67,7 +67,7 @@ pnpm --filter @themoss/example-agent-swap wallet -- balance
 pnpm --filter @themoss/example-agent-swap wallet -- send /absolute/path/to/capability.json
 ```
 
-The wallet refuses trees for a different sender. It also requires the local RPC to report Monad chain ID `143`.
+The wallet refuses trees for a different sender. It also requires the local RPC to report Monad chain ID `143` and re-simulates the Capability immediately before sending.
 
 ## Reset the fork
 

--- a/examples/agent-swap/src/wallet.ts
+++ b/examples/agent-swap/src/wallet.ts
@@ -1,11 +1,14 @@
 /** Local-fork signer. It accepts only a validated Capability tree from the Agent example. */
 import { readFileSync } from "node:fs";
-import { type CapabilityNode, flattenCapabilityTree, NATIVE } from "@themoss/core";
-import { ERC20Abi } from "@themoss/erc";
-import { AUSD_ADDRESS, MONAD_CHAIN_ID, USDC_ADDRESS, WMON_ADDRESS } from "@themoss/system";
+import { type CapabilityNode, flattenCapabilityTree, NATIVE, Registry } from "@themoss/core";
+import * as erc from "@themoss/erc";
+import * as kuru from "@themoss/protocol-kuru";
+import { createTraceSimulator } from "@themoss/simulator";
+import * as system from "@themoss/system";
 import { createPublicClient, createWalletClient, defineChain, formatUnits, http } from "viem";
 import { devAccount, FORK_RPC_URL, rpc } from "./dev-wallet.js";
 
+const { AUSD_ADDRESS, MONAD_CHAIN_ID, USDC_ADDRESS, WMON_ADDRESS } = system;
 const chainId = Number(await rpc<string>("eth_chainId"));
 if (chainId !== MONAD_CHAIN_ID) throw new Error(`wallet requires Monad chain ${MONAD_CHAIN_ID}`);
 const chain = defineChain({
@@ -30,7 +33,7 @@ async function printBalances(): Promise<void> {
         ? await reader.getBalance({ address: devAccount.address })
         : await reader.readContract({
             address: token.ref,
-            abi: ERC20Abi,
+            abi: erc.ERC20Abi,
             functionName: "balanceOf",
             args: [devAccount.address],
           });
@@ -52,6 +55,7 @@ if (command === "address") {
   if (executable.some(({ transaction }) => transaction.from.toLowerCase() !== sender)) {
     throw new Error(`Capability contains a transaction not sent by ${devAccount.address}`);
   }
+  await assertCleanSignerSimulation(capability, executable.length);
   for (const [index, { transaction }] of executable.entries()) {
     const hash = await wallet.sendTransaction({
       to: transaction.to,
@@ -65,4 +69,36 @@ if (command === "address") {
   await printBalances();
 } else {
   throw new Error("usage: wallet <address|balance|send <verified-capability.json>>");
+}
+
+async function assertCleanSignerSimulation(
+  capability: CapabilityNode,
+  expectedTransactions: number,
+): Promise<void> {
+  const runtime = await system.monadRuntime({ rpcUrl: FORK_RPC_URL });
+  const registry = new Registry(runtime).use(system, erc, kuru);
+  const simulation = await createTraceSimulator(runtime, {
+    receipt: (capabilityNode, changes) => registry.parseReceipt(capabilityNode, changes),
+  }).simulate(capability);
+
+  const unsafe =
+    Boolean(simulation.halted) ||
+    simulation.results.length !== expectedTransactions ||
+    simulation.results.some((result) => {
+      return result.reverted || result.warnings.length > 0 || !result.receipt;
+    });
+
+  if (unsafe) {
+    console.error(JSON.stringify(simulation, null, 2));
+    throw new Error("Capability did not re-simulate cleanly at the signer boundary");
+  }
+
+  console.log(
+    `re-simulated ${simulation.results.length} transaction${
+      simulation.results.length === 1 ? "" : "s"
+    } at the signer boundary`,
+  );
+  for (const [index, result] of simulation.results.entries()) {
+    console.log(`  ${index + 1}/${simulation.results.length} ${result.receipt?.text}`);
+  }
 }


### PR DESCRIPTION
## Problem

The previous version of this PR included fixed-block simulation and exposed `baseBlock` through SDK/MCP results. Maintainer feedback clarified that Moss simulations currently run on the latest block and Agents do not need to simulate other blocks.

The remaining safety issue is narrower: the agent-swap wallet accepted a previously verified Capability JSON and sent it after checking only the tree shape and sender. That left the final signer boundary without a current-state simulation check.

## Changes

- Removed the fixed-block / `baseBlock` simulation direction from this PR.
- Removed the `system.assets` addition from this PR so the change stays focused.
- Re-simulate the Capability inside `wallet send` immediately before broadcasting.
- Refuse to send if simulation halts, returns warnings, reverts, omits Receipts, or returns a result count that does not match the executable transaction count.
- Update the agent-swap README to document the wallet-side re-simulation.

## Effect

This PR no longer changes simulator or MCP public API. It only hardens the example wallet flow so a Capability must still simulate cleanly at the final signer boundary before any transaction is sent.

## Security review

- No dependency, lockfile, CI, SDK API, MCP response, simulator, system package, or protocol behavior changes.
- The signer path becomes stricter: it refuses halted simulations, warnings, reverts, missing Receipts, and result-count mismatch before broadcasting.
- No private-key handling, dynamic code execution, command execution, or external signing path changes introduced.
- Diff secret scan: no credentials or sensitive material found in added lines.
- Diff dangerous API scan: no new process execution, file write/delete, signing, send-transaction, debug trace, or fixed-block APIs added.
- `pnpm audit --audit-level moderate`: passed; output reports only one existing low advisory below the moderate gate.
- `pnpm audit --prod --audit-level low`: passed with no known production vulnerabilities.

## Verification

- `pnpm --filter @themoss/example-agent-swap typecheck`
- `pnpm lint`
- `git diff --check`
- `pnpm build`
- `pnpm typecheck`
- `MOSS_SKIP_E2E=1 pnpm test`
