### PR TITLE
test: cover halted mcp simulation projection

### DIFF
--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -103,38 +103,8 @@ describe("moss MCP server", () => {
   });
 
   it("projects full SDK Receipts into ordered Agent text only", () => {
-    const first = eventChange("0x1111111111111111111111111111111111111111");
-    const second = eventChange("0x2222222222222222222222222222222222222222");
-    const nested: ReceiptResult = {
-      kind: "receipt",
-      outcome: { operation: "transfer" },
-      text: "nested summary",
-      changes: [{ kind: "change", change: second, data: { amount: "2" }, text: "second" }],
-    };
-    const receipt: ReceiptResult = {
-      kind: "receipt",
-      outcome: { operation: "swap" },
-      text: "root summary",
-      changes: [{ kind: "change", change: first, data: { amount: "1" }, text: "first" }, nested],
-    };
     const outcome: SimulateOutcome = {
-      results: [
-        {
-          protocol: "kuru",
-          method: "swap",
-          transaction: {
-            from: "0xcccccccccccccccccccccccccccccccccccccccc",
-            to: "0xdddddddddddddddddddddddddddddddddddddddd",
-            data: "0x",
-            value: "0x0",
-          },
-          reverted: false,
-          receipt,
-          changes: [first, second],
-          warnings: [],
-          gas: "1",
-        },
-      ],
+      results: [successfulSimulationResult()],
     };
 
     const projected = toAgentSimulation(outcome);
@@ -144,7 +114,45 @@ describe("moss MCP server", () => {
         "Compare every ordered Receipt text with the user's intent before handing transactions to a signer.",
       results: [{ protocol: "kuru", method: "swap", texts: ["first", "second"], warnings: [] }],
     });
-    expect(JSON.stringify(projected)).not.toMatch(/"(?:outcome|change|data|transaction|gas)":/);
+  });
+
+  it("projects halted simulations into stop guidance without leaking SDK evidence", () => {
+    const outcome: SimulateOutcome = {
+      halted: { transactionIndex: 1, reason: "execution reverted" },
+      results: [
+        successfulSimulationResult(),
+        {
+          protocol: "kuru",
+          method: "swap",
+          transaction: {
+            from: "0xcccccccccccccccccccccccccccccccccccccccc",
+            to: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            data: "0xabcd",
+            value: "0x0",
+          },
+          reverted: true,
+          revertReason: "execution reverted",
+          warnings: [{ code: "REVERTED", message: "transaction reverted: execution reverted" }],
+          gas: null,
+        },
+      ],
+    };
+
+    const projected = toAgentSimulation(outcome);
+    expect(projected).toEqual({
+      ok: false,
+      guidance: "Stop. Do not sign; report the warning and failed transaction.",
+      halted: { transactionIndex: 1, reason: "execution reverted" },
+      results: [
+        { protocol: "kuru", method: "swap", texts: ["first", "second"], warnings: [] },
+        {
+          protocol: "kuru",
+          method: "swap",
+          texts: [],
+          warnings: [{ code: "REVERTED", message: "transaction reverted: execution reverted" }],
+        },
+      ],
+    });
   });
 
   it("shows the exact Kuru simulation response an Agent receives", async () => {
@@ -282,6 +290,39 @@ describe("moss MCP server", () => {
 
 function eventChange(address: `0x${string}`): Change {
   return { kind: "event", address, topics: ["0x01"], data: "0x02" };
+}
+
+function successfulSimulationResult(): SimulateOutcome["results"][number] {
+  const first = eventChange("0x1111111111111111111111111111111111111111");
+  const second = eventChange("0x2222222222222222222222222222222222222222");
+  const nested: ReceiptResult = {
+    kind: "receipt",
+    outcome: { operation: "transfer" },
+    text: "nested summary",
+    changes: [{ kind: "change", change: second, data: { amount: "2" }, text: "second" }],
+  };
+  const receipt: ReceiptResult = {
+    kind: "receipt",
+    outcome: { operation: "swap" },
+    text: "root summary",
+    changes: [{ kind: "change", change: first, data: { amount: "1" }, text: "first" }, nested],
+  };
+
+  return {
+    protocol: "kuru",
+    method: "swap",
+    transaction: {
+      from: "0xcccccccccccccccccccccccccccccccccccccccc",
+      to: "0xdddddddddddddddddddddddddddddddddddddddd",
+      data: "0x",
+      value: "0x0",
+    },
+    reverted: false,
+    receipt,
+    changes: [first, second],
+    warnings: [],
+    gas: "1",
+  };
 }
 
 function receiptCapability(protocol: string, method: string): CapabilityNode {


### PR DESCRIPTION
## Problem

MCP Agent-facing simulation projection should continue to prove halted simulations are stop signals and do not leak SDK-only fields.

After #48 landed, this PR needed a final refresh against current `main`: the stale `CapabilityNode.receipt` fixture shape had to be removed, and the previous conflict in `packages/mcp-server/test/server.test.ts` had to be resolved without expanding the scope.

## Changes

- Rebased/rebuilt the PR onto current `main` after #48.
- Kept one compact halted Agent-projection regression test.
- The halted projection now asserts:
  - `ok: false`
  - stop guidance
  - halt location
  - the `REVERTED` Warning
  - earlier verified Receipt texts are preserved
  - no SDK-only evidence appears in the exact Agent-facing projection
- Removed stale `CapabilityNode.receipt` fields from fixtures; the only caller-supplied `receipt` field left is the existing negative test that proves MCP rejects it before tracing.
- Reused `successfulSimulationResult()` for the shared successful SDK simulation fixture.

## Effect

This remains a single-file test-only PR. It locks the halted MCP projection boundary that #48 does not cover, while staying aligned with the registry-owned Receipt model.

## Verification

- `pnpm --filter @themoss/mcp-server test`
- `pnpm build`
- `pnpm --filter @themoss/mcp-server typecheck`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:offline`
- `git diff --check`

Note: the first focused mcp-server typecheck was intentionally rerun after `pnpm build`; this repo resolves cross-package types through built declarations.

## Security Review

- Test-only change in `packages/mcp-server/test/server.test.ts`.
- No runtime behavior, MCP API, simulator, protocol, dependency, lockfile, shell, network, signing, transaction broadcast, file write/delete, debug trace, or fixed-block changes.
- Changed-line secret scan found no private keys, mnemonics, API keys, access tokens, auth tokens, or secrets.
- Dangerous API scan found no new command execution, file write/delete, signing, broadcast, network, trace, or fixed-block APIs.
- `pnpm audit --prod --audit-level low`: no known production dependency vulnerabilities.
- `pnpm audit --audit-level moderate`: passes the moderate threshold; the only advisory reported is an existing low dev-only `esbuild` advisory through `tsup`, not introduced by this PR.
