### PR TITLE
fix: bound Kuru market discovery

### DIFF
--- a/.changeset/kuru-discovery-guardrails.md
+++ b/.changeset/kuru-discovery-guardrails.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-kuru": patch
+---
+
+Bound Kuru market discovery with timeout, response-size, candidate-count, and route-count limits before on-chain market verification and quoting.

--- a/docs/adr/0012-kuru-market-discovery.md
+++ b/docs/adr/0012-kuru-market-discovery.md
@@ -2,6 +2,8 @@
 
 Kuru has no pair-indexed on-chain `getPool`; its official SDK discovers candidate markets through the filtered-markets API. The Kuru Protocol follows that discovery path for direct and via-MON candidates, then verifies every returned market against the Router's on-chain `verifiedMarket` data before quoting or constructing a Capability. The API supplies candidates, never trusted market facts.
 
+The filtered-markets HTTP request is bounded by a timeout, maximum response size, maximum candidate count, and maximum constructed route count. Discovery failure, malformed responses, oversized responses, excessive candidates, and excessive direct or via-MON route combinations stop the Query or Capability before unbounded on-chain verification or quoting fanout.
+
 “Direct” and “via MON” are path classes, not single markets. Kuru quotes every verified direct market and every verified two-market combination through native MON, then selects the best result using the swap-side rules. API response order never determines the selected market; an equal quote still prefers a direct path.
 
 The public quote is advisory. Capability construction repeats discovery and quoting against current state, selects the path itself, and derives current slippage protection. An Agent cannot supply a market address, path, or quote identifier to `swap`; stale or manipulated routing data therefore cannot enter the Capability request.

--- a/packages/protocols/kuru/src/kuru.ts
+++ b/packages/protocols/kuru/src/kuru.ts
@@ -42,6 +42,10 @@ export const KURU_ROUTER_ADDRESS = "0xd651346d7c789536ebf06dc72aE3C8502cd695CC" 
 const KURU_API_URL = "https://api.kuru.io";
 const KURU_NATIVE = "0x0000000000000000000000000000000000000000" as const;
 const DEFAULT_SLIPPAGE_BPS = 50;
+const KURU_MARKET_DISCOVERY_TIMEOUT_MS = 10_000;
+const MAX_KURU_MARKET_DISCOVERY_BYTES = 1_000_000;
+const MAX_KURU_MARKET_CANDIDATES = 256;
+const MAX_KURU_MARKET_ROUTES = 256;
 
 const OptionalHumanTokenAmount = PositiveDecimalString.optional().describe(
   'An optional positive base-10 decimal amount in a token\'s display units, such as "1" or "1.5".',
@@ -277,9 +281,15 @@ export class Kuru {
       candidates.map((candidate) => this.#verifyMarket(candidate, account)),
     );
     const routes: Route[] = [];
+    const addRoute = (route: Route): void => {
+      if (routes.length >= MAX_KURU_MARKET_ROUTES) {
+        throw new Error(`too many Kuru market routes; maximum is ${MAX_KURU_MARKET_ROUTES}`);
+      }
+      routes.push(route);
+    };
     for (const market of markets) {
       const leg = routeLeg(market, tokenIn);
-      if (leg && sameToken(leg.output, tokenOut)) routes.push([leg]);
+      if (leg && sameToken(leg.output, tokenOut)) addRoute([leg]);
     }
     if (tokenIn !== NATIVE && tokenOut !== NATIVE) {
       const firstLegs = markets
@@ -293,7 +303,7 @@ export class Kuru {
           if (first.outputDecimals !== second.inputDecimals) {
             throw new Error("verified Kuru markets disagree on native MON decimals");
           }
-          routes.push([first, second]);
+          addRoute([first, second]);
         }
       }
     }
@@ -417,27 +427,44 @@ export class Kuru {
 
 async function fetchMarketCandidates(tokenIn: TokenRef, tokenOut: TokenRef) {
   const pairs = requestedPairs(tokenIn, tokenOut);
-  let response: Response;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), KURU_MARKET_DISCOVERY_TIMEOUT_MS);
+  let text: string;
   try {
-    response = await fetch(`${KURU_API_URL}/api/v1/markets/filtered`, {
+    const response = await fetch(`${KURU_API_URL}/api/v1/markets/filtered`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ pairs }),
+      signal: controller.signal,
     });
+    if (!response.ok) {
+      throw new Error(`Kuru market discovery failed with HTTP ${response.status}`);
+    }
+    text = await readBoundedMarketDiscoveryResponse(response);
   } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `Kuru market discovery timed out after ${KURU_MARKET_DISCOVERY_TIMEOUT_MS}ms`,
+      );
+    }
+    if (error instanceof Error && error.message.startsWith("Kuru market discovery")) throw error;
     throw new Error(`Kuru market discovery failed: ${errorMessage(error)}`);
-  }
-  if (!response.ok) {
-    throw new Error(`Kuru market discovery failed with HTTP ${response.status}`);
+  } finally {
+    clearTimeout(timeout);
   }
   let payload: unknown;
   try {
-    payload = await response.json();
+    payload = JSON.parse(text);
   } catch (error) {
     throw new Error(`Kuru market discovery returned invalid JSON: ${errorMessage(error)}`);
   }
   if (!isRecord(payload) || !Array.isArray(payload.data)) {
     throw new Error("Kuru market discovery returned an invalid response");
+  }
+  if (payload.data.length > MAX_KURU_MARKET_CANDIDATES) {
+    throw new Error(
+      `Kuru market discovery returned too many markets; maximum is ${MAX_KURU_MARKET_CANDIDATES}`,
+    );
   }
   const candidates = payload.data.map(parseMarketCandidate);
   const unique = new Map<string, MarketCandidate>();
@@ -453,6 +480,43 @@ async function fetchMarketCandidates(tokenIn: TokenRef, tokenOut: TokenRef) {
     unique.set(key, candidate);
   }
   return [...unique.values()];
+}
+
+async function readBoundedMarketDiscoveryResponse(response: Response) {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const length = Number(contentLength);
+    if (Number.isFinite(length) && length > MAX_KURU_MARKET_DISCOVERY_BYTES) {
+      throw new Error("Kuru market discovery response is too large");
+    }
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_KURU_MARKET_DISCOVERY_BYTES) {
+      throw new Error("Kuru market discovery response is too large");
+    }
+    return text;
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > MAX_KURU_MARKET_DISCOVERY_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error("Kuru market discovery response is too large");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 function requestedPairs(tokenIn: TokenRef, tokenOut: TokenRef) {

--- a/packages/protocols/kuru/test/kuru.test.ts
+++ b/packages/protocols/kuru/test/kuru.test.ts
@@ -50,7 +50,10 @@ const MARKETS: readonly MockMarket[] = [
   market(DIRECT_USDC_AUSD_BETTER, USDC_ADDRESS, AUSD_ADDRESS, 6, 6, 11n, 10n),
 ];
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe("Kuru", () => {
   it("loads separate human-amount fields and requires exactly one side", async () => {
@@ -118,6 +121,7 @@ describe("Kuru", () => {
       pairs: readonly unknown[];
     };
     expect(request.pairs).toHaveLength(6);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
 
     const capability = await registry.action("kuru", "swap", ACCOUNT, {
       tokenIn: USDC_ADDRESS,
@@ -259,6 +263,147 @@ describe("Kuru", () => {
       }),
     ).rejects.toThrow("invalid base token decimals");
   });
+
+  it("bounds Kuru market discovery response size from content-length", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response("{}", { status: 200, headers: { "content-length": "1000001" } }),
+    );
+    const { registry } = offlineRegistry([], fetchMock);
+
+    await expect(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("response is too large");
+  });
+
+  it("accepts a Kuru market discovery response at the exact byte limit", async () => {
+    const prefix = '{"data":[],"padding":"';
+    const suffix = '"}';
+    const body = `${prefix}${"x".repeat(1_000_000 - prefix.length - suffix.length)}${suffix}`;
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(body, { status: 200 }),
+    );
+    const { registry } = offlineRegistry([], fetchMock);
+
+    await expect(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("no verified Kuru market path");
+  });
+
+  it("bounds Kuru market discovery response size from the body", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response("x".repeat(1_000_001), { status: 200 }),
+    );
+    const { registry } = offlineRegistry([], fetchMock);
+
+    await expect(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("response is too large");
+  });
+
+  it("bounds the number of Kuru market candidates before on-chain verification", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(JSON.stringify({ data: Array.from({ length: 257 }, () => ({})) }), {
+          status: 200,
+        }),
+    );
+    const { registry } = offlineRegistry([], fetchMock);
+
+    await expect(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("too many markets");
+  });
+
+  it("accepts the exact Kuru market candidate limit", async () => {
+    const directMarket = MARKETS[0];
+    if (!directMarket) throw new Error("expected direct market fixture");
+    const candidate = {
+      market: directMarket.address,
+      baseasset: directMarket.base,
+      quoteasset: directMarket.quote,
+    };
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(JSON.stringify({ data: Array.from({ length: 256 }, () => candidate) }), {
+          status: 200,
+        }),
+    );
+    const { registry } = offlineRegistry([directMarket], fetchMock);
+
+    const quote = await registry.action("kuru", "quote", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1",
+    });
+
+    expect(quote.kind).toBe("query");
+  });
+
+  it("accepts the exact Kuru market route limit", async () => {
+    const { registry } = offlineRegistry(viaMonMarkets(16, 16));
+
+    const quote = await registry.action("kuru", "quote", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+
+    expect(quote.kind).toBe("query");
+  });
+
+  it("bounds via-MON route combinations before quoting", async () => {
+    const { registry } = offlineRegistry(viaMonMarkets(16, 16, true));
+
+    await expect(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: USDC_ADDRESS,
+        tokenOut: AUSD_ADDRESS,
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("too many Kuru market routes");
+  });
+
+  it("times out Kuru market discovery", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+            once: true,
+          });
+        }),
+    );
+    const { registry } = offlineRegistry([], fetchMock);
+
+    const quote = registry.action("kuru", "quote", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1",
+    });
+    const assertion = expect(quote).rejects.toThrow("timed out after 10000ms");
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await assertion;
+  });
 });
 
 describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Kuru mainnet", () => {
@@ -301,21 +446,11 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Kuru mainnet", () => {
   });
 });
 
-function offlineRegistry(markets: readonly MockMarket[] = MARKETS) {
+function offlineRegistry(
+  markets: readonly MockMarket[] = MARKETS,
+  fetchMock = marketDiscoveryFetch(markets),
+) {
   const byAddress = new Map(markets.map((entry) => [entry.address.toLowerCase(), entry]));
-  const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestInit) =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        data: markets.map(({ address, base, quote }) => ({
-          market: address,
-          baseasset: base,
-          quoteasset: quote,
-        })),
-      }),
-    } as Response),
-  );
   vi.stubGlobal("fetch", fetchMock);
   const client = {
     readContract: async ({
@@ -391,6 +526,22 @@ function offlineRegistry(markets: readonly MockMarket[] = MARKETS) {
   };
 }
 
+function marketDiscoveryFetch(markets: readonly MockMarket[]) {
+  return vi.fn(
+    async (_input: string | URL | Request, _init?: RequestInit) =>
+      new Response(
+        JSON.stringify({
+          data: markets.map(({ address, base, quote }) => ({
+            market: address,
+            baseasset: base,
+            quoteasset: quote,
+          })),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+  );
+}
+
 function market(
   address: `0x${string}`,
   base: `0x${string}`,
@@ -411,6 +562,49 @@ function market(
     buyNumerator: sellDenominator,
     buyDenominator: sellNumerator,
   };
+}
+
+function viaMonMarkets(
+  firstCount: number,
+  secondCount: number,
+  includeDirect = false,
+): MockMarket[] {
+  const firstLegs = Array.from({ length: firstCount }, (_, index) =>
+    market(
+      getAddress(`0x${(index + 100).toString(16).padStart(40, "0")}`),
+      USDC_ADDRESS,
+      ZERO,
+      6,
+      18,
+      1n,
+      1n,
+    ),
+  );
+  const secondLegs = Array.from({ length: secondCount }, (_, index) =>
+    market(
+      getAddress(`0x${(index + 200).toString(16).padStart(40, "0")}`),
+      ZERO,
+      AUSD_ADDRESS,
+      18,
+      6,
+      1n,
+      1n,
+    ),
+  );
+  const direct = includeDirect
+    ? [
+        market(
+          getAddress(`0x${(300).toString(16).padStart(40, "0")}`),
+          USDC_ADDRESS,
+          AUSD_ADDRESS,
+          6,
+          6,
+          1n,
+          1n,
+        ),
+      ]
+    : [];
+  return [...direct, ...firstLegs, ...secondLegs];
 }
 
 function convertUnits(


### PR DESCRIPTION
## Problem

Kuru market discovery treats `https://api.kuru.io/api/v1/markets/filtered` only as an off-chain candidate source and verifies every returned market against the Router's on-chain `verifiedMarket` data before quoting or constructing a Capability.

The remaining issue was resource bounding: a slow, oversized, or excessively large candidate response could delay discovery, consume unnecessary memory/CPU before JSON parsing, or trigger excessive on-chain verification and quoting work. Candidate count alone is not sufficient because two groups of valid via-MON markets form a Cartesian product of routes before quoting.

## Changes

- Rebased onto current `main` at `efa0a72`.
- Added a 10s timeout to the Kuru filtered-markets request with `AbortController`.
- Added a 1 MB response-size bound using `content-length` when available and bounded streaming reads when it is not.
- Added a 256-candidate cap before market parsing and before `verifiedMarket` fanout.
- Added a separate 256-route cap while constructing direct and via-MON routes, before quote RPC fanout.
- Kept the existing trust model: API results remain candidates; Router `verifiedMarket` remains the source of market facts.
- Added tests for signal wiring, timeout, response bytes, candidate count, route count, and exact boundary behavior.
- Updated ADR 0012 and the changeset to describe both verification and quoting bounds.

## Effect

Malformed, slow, oversized, or excessive Kuru discovery responses now stop quote and Capability construction with explicit errors before unbounded parsing, verification, or route-quoting work. Valid discovery still follows the existing direct/via-MON flow and verifies every returned market on-chain before use.

The exact limits are covered in both directions:

- 1,000,000 response bytes pass; 1,000,001 fail;
- 256 candidates pass; 257 fail;
- 256 routes pass; the 257th fails before quoting.

## Verification

Run in the maintainer-requested order after the final changes:

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `NODE_USE_ENV_PROXY=1 pnpm test` — 62/62 passed

The full test run included live Monad mainnet checks:

- official token bytecode and metadata;
- WMON simulation;
- Kuru Router bytecode and dynamic quote;
- Kuru native swap simulation with exhaustive Receipt coverage.

Additional checks:

- focused Kuru boundary tests passed;
- `git diff --check origin/main...HEAD` passed;
- changed-file secret and dangerous-API scans found no additions;
- `pnpm audit --prod --audit-level low` found no known production vulnerabilities;
- the complete development audit still reports one existing low-severity tooling advisory, not introduced by this PR.

## Security Review

- No signing, transaction broadcasting, private-key handling, command execution, file writes, or dynamic code execution were added.
- The only network surface changed is the existing Kuru candidate request and its bounded downstream verification/quoting flow.
- API data remains untrusted until each candidate is verified against Router state.
- Candidate count and route count are separate limits so valid markets cannot amplify into an unbounded via-MON Cartesian product.
