### PR TITLE
fix: reject unsafe protocol injection keys

### DIFF
--- a/.changeset/registry-injection-guardrails.md
+++ b/.changeset/registry-injection-guardrails.md
@@ -1,0 +1,5 @@
+---
+"@themoss/core": patch
+---
+
+Reject Protocol contract and dependency injection keys that are reserved, duplicated, or would shadow Capability, Query, or Receipt methods.

--- a/docs/protocol-onboarding.md
+++ b/docs/protocol-onboarding.md
@@ -51,6 +51,8 @@ export class MyProtocol {
 
 Protocol dependencies are explicit. Registry recursively registers them and injects typed instances. Calling an injected Capability creates a nested Capability node; calling an injected Query returns data directly.
 
+Injected contract and Protocol field names must be unique and must not be `runtime`, or the name of any Capability, Query, or Receipt method on the same Protocol.
+
 ## 3. Define parameter contracts
 
 Each field pairs a reusable Zod value contract with a description of that field's role.

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -72,6 +72,8 @@ interface Registered {
 
 export type ProtocolSource = ProtocolCtor | Record<string, unknown>;
 
+const RESERVED_INJECTION_KEYS = new Set(["constructor", "runtime"]);
+
 function configOf(value: unknown): ProtocolConfig<ProtocolDependencies> | undefined {
   if (typeof value !== "function") return undefined;
   if (!Object.hasOwn(value, PROTOCOL_META)) return undefined;
@@ -83,6 +85,27 @@ function configOf(value: unknown): ProtocolConfig<ProtocolDependencies> | undefi
 function requireMetadataText(value: unknown, path: string): void {
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new Error(`${path} must be a non-empty string`);
+  }
+}
+
+function validateInjectionKeys(
+  config: ProtocolConfig<ProtocolDependencies>,
+  memberNames: ReadonlySet<string>,
+): void {
+  const seen = new Set<string>();
+  for (const key of [...Object.keys(config.contracts), ...Object.keys(config.protocols ?? {})]) {
+    if (RESERVED_INJECTION_KEYS.has(key)) {
+      throw new Error(`protocol "${config.name}" injection key "${key}" is reserved`);
+    }
+    if (memberNames.has(key)) {
+      throw new Error(
+        `protocol "${config.name}" injection key "${key}" conflicts with a method or Receipt`,
+      );
+    }
+    if (seen.has(key)) {
+      throw new Error(`protocol "${config.name}" declares injection key "${key}" more than once`);
+    }
+    seen.add(key);
   }
 }
 
@@ -134,9 +157,6 @@ export class Registry {
     if (stack.includes(config.name)) {
       throw new Error(`Protocol dependency cycle: ${[...stack, config.name].join(" -> ")}`);
     }
-    for (const dependency of Object.values(config.protocols ?? {})) {
-      this.register(dependency, [...stack, config.name]);
-    }
 
     const methods: Record<string, MethodMeta> = {};
     const receipts = new Set<string>();
@@ -161,6 +181,7 @@ export class Registry {
     if (Object.keys(methods).length === 0) {
       throw new Error(`protocol "${config.name}" declares no @Capability or @Query methods`);
     }
+    validateInjectionKeys(config, new Set([...Object.keys(methods), ...receipts]));
     for (const [name, meta] of Object.entries(methods)) {
       requireMetadataText(meta.spec.intent, `method "${config.name}.${name}" intent`);
       if (meta.spec.tags?.some((tag) => typeof tag !== "string" || tag.trim().length === 0)) {
@@ -194,6 +215,9 @@ export class Registry {
           `capability "${config.name}.${name}" names "${meta.spec.receipt}", which is not an @Receipt method`,
         );
       }
+    }
+    for (const dependency of Object.values(config.protocols ?? {})) {
+      this.register(dependency, [...stack, config.name]);
     }
     const receiptCtor =
       (ctor as unknown as Record<symbol, ProtocolCtor | undefined>)[PROTOCOL_TARGET] ?? ctor;

--- a/packages/core/test/framework.test.ts
+++ b/packages/core/test/framework.test.ts
@@ -298,6 +298,71 @@ class UndescribedParameterProtocol {
   }
 }
 
+@Protocol({
+  name: "reserved-injection",
+  category: "token",
+  description: "Fixture with a reserved injected field.",
+  contracts: { runtime: { abi: VaultAbi, addr: VAULT } },
+})
+class ReservedInjectionProtocol {
+  @Query({ intent: "Inspect the fixture", params: noParams })
+  async inspect() {
+    return null;
+  }
+}
+
+@Protocol({
+  name: "duplicate-injection",
+  category: "token",
+  description: "Fixture with duplicate injected field names.",
+  contracts: { approval: { abi: VaultAbi, addr: VAULT } },
+  protocols: { approval: ApprovalProtocol },
+})
+class DuplicateInjectionProtocol {
+  declare approval: ProtocolRef<ApprovalProtocol>;
+
+  @Query({ intent: "Inspect the fixture", params: noParams })
+  async inspect() {
+    return null;
+  }
+}
+
+@Protocol({
+  name: "method-injection",
+  category: "token",
+  description: "Fixture whose injection key would shadow a Query method.",
+  contracts: { inspect: { abi: VaultAbi, addr: VAULT } },
+})
+class MethodInjectionProtocol {
+  @Query({ intent: "Inspect the fixture", params: noParams })
+  async inspect() {
+    return null;
+  }
+}
+
+@Protocol({
+  name: "receipt-injection",
+  category: "token",
+  description: "Fixture whose injection key would shadow a Receipt method.",
+  contracts: { fixtureReceipt: { abi: VaultAbi, addr: VAULT } },
+})
+class ReceiptInjectionProtocol {
+  @Query({ intent: "Inspect the fixture", params: noParams })
+  async inspect() {
+    return null;
+  }
+
+  @Receipt()
+  fixtureReceipt(changes: readonly Change[]): MossReceipt<null> {
+    return {
+      kind: "receipt",
+      outcome: null,
+      text: "fixture",
+      changes: changes.map((change) => ({ kind: "change", change, data: null, text: "change" })),
+    };
+  }
+}
+
 function receiptFor<T extends "approve" | "swap">(
   operation: T,
   changes: readonly Change[],
@@ -398,6 +463,21 @@ describe("framework core seam", () => {
     expect(() => new Registry(runtime).use(InvalidMetadataProtocol)).toThrow("non-empty string");
     expect(() => new Registry(runtime).use(UndescribedParameterProtocol)).toThrow(
       "type description",
+    );
+  });
+
+  it("rejects injected fields that would shadow runtime, methods, or Receipts", () => {
+    expect(() => new Registry(runtime).use(ReservedInjectionProtocol)).toThrow(
+      'injection key "runtime" is reserved',
+    );
+    expect(() => new Registry(runtime).use(DuplicateInjectionProtocol)).toThrow(
+      'injection key "approval" more than once',
+    );
+    expect(() => new Registry(runtime).use(MethodInjectionProtocol)).toThrow(
+      'injection key "inspect" conflicts',
+    );
+    expect(() => new Registry(runtime).use(ReceiptInjectionProtocol)).toThrow(
+      'injection key "fixtureReceipt" conflicts',
     );
   });
 


### PR DESCRIPTION
## Summary

P2 framework guardrails for #31:

- reject contract/dependency injection keys that are reserved (`runtime`, `constructor`)
- reject duplicate injected field names across `contracts` and `protocols`
- reject injected field names that would shadow Capability, Query, or Receipt methods
- validate current Protocol metadata before recursively registering dependencies, avoiding partial dependency registration for invalid Protocols
- update protocol onboarding docs and add a changeset

## Security review

- No new dependencies, lockfile changes, secrets, dynamic code execution, network calls, or CI changes
- Change tightens Registry registration behavior before runtime instantiation
- Prevents Protocol adapters from accidentally shadowing `runtime` or executable/Receipt methods with injected Handles or dependency refs
- `pnpm audit --audit-level moderate` reports one existing low-severity dev-only `esbuild` advisory via `tsup`; this PR does not introduce it

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `MOSS_SKIP_E2E=1 pnpm test`
- `pnpm test`
