### PR TITLE
docs: add Chinese beginner tutorials

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,7 @@ workspace package 的类型来自构建产物，因此必须先 build 再 typech
 
 | 文档 | 用途 |
 | --- | --- |
+| [Moss 新手教程](./docs/tutorials/zh-CN/) | 环境配置、入门、PR、Protocol 接入、AI Agent Demo 与 FAQ |
 | [新手上路](./docs/getting-started.zh-CN.md)（[English](./docs/getting-started.md)） | 逐步运行并开发 Moss |
 | [MCP 工具契约](./docs/mcp-tools.md) | 四个 MCP 工具的输入输出 |
 | [Protocol 接入指南](./docs/protocol-onboarding.md) | 开发并提交一个 Protocol 包 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ The framework contract and its decisions are documented here.
 
 - [Overview](../README.md)
 - [Getting started](./getting-started.md) ([中文](./getting-started.zh-CN.md))
+- [Chinese beginner tutorial suite / 中文新手教程](./tutorials/zh-CN/)
 - [MCP tool contracts](./mcp-tools.md)
 - [Protocol onboarding](./protocol-onboarding.md)
 - [Agent safety rules](./agent-skill.md)

--- a/docs/superpowers/plans/2026-07-16-moss-beginner-tutorials.md
+++ b/docs/superpowers/plans/2026-07-16-moss-beginner-tutorials.md
@@ -1,0 +1,150 @@
+# Moss Beginner Tutorials Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Chinese beginner tutorial suite that teaches setup, the Moss workflow, first-time contribution, Protocol integration, and a safe AI Agent demo using the repository's current APIs.
+
+**Architecture:** Keep each learning goal in one focused Markdown file under `docs/tutorials/zh-CN/`, with an index that supplies the recommended reading order. Reuse repository examples and Protocol templates instead of introducing new runtime code, and add entry links to the existing Chinese README and documentation index.
+
+**Tech Stack:** Markdown, Node.js 22+, pnpm 11.10.0, TypeScript 5.9.x, Moss Registry/Simulator/MCP APIs, Monad mainnet chain ID 143.
+
+---
+
+### Task 1: Create the tutorial index and learning path
+
+**Files:**
+- Create: `docs/tutorials/zh-CN/README.md`
+
+- [ ] **Step 1: Write the tutorial index**
+
+Create a landing page with the six requested topics, their learning outcomes, recommended order, audience notes, and the safety invariant that Moss never signs or sends transactions.
+
+- [ ] **Step 2: Verify every planned page has one index link**
+
+Run: `rg -n '01-getting-started|02-first-pull-request|03-protocol-integration|04-ai-agent-demo|05-environment-setup|06-faq' docs/tutorials/zh-CN/README.md`
+
+Expected: all six filenames appear.
+
+### Task 2: Write environment setup and getting-started guides
+
+**Files:**
+- Create: `docs/tutorials/zh-CN/01-getting-started.md`
+- Create: `docs/tutorials/zh-CN/05-environment-setup.md`
+
+- [ ] **Step 1: Write the environment setup guide**
+
+Document Git, Node.js 22+, Corepack/pnpm 11.10.0, cloning `https://github.com/Wea1her/moss`, dependency installation, optional `MOSS_RPC_URL`, build-before-typecheck ordering, offline tests, and common environment diagnostics.
+
+- [ ] **Step 2: Write the Moss getting-started guide**
+
+Explain the architecture and `discover → load → action → simulate` workflow; run the existing WMON and Kuru examples; explain Capability, Query, Change, Receipt, Outcome, and Warning; require stopping on every Warning and intent alignment before any external signer boundary.
+
+- [ ] **Step 3: Check commands against workspace scripts**
+
+Run: `rg -n '"(build|typecheck|lint|test)"|packageManager|"node"' package.json .github/workflows/ci.yml`
+
+Expected: tutorial commands match Node 22+, pnpm 11.10.0, and repository scripts.
+
+### Task 3: Write the first Pull Request guide
+
+**Files:**
+- Create: `docs/tutorials/zh-CN/02-first-pull-request.md`
+
+- [ ] **Step 1: Write the contribution workflow**
+
+Cover fork/clone/upstream remotes, branching from `main`, small changes, documentation checks, required verification commands, when to add a changeset, Conventional Commit examples with an English prefix and Chinese subject, pushing, completing the PR template, handling CI/review, and security-reporting boundaries.
+
+- [ ] **Step 2: Cross-check repository contribution requirements**
+
+Run: `rg -n 'changeset|build|typecheck|lint|test|private vulnerability|branch' CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md SECURITY.md`
+
+Expected: every mandatory requirement is represented in the guide.
+
+### Task 4: Write the Protocol integration practice
+
+**Files:**
+- Create: `docs/tutorials/zh-CN/03-protocol-integration.md`
+
+- [ ] **Step 1: Write a template-based integration walkthrough**
+
+Teach copying `packages/protocols/_template`, renaming the package, ABI and fixed-address provenance, typed Handles, `{ type, description }` parameters, Capability/Query decorators, exactly one direct transaction per Capability, pure exhaustive Receipts, exports/composition, tests, live simulation, and changesets.
+
+- [ ] **Step 2: Include a review checklist and explicit anti-patterns**
+
+Call out hand-written ABIs, private keys, zero/multiple direct transactions, RPC use inside Receipts, incomplete Change coverage, guessed token symbols, skipped simulations, and edits to generic core for Protocol-specific behavior.
+
+- [ ] **Step 3: Cross-check the template and ADRs**
+
+Run: `rg -n 'CHANGEME|exactly one|ABI origin|Receipt|ParamsSpec|Handle' packages/protocols/_template docs/adr docs/protocol-onboarding.md`
+
+Expected: guide terminology matches current template and architecture decisions.
+
+### Task 5: Write the AI Agent demo guide
+
+**Files:**
+- Create: `docs/tutorials/zh-CN/04-ai-agent-demo.md`
+
+- [ ] **Step 1: Write the no-private-key MCP path**
+
+Document building the MCP server, configuring its absolute path and RPC environment, starting an MCP client, recording user intent, invoking the four tools in order, comparing ordered Receipt texts, and stopping on every Warning.
+
+- [ ] **Step 2: Write the optional local-fork signer demo**
+
+Use the existing `examples/agent-swap` scripts to separate Agent construction/simulation from the disposable local-fork wallet; state clearly that the bundled Anvil key is public and must never hold real funds.
+
+- [ ] **Step 3: Verify names and scripts**
+
+Run: `rg -n 'discover|load|action|simulate|fork|swap|wallet' docs/mcp-tools.md examples/agent-swap/package.json examples/agent-swap/README.md`
+
+Expected: all tool and script names used by the guide exist.
+
+### Task 6: Write FAQ and wire navigation
+
+**Files:**
+- Create: `docs/tutorials/zh-CN/06-faq.md`
+- Modify: `README.zh-CN.md`
+- Modify: `docs/README.md`
+
+- [ ] **Step 1: Write the FAQ**
+
+Answer setup, RPC, chain support, balance/private-key, build/typecheck, Warning, Capability editing, token identity, Protocol contribution, changeset, MCP path, and production-readiness questions with links to authoritative repository documents.
+
+- [ ] **Step 2: Add navigation links**
+
+Add one beginner-tutorial entry to the Chinese README documentation table and one Chinese tutorial-suite entry to `docs/README.md`.
+
+- [ ] **Step 3: Check local Markdown links**
+
+Run a local script that extracts relative Markdown links from the seven new pages plus the two modified indexes, resolves fragments away, and reports any missing target.
+
+Expected: `0 missing local links`.
+
+### Task 7: Validate the documentation change
+
+**Files:**
+- Verify: all files listed above
+
+- [ ] **Step 1: Run formatting/lint checks**
+
+Run: `pnpm exec biome check docs/tutorials/zh-CN README.zh-CN.md docs/README.md`
+
+Expected: no errors.
+
+- [ ] **Step 2: Run repository checks in required order**
+
+Run:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+MOSS_SKIP_E2E=1 pnpm test
+```
+
+Expected: all commands exit successfully. If dependencies are unavailable, report the exact missing prerequisite and still run link and content checks.
+
+- [ ] **Step 3: Review the diff**
+
+Run: `git diff --check` and `git status --short`.
+
+Expected: no whitespace errors and only the planned documentation files are modified.

--- a/docs/tutorials/zh-CN/01-getting-started.md
+++ b/docs/tutorials/zh-CN/01-getting-started.md
@@ -1,0 +1,173 @@
+# Moss 入门指南
+
+本章通过仓库现有示例理解 Moss 的核心流程和安全模型。开始前请先完成[项目环境配置](./05-environment-setup.md)。
+
+## 1. Moss 解决什么问题
+
+AI Agent 很容易生成“看起来合理”的 calldata，却难以证明交易真正做了什么。Moss 把协议交互封装为自描述的 Capability，并在签名前模拟交易、提取真实 Change、交给 Protocol 解析成 Receipt。
+
+Moss 的边界非常明确：
+
+- 构建未签名交易；
+- 模拟 Capability tree；
+- 验证 Receipt 是否完整、按顺序覆盖观察到的 Change；
+- 不管理私钥；
+- 不签名；
+- 不发送交易。
+
+## 2. 四阶段工作流
+
+```text
+用户意图
+   ↓
+discover → load → action → simulate
+   ↓          ↓          ↓
+候选操作   调用契约   Capability tree
+                         ↓
+                  Warning + Receipt
+```
+
+### discover：发现操作
+
+根据统一的 verb、category 或 Protocol 名称搜索 Capability 和 Query。例如 `swap` 是用户视角的 verb，`clob`、`orderbook` 等细节属于 tag。
+
+### load：加载调用契约
+
+读取操作意图、风险标签和参数契约。每个参数同时包含：
+
+- `type`：JSON Schema、格式、范围、单位和示例；
+- `description`：这个字段在当前操作中的具体用途。
+
+不能根据字段名猜单位。例如 swap 的 `slippage: 50` 表示 50 basis points，也就是 `0.5%`。
+
+### action：查询或构建交易
+
+Query 会立即返回 JSON-safe 数据；写操作会返回一棵 Capability tree。每个 Capability 恰好拥有一笔直接 TransactionNode 和一个 Receipt parser，额外交易属于嵌套 Capability。
+
+### simulate：模拟并验证
+
+模拟器按深度优先顺序执行交易并传递状态，提取按真实顺序排列的 Event 和 native transfer。Protocol 将这些 Change 解析成结构化 Receipt，core 再检查所有原始 Change 是否被完整、按顺序、以相同对象保留。
+
+## 3. 运行 WMON 入门示例
+
+```bash
+pnpm --filter @themoss/example-simple-flow wrap
+```
+
+源码位于 `examples/simple-flow/src/wmon-wrap.ts`。它完成：
+
+```ts
+const candidates = registry.discover({ verb: "wrap" });
+const [operation] = registry.load([{ protocol: "wmon", method: "wrap" }]);
+const capability = await registry.action("wmon", "wrap", ACCOUNT, { amount: "1.5" });
+const outcome = await simulator.simulate(capability);
+```
+
+示例中的 `ACCOUNT` 只是模拟发送方。Moss 会为模拟提供必要的 sender balance override，因此这个地址不需要真实余额。
+
+输出检查重点：
+
+1. `action` 返回 `kind: "capability"`；
+2. 模拟没有 `halted`；
+3. 每个 result 的 `warnings` 都为空；
+4. Receipt 描述的是预期 WMON wrap，而不是其他资产或操作。
+
+## 4. 运行 Kuru swap 示例
+
+```bash
+pnpm --filter @themoss/example-simple-flow swap
+```
+
+该示例先执行 Kuru quote Query，再构建 MON → USDC swap Capability：
+
+```ts
+const quote = await registry.action("kuru", "quote", ACCOUNT, {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1",
+});
+
+const capability = await registry.action("kuru", "swap", ACCOUNT, {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1",
+  slippage: 50,
+});
+```
+
+Kuru 会动态发现候选市场、在链上验证市场、比较直连与经 MON 路径，并在构建 Capability 时重新报价。Agent 不能指定 market address 或注入旧 quote。
+
+## 5. 核心术语
+
+| 术语 | 含义 |
+| --- | --- |
+| Protocol | 某协议的自描述适配器，拥有 ABI、地址、Capability、Query 和 Receipt 语义 |
+| Capability | 一个用户写操作；拥有一笔直接未签名交易、一个 Receipt parser 和可选嵌套 Capability |
+| Query | 只读操作，直接返回 JSON-safe 数据，不生成 Capability |
+| TransactionNode | `from`、`to`、`data`、`value` 组成的未签名交易 |
+| Change | 模拟观察到的原始 Event 或 native MON transfer |
+| Receipt | Protocol 对一笔成功交易的完整、有序语义解释 |
+| Outcome | Receipt 中适合程序检查的结构化结果 |
+| Warning | 回滚、trace、Receipt 或 Change coverage 等失败；出现即停止 |
+
+## 6. 正确处理 Warning
+
+下面任一情况都不能继续到签名方：
+
+- 交易回滚；
+- RPC 无法提供 trace 或精确 Change 顺序；
+- Receipt parser 失败；
+- Receipt 遗漏、复制、替换或重排 Change；
+- 多交易状态无法继续串联。
+
+推荐检查：
+
+```ts
+if (outcome.halted || outcome.results.some(({ warnings }) => warnings.length > 0)) {
+  throw new Error("simulation warning: stop before signing");
+}
+```
+
+不要隐藏 Warning，也不要不改变条件反复重试，希望它自己消失。
+
+## 7. 零 Warning 之后仍要对齐意图
+
+干净模拟证明“观察到的 Change 已被完整解释”，不等于“交易符合用户要求”。仍需逐项比较：
+
+- 操作和 Protocol；
+- sender 与 recipient；
+- token 的明确地址或 `native`；
+- 输入、输出和授权数量；
+- 滑点、价格边界和其他限制；
+- 嵌套 approve 等附加动作；
+- Receipt 的顺序。
+
+如果参数发生变化，重新调用 `action` 和 `simulate`。不能修改旧 Capability tree。
+
+## 8. 通过 library 组装 Moss
+
+最小 composition root 与仓库示例一致：
+
+```ts
+import { Registry } from "@themoss/core";
+import * as erc from "@themoss/erc";
+import * as kuru from "@themoss/protocol-kuru";
+import { createTraceSimulator } from "@themoss/simulator";
+import * as system from "@themoss/system";
+import { monadRuntime } from "@themoss/system";
+
+const runtime = await monadRuntime();
+const registry = new Registry(runtime).use(system, erc, kuru);
+const simulator = createTraceSimulator(runtime, {
+  receipt: (capability, changes) => registry.parseReceipt(capability, changes),
+});
+```
+
+`Registry.use(...)` 选择应用支持的 Protocol module，并递归注入声明的 Protocol 依赖。
+
+## 9. 下一步
+
+- 想让 Agent 调用：阅读 [AI Agent Demo 搭建教程](./04-ai-agent-demo.md)；
+- 想参与项目：阅读 [第一次提交 Pull Request 教程](./02-first-pull-request.md)；
+- 想支持新协议：阅读 [Moss 协议接入实践](./03-protocol-integration.md)；
+- 遇到问题：查看 [FAQ](./06-faq.md)。

--- a/docs/tutorials/zh-CN/02-first-pull-request.md
+++ b/docs/tutorials/zh-CN/02-first-pull-request.md
@@ -1,0 +1,213 @@
+# 第一次提交 Pull Request 教程
+
+本章以一次文档改动为例，完成从同步仓库到提交 PR 的完整流程。代码或 Protocol 改动使用同样流程，但需要更充分的测试和证据。
+
+## 1. 理解 origin 和 upstream
+
+如果 `Wea1her/moss` 是你自己的 fork，推荐配置：
+
+- `origin`：你的 fork，用于推送分支；
+- `upstream`：原项目仓库，用于同步最新 `main`。
+
+查看当前远程：
+
+```bash
+git remote -v
+```
+
+需要时添加 upstream：
+
+```bash
+git remote add upstream https://github.com/nishuzumi/moss.git
+git fetch upstream
+```
+
+如果你直接在 `Wea1her/moss` 协作且它就是目标仓库，可以只保留 `origin`。不要在不确认目标仓库的情况下推送。
+
+## 2. 从最新 main 创建分支
+
+先确保工作区干净：
+
+```bash
+git status
+```
+
+同步并创建分支：
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch -c docs/my-first-contribution
+```
+
+如果需要从 upstream 同步，则使用：
+
+```bash
+git switch main
+git fetch upstream
+git merge --ff-only upstream/main
+git push origin main
+git switch -c docs/my-first-contribution
+```
+
+分支名应简短表达目的，例如：
+
+- `docs/add-mcp-guide`
+- `fix/receipt-error-message`
+- `feat/protocol-example`
+
+## 3. 阅读贡献约束
+
+开始修改前至少阅读：
+
+- `AGENTS.md`：仓库工作约束；
+- `CONTEXT.md`：Moss 领域词汇；
+- `CONTRIBUTING.md`：开发与 PR 要求；
+- 与改动相关的 `docs/adr/`；
+- Protocol 改动还要阅读 `docs/protocol-onboarding.md`。
+
+不要让文档、示例、测试和当前 API 互相矛盾。
+
+## 4. 做一个小而完整的改动
+
+首次贡献推荐选择：
+
+- 修复错字或失效链接；
+- 补充一个可运行示例；
+- 改善错误信息；
+- 为现有行为补测试；
+- 整理 FAQ 或文档导航。
+
+随时查看改动：
+
+```bash
+git status --short
+git diff
+```
+
+不要顺便格式化无关文件，也不要提交本地配置、私钥、构建缓存或临时输出。
+
+## 5. 运行验证
+
+从仓库根目录按顺序运行：
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+MOSS_SKIP_E2E=1 pnpm test
+```
+
+准备正式 PR 时，网络条件允许应再运行完整测试：
+
+```bash
+pnpm test
+```
+
+Protocol 改动还需要 Monad 主网 happy path 的零 Warning 模拟证据。
+
+文档改动至少检查：
+
+```bash
+git diff --check
+```
+
+确认命令、路径、类型名和链接都来自当前仓库实现。
+
+## 6. 判断是否需要 changeset
+
+用户可见 package 行为或发布内容发生变化时，运行：
+
+```bash
+pnpm changeset
+```
+
+选择受影响 package、版本级别并填写面向使用者的说明。纯仓库内部文档、CI 或不参与发布的示例通常不需要 changeset；不确定时在 PR 中说明判断依据。
+
+## 7. 创建提交
+
+暂存前再确认文件范围：
+
+```bash
+git status --short
+git diff --check
+git add docs/path/to/file.md
+git diff --cached
+```
+
+推荐使用 Conventional Commit 风格。类型前缀保持英文，后面的说明可以写中文：
+
+```bash
+git commit -m "docs: 新增 Moss 新手教程"
+```
+
+常见前缀：
+
+- `docs:` 文档；
+- `fix:` 修复；
+- `feat:` 新功能或新 Protocol 能力；
+- `test:` 测试；
+- `refactor:` 不改变外部行为的重构；
+- `chore:` 工具或维护工作。
+
+一个提交应表达一个完整目的。不要把互不相关的修改塞进同一个 commit。
+
+## 8. 推送分支
+
+```bash
+git push -u origin docs/my-first-contribution
+```
+
+如果网络环境需要本地代理，可只为当前命令设置 Git 代理，例如：
+
+```bash
+git -c http.proxy=http://127.0.0.1:8443 -c https.proxy=http://127.0.0.1:8443 push -u origin docs/my-first-contribution
+```
+
+代理协议和地址必须与你本机代理实际配置一致，不要把个人代理配置提交到仓库。
+
+## 9. 填写 Pull Request
+
+打开 GitHub 创建 PR，并按 `.github/PULL_REQUEST_TEMPLATE.md` 填写：
+
+1. **What and why**：改了什么，为什么需要；
+2. **Type of change**：勾选改动类型；
+3. **Framework and package impact**：说明公共类型、package 边界、Capability tree、Change/Receipt 行为，或填写 `none`；
+4. **Verification**：列出真实运行过的命令；
+5. **Protocol changes**：非 Protocol PR 标记 N/A；
+6. **Evidence**：附测试输出、Receipt Outcome、截图或复现步骤。
+
+PR 标题也可以采用同样格式：
+
+```text
+docs: 新增 Moss 新手教程
+```
+
+## 10. 处理 CI 和 Review
+
+CI 会检查无 Git submodule、安装依赖、lint、build、typecheck 和 test。
+
+收到 review 后：
+
+1. 先理解问题和相关架构约束；
+2. 在原分支继续修改；
+3. 重新运行受影响检查；
+4. 提交并 push，PR 会自动更新；
+5. 用证据回复已处理内容。
+
+不要为了让 CI 变绿而删除测试、跳过 Warning、放宽 Receipt coverage 或绕过 ABI 来源规则。
+
+## 11. 安全问题不要发公开 PR
+
+如果发现可能影响用户资金、私钥、模拟证据或 Receipt 验证的漏洞，请按照 `SECURITY.md` 使用 GitHub Private Vulnerability Reporting。不要先开公开 Issue 或 PR 暴露漏洞细节。
+
+## 提交前清单
+
+- [ ] 分支来自最新 `main`；
+- [ ] 只包含本次任务相关文件；
+- [ ] 文档和示例与当前 API 一致；
+- [ ] `build → typecheck → lint → test` 已按顺序运行；
+- [ ] 需要发布的用户可见 package 变更已添加 changeset；
+- [ ] 没有私钥、凭证、个人配置或临时文件；
+- [ ] commit 和 PR 标题清楚表达目的；
+- [ ] PR 模板和验证证据填写完整。

--- a/docs/tutorials/zh-CN/03-protocol-integration.md
+++ b/docs/tutorials/zh-CN/03-protocol-integration.md
@@ -1,0 +1,273 @@
+# Moss 协议接入实践
+
+本章说明如何从官方模板开始接入一个 Monad Protocol。重点不是“能生成 calldata”，而是让地址、ABI、参数、交易树和模拟结果都能被审查与验证。
+
+开始前先阅读 [Protocol onboarding](../../protocol-onboarding.md)、`CONTEXT.md` 和相关 ADR。
+
+## 1. 从模板创建 package
+
+不要手工拼装 package 配置：
+
+```bash
+cp -R packages/protocols/_template packages/protocols/myprotocol
+pnpm install
+```
+
+然后修改 `packages/protocols/myprotocol/package.json`：
+
+```json
+{
+  "name": "@themoss/protocol-myprotocol",
+  "version": "0.0.0",
+  "private": true
+}
+```
+
+开发期间保留 `private: true`。准备发布时再按维护者要求移除。搜索并替换所有占位符：
+
+```bash
+rg -n CHANGEME packages/protocols/myprotocol
+```
+
+## 2. 明确 Protocol 边界
+
+一个 Protocol package 应拥有：
+
+- 协议 ABI 及其来源；
+- 协议独占的固定部署地址及来源；
+- `@Protocol` class；
+- Capability、Query 和参数契约；
+- Receipt parser 与结构化 Outcome；
+- 单元测试、类型 fixture 和主网 happy path；
+- README 中的支持范围、风险和限制。
+
+Protocol 特定逻辑不要塞进 core、simulator 或 MCP 通用传输层。动态 pool、market 和 token 应从链状态或可信候选源发现，而不是不断添加全局常量。
+
+## 3. 建立 ABI 和地址来源
+
+ABI 是安全关键工件。`src/abis/` 中每个 ABI 必须选择一种来源：
+
+1. `compiled`：由 package 中提交的 Solidity source 编译生成；
+2. `explorer`：来自区块浏览器的 verified contract 页面，记录 URL 和日期；
+3. `vendored`：从官方 SDK 或协议仓库完整 vendoring，并可确定性重新生成。
+
+示例头部：
+
+```ts
+// ABI origin: explorer — https://example-explorer/... (retrieved 2026-07-16)
+```
+
+不能凭记忆手写 ABI，也不能手工挑选几个函数伪装成 vendored artifact。生成的 TypeScript ABI 需要保留字面量类型，例如 `as const` 或 `parseAbi(...)`，这样 `Handle<typeof RouterAbi>` 才能获得完整类型推断。
+
+每个固定地址要引用 canonical source，并添加主网 bytecode 检查。固定 token 还要验证预期 metadata。
+
+## 4. 声明自描述 Protocol
+
+模板中的核心形态如下：
+
+```ts
+@Protocol({
+  name: "myprotocol",
+  category: "dex",
+  description: "Describe the Protocol in one sentence for an Agent.",
+  contracts: {
+    router: { abi: RouterAbi, addr: ROUTER_ADDRESS },
+  },
+})
+export class MyProtocol {
+  declare router: Handle<typeof RouterAbi>;
+}
+```
+
+必须给 Handle 提供 ABI 类型参数。`@Protocol` 在运行时注入 Handle，而 `declare` 字段只提供编译期类型，不会生成额外实例字段。
+
+如果依赖 ERC-20 approve、transfer 或其他 Protocol，必须在 Protocol metadata 中显式声明依赖，并使用注入的 typed Protocol reference。不能用隐式注册副作用。
+
+## 5. 定义参数契约
+
+每个字段都使用 `{ type, description }`：
+
+```ts
+const swapParams = {
+  tokenIn: {
+    type: TokenReference,
+    description: "Token supplied to this swap.",
+  },
+  tokenOut: {
+    type: TokenReference,
+    description: "Token requested from this swap.",
+  },
+  amountIn: {
+    type: PositiveDecimalString,
+    description: "Human-readable amount of tokenIn to spend.",
+  },
+  slippage: {
+    type: BasisPoints.default(50),
+    description: "Maximum slippage allowed for this swap.",
+  },
+} satisfies ParamsSpec;
+
+type SwapParams = InferParams<typeof swapParams>;
+```
+
+`type` 描述可复用的值规则，字段 `description` 描述它在当前方法中的用途。不要把两者混为一个模糊字符串，也不要让 Zod object 穿过 MCP 边界。
+
+## 6. 添加 Query
+
+Query 用于读取或报价，不生成 Capability：
+
+```ts
+@Query({ intent: "Quote a swap", params: quoteParams })
+async quote(params: InferParams<typeof quoteParams>) {
+  const raw = await this.router.read.getQuote([/* typed arguments */]);
+  return { amountOut: raw.toString() };
+}
+```
+
+Query 返回值必须 JSON-safe。链上数量通常转为十进制字符串。
+
+写函数的只读预览可以使用 `handle.call.fn(...)`，普通 view/pure 读取使用 `handle.read.fn(...)`。Receipt parser 不允许使用任何 RPC face。
+
+## 7. 添加 Capability
+
+Capability 从用户视角选择统一 verb：
+
+```ts
+@Capability<MyProtocol, typeof swapParams>({
+  intent: "Swap one asset into another",
+  verb: "swap",
+  params: swapParams,
+  receipt: "swapReceipt",
+  risk: ["fundOut", "priceImpact"],
+  tags: ["example"],
+})
+async swap(params: SwapParams) {
+  const transaction = this.router.swap([/* typed arguments */]);
+  return [transaction];
+}
+```
+
+强制规则：
+
+- 每个 Capability 恰好有一笔直接 TransactionNode；
+- 每个 Capability 恰好绑定一个 typed Receipt parser；
+- 额外交易必须由嵌套 Capability 拥有；
+- Capability tree 中的数据必须 JSON-safe；
+- Moss 只返回未签名交易。
+
+如果 ERC-20 swap 需要 approve，调用注入的 ERC Capability，并返回 `[approval, transaction]`。`approval` 是拥有自己交易和 Receipt 的嵌套 Capability；`transaction` 是当前 swap 唯一的直接交易。
+
+## 8. 实现纯 Receipt parser
+
+Receipt 只能根据一笔成功直接交易产生的 immutable ordered Changes 工作：
+
+```ts
+@Receipt()
+swapReceipt(changes: readonly Change[]): ReceiptResult<SwapOutcome> {
+  const parsed = changes.map((change) => {
+    // Decode this exact Change and keep the original object.
+    return {
+      kind: "change" as const,
+      change,
+      data: decodeProtocolFact(change),
+      text: describeProtocolFact(change),
+    };
+  });
+
+  return {
+    kind: "receipt",
+    outcome: buildJsonSafeOutcome(parsed),
+    text: "MyProtocol Swap",
+    changes: parsed,
+  };
+}
+```
+
+上面只展示结构，实际 decoder 必须严格验证 event address、topic、data、次数和语义。
+
+Receipt 必须：
+
+- 保留每个原始 Change 对象；
+- 数量完全一致；
+- 顺序完全一致；
+- 对未知或矛盾 Change 失败；
+- 返回 JSON-safe structured Outcome；
+- 不访问 Runtime、Handle、Query、RPC 或外部状态；
+- 不用计划参数补造模拟中不存在的事实。
+
+Receipt text 用于展示，Outcome 才是 SDK 程序检查的权威结果。
+
+## 9. 导出并加入 composition root
+
+从 package entry point 直接导出稳定 Protocol：
+
+```ts
+export { MyProtocol } from "./my-protocol.js";
+```
+
+应用层显式选择 module：
+
+```ts
+import * as myprotocol from "@themoss/protocol-myprotocol";
+
+const registry = new Registry(runtime).use(system, erc, myprotocol);
+```
+
+实验性 class 保持内部使用。新增 Protocol 通常只修改它自己的 package 和明确的 application composition root。
+
+## 10. 测试要求
+
+至少覆盖：
+
+1. Protocol metadata 和导出可被 Registry 注册；
+2. 正确参数、Handle method 和 Receipt name 的类型推断；
+3. 使用 `@ts-expect-error` 的负面类型 fixture；
+4. Capability 恰好一笔直接交易；
+5. Receipt 保留全部原始 Change 对象和顺序；
+6. 缺失、重复、替换、重排和未知 Change 会失败；
+7. 固定地址有 bytecode，token metadata 正确；
+8. Monad 主网 happy path 模拟为零 Warning。
+
+从根目录运行：
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+MOSS_SKIP_E2E=1 pnpm test
+pnpm test
+```
+
+## 11. 文档和提交
+
+Protocol README 应写明：
+
+- 支持哪些 Capability 和 Query；
+- 合约、市场或资产范围；
+- 参数单位与默认值；
+- 授权、资金流出、价格影响等风险；
+- ABI 和固定地址来源；
+- 已知限制和动态发现方式。
+
+用户可见 package 变更需要：
+
+```bash
+pnpm changeset
+```
+
+PR 中附上主网零 Warning 的模拟证据，并完整填写 Protocol checklist。
+
+## 12. 常见错误
+
+| 错误 | 正确做法 |
+| --- | --- |
+| 凭记忆手写或裁剪 ABI | 使用 compiled、explorer 或完整 vendored 来源 |
+| 在 Agent 或 Protocol 中处理私钥 | 把签名方保持在 Moss 之外 |
+| 一个 Capability 直接创建多笔交易 | 把附加交易放入嵌套 Capability |
+| Receipt 调 RPC 或读取 Capability 参数 | 只解析传入的 ordered Changes |
+| 忽略未知 event | 明确失败，不能静默丢弃 |
+| 用 symbol 猜 token | 使用明确地址或 `native` |
+| 只测 calldata，不测 Receipt | 同时验证树结构、Change coverage 和 Outcome |
+| 为 Protocol 特例修改 generic core | 把协议语义保留在 Protocol package |
+
+提交前逐项对照 [`packages/protocols/_template`](../../../packages/protocols/_template) 的 checklist。

--- a/docs/tutorials/zh-CN/04-ai-agent-demo.md
+++ b/docs/tutorials/zh-CN/04-ai-agent-demo.md
@@ -1,0 +1,248 @@
+# AI Agent Demo 搭建教程
+
+本章搭建两层 Demo：先让 AI Agent 通过 MCP 完成“发现、构建、模拟和审查”，再可选地在一次性 Monad 本地 fork 上体验独立钱包发送。整个过程中，Moss 和 Agent 都不应接触真实私钥。
+
+## 1. 架构和安全边界
+
+```text
+用户请求
+   ↓
+AI Agent ── discover/load/action/simulate ── Moss MCP server
+   ↓                                      ↓
+意图对齐                         未签名 Capability + 模拟证据
+   ↓
+独立钱包或人工审核（Moss 之外）
+```
+
+生产思路中，Agent 只负责记录意图、调用 Moss、处理 Warning 和展示证据。钱包应独立验证 sender、网络和交易树，再由用户决定是否签名。
+
+## 2. 构建 MCP server
+
+在仓库根目录执行：
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+```
+
+server 入口生成在：
+
+```text
+packages/mcp-server/dist/cli.js
+```
+
+## 3. 配置 MCP client
+
+把绝对路径写入支持 MCP stdio server 的 client：
+
+```jsonc
+{
+  "mcpServers": {
+    "moss": {
+      "command": "node",
+      "args": ["/absolute/path/to/moss/packages/mcp-server/dist/cli.js"],
+      "env": {
+        "MOSS_RPC_URL": "https://rpc.monad.xyz"
+      }
+    }
+  }
+}
+```
+
+注意：
+
+- 必须使用绝对路径；
+- 修改配置后重启 MCP client；
+- RPC 必须是 Monad chain ID `143`；
+- 配置中不需要、也不应出现私钥；
+- Moss MCP server 只提供 `discover`、`load`、`action`、`simulate` 四个工具。
+
+## 4. 为 Agent 写清楚操作规则
+
+可以把下面内容加入 Agent system prompt 或项目规则：
+
+```text
+使用 Moss 时：
+1. 先记录用户的操作、资产地址、数量、recipient、限制和 Protocol 约束。
+2. 严格执行 discover → load → action → simulate。
+3. 不猜 method 或参数，不用 token symbol 代替地址。
+4. 不编辑、重排或重建 action 返回的 Capability tree。
+5. 任意 Warning 都立即停止，不交给签名方。
+6. 零 Warning 后，把所有有序 Receipt text 与原始请求逐项对齐。
+7. 永远不请求、读取或保存私钥；Moss 不签名、不发送。
+```
+
+仓库中的完整规则见 [Agent safety rules](../../agent-skill.md)。
+
+## 5. Demo 请求
+
+向 Agent 发出明确请求：
+
+> 使用 Moss 在 Kuru 上模拟把 1 native MON 换成官方 USDC，最大滑点 0.5%。只构建和模拟，不要签名或发送；如果出现任何 Warning 就停止。
+
+Agent 应先记录：
+
+- verb：`swap`；
+- Protocol：`kuru`；
+- tokenIn：`native`；
+- tokenOut：官方 USDC 地址；
+- amountIn：`1`；
+- slippage：`50` basis points；
+- account：用户明确提供的 EVM address。
+
+## 6. 第一步：discover
+
+工具输入：
+
+```json
+{
+  "verb": "swap"
+}
+```
+
+从输出中选择真实返回的 `{ protocol, method }`。不能直接猜 `kuru.swap`，即使之前见过这个名字。
+
+## 7. 第二步：load
+
+```json
+{
+  "items": [
+    { "protocol": "kuru", "method": "swap" },
+    { "protocol": "kuru", "method": "quote" }
+  ]
+}
+```
+
+Agent 要检查：
+
+- method 的 intent 是否符合 swap；
+- risk labels 是否可接受；
+- `tokenIn`、`tokenOut`、`amountIn`、`slippage` 的 type 和 description；
+- `50` 是否确实代表 0.5%，而不是 50%。
+
+## 8. 第三步：action
+
+可以先执行 quote Query。官方 USDC 地址以当前 `@themoss/system` 导出为准；仓库当前示例使用：
+
+```json
+{
+  "protocol": "kuru",
+  "method": "quote",
+  "account": "0xcccccccccccccccccccccccccccccccccccccccc",
+  "params": {
+    "tokenIn": "native",
+    "tokenOut": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+    "amountIn": "1"
+  }
+}
+```
+
+Query 返回 `kind: "query"`，不需要 simulate。
+
+随后构建写 Capability：
+
+```json
+{
+  "protocol": "kuru",
+  "method": "swap",
+  "account": "0xcccccccccccccccccccccccccccccccccccccccc",
+  "params": {
+    "tokenIn": "native",
+    "tokenOut": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+    "amountIn": "1",
+    "slippage": 50
+  }
+}
+```
+
+保存工具返回的完整 Capability tree。不要修改其中的 `from`、`to`、`data`、`value`、params、children 或顺序。
+
+## 9. 第四步：simulate
+
+把 `action` 返回的原始 Capability 原样传入：
+
+```jsonc
+{
+  "capability": {
+    // exact CapabilityNode returned by action
+  }
+}
+```
+
+通过条件必须同时满足：
+
+- `ok` 为真；
+- 没有 `halted`；
+- 每个 result 的 `warnings` 都为空；
+- 每条 ordered Receipt text 都符合原始请求；
+- 没有意外 approve、recipient、token、数量或 Protocol。
+
+MCP 返回的是经过完整 Receipt coverage 验证后的有序文本。library API 还可以取得完整 Change、Receipt tree 和 structured Outcome。
+
+## 10. Agent 最终展示模板
+
+一个合格的 Demo 回复应包含：
+
+```text
+操作：Kuru swap
+发送方：0x...
+输入：1 native MON
+输出资产：USDC 0x...
+滑点上限：50 bps（0.5%）
+模拟：完成，0 Warning
+有序 Receipt：
+1. ...
+2. ...
+结论：Moss 仅构建并模拟了未签名交易，尚未签名或发送。
+```
+
+如果存在 Warning，结论必须改成“停止”，并保留原因供诊断。
+
+## 11. 可选：运行本地 fork 签名 Demo
+
+仓库的 `examples/agent-swap` 把 Agent 和 wallet 分成两个进程。先安装 Monad Foundry：
+
+```bash
+curl -L https://foundry.category.xyz | bash
+foundryup --network monad
+```
+
+启动本地 fork 并给演示账户充值本地余额：
+
+```bash
+pnpm --filter @themoss/example-agent-swap fork
+```
+
+构建、模拟、验证并输出未签名 Capability JSON：
+
+```bash
+pnpm --filter @themoss/example-agent-swap swap -- verified-capability.json
+```
+
+人工检查终端中的 ordered Receipts 和 JSON。确认无 Warning 后，才在本地 fork 发送：
+
+```bash
+pnpm --filter @themoss/example-agent-swap wallet -- send verified-capability.json
+```
+
+检查地址和余额：
+
+```bash
+pnpm --filter @themoss/example-agent-swap wallet -- address
+pnpm --filter @themoss/example-agent-swap wallet -- balance
+```
+
+> [!CAUTION]
+> 示例里的 Anvil 私钥是全世界公开的开发密钥，只能用于一次性本地 fork。绝不能给该地址充值真实资产，也不能把这种内置密钥模式用于生产。
+
+## 12. Demo 验收清单
+
+- [ ] MCP client 能看到四个 Moss 工具；
+- [ ] Agent 在 action 前执行了 discover 和 load；
+- [ ] token 使用明确地址或 `native`；
+- [ ] action 结果没有被修改；
+- [ ] 写操作执行了 simulate；
+- [ ] 任意 Warning 都会停止；
+- [ ] ordered Receipt 与用户意图逐项对齐；
+- [ ] Moss/Agent 未接触真实私钥；
+- [ ] 可选 wallet 只连接本地 chain ID 143 fork。

--- a/docs/tutorials/zh-CN/05-environment-setup.md
+++ b/docs/tutorials/zh-CN/05-environment-setup.md
@@ -1,0 +1,151 @@
+# Moss 项目环境配置指南
+
+本章完成从空目录到可运行 Moss 的环境配置。Moss 当前只支持 Monad 主网，chain ID 为 `143`。
+
+## 1. 准备工具
+
+必须安装：
+
+- Git；
+- Node.js 22 或更高版本；
+- pnpm 11。仓库固定使用 `pnpm@11.10.0`。
+
+检查版本：
+
+```bash
+git --version
+node --version
+corepack --version
+```
+
+推荐让 Corepack 根据仓库的 `packageManager` 字段启用正确的 pnpm：
+
+```bash
+corepack enable
+corepack prepare pnpm@11.10.0 --activate
+pnpm --version
+```
+
+预期 `node --version` 至少为 `v22.x`，`pnpm --version` 为 `11.10.0`。
+
+## 2. 克隆仓库
+
+```bash
+git clone https://github.com/Wea1her/moss.git
+cd moss
+```
+
+确认当前目录正确：
+
+```bash
+git status
+pnpm --version
+```
+
+根目录应该包含 `package.json`、`pnpm-workspace.yaml`、`packages/`、`examples/` 和 `docs/`。
+
+## 3. 安装依赖
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+仓库设置了依赖供应链保护：发布时间不足一天的依赖版本会被拒绝解析。不要为了绕过它而删除 `minimumReleaseAge`。
+
+## 4. 构建和检查
+
+按以下顺序执行：
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+MOSS_SKIP_E2E=1 pnpm test
+```
+
+必须先 `build` 再 `typecheck`，因为 workspace package 的类型会从已经构建的 `dist/*.d.ts` 解析。
+
+`MOSS_SKIP_E2E=1` 会跳过需要访问 Monad 主网的测试，适合首次安装、离线环境或 CI 之外的快速检查。需要完整验证时运行：
+
+```bash
+pnpm test
+```
+
+## 5. 配置 RPC
+
+默认 RPC 是：
+
+```text
+https://rpc.monad.xyz
+```
+
+普通示例不需要 `.env` 文件。可以临时在当前 shell 设置：
+
+```bash
+export MOSS_RPC_URL=https://rpc.monad.xyz
+```
+
+也可以只对一条命令生效：
+
+```bash
+MOSS_RPC_URL=https://rpc.monad.xyz pnpm --filter @themoss/example-simple-flow wrap
+```
+
+如果通过 MCP 使用 Moss，把变量写在 MCP client 配置的 `env` 中，而不是把密钥写进仓库：
+
+```jsonc
+{
+  "mcpServers": {
+    "moss": {
+      "command": "node",
+      "args": ["/absolute/path/to/moss/packages/mcp-server/dist/cli.js"],
+      "env": {
+        "MOSS_RPC_URL": "https://rpc.monad.xyz"
+      }
+    }
+  }
+}
+```
+
+用于模拟的 RPC 必须支持 `debug_traceCall`、call/log evidence、`prestateTracer` state diff 和 state override。只支持普通 `eth_call` 的节点不能完成 Moss 的完整验证流程。
+
+## 6. 运行第一个示例
+
+```bash
+pnpm --filter @themoss/example-simple-flow wrap
+```
+
+这个命令读取 Monad 主网状态，构建并模拟一笔 WMON wrap Capability。它不会签名或广播交易，因此示例账户不需要私钥，也不需要余额。
+
+再运行 Kuru swap：
+
+```bash
+pnpm --filter @themoss/example-simple-flow swap
+```
+
+正常输出会依次展示 Capability/Query 和模拟结果。只要存在 Warning，就应视为失败并停止。
+
+## 7. 可选：本地 Monad fork 环境
+
+只有运行 `examples/agent-swap` 的本地签名演示时，才需要 Monad 版本的 Foundry：
+
+```bash
+curl -L https://foundry.category.xyz | bash
+foundryup --network monad
+anvil --version
+```
+
+这里必须是 Monad build，普通上游 Anvil 不具备示例要求的 Monad gas model、opcode pricing 和 precompile 行为。
+
+## 8. 环境自检清单
+
+- [ ] Node.js 版本不低于 22；
+- [ ] pnpm 版本为 11.10.0；
+- [ ] `pnpm install --frozen-lockfile` 成功；
+- [ ] `pnpm build` 在 `pnpm typecheck` 之前运行；
+- [ ] 离线测试通过；
+- [ ] RPC 报告 chain ID `143`；
+- [ ] 没有把私钥写入 `.env`、MCP 配置或项目代码；
+- [ ] 示例遇到 Warning 会立即停止。
+
+下一步：[Moss 入门指南](./01-getting-started.md)。

--- a/docs/tutorials/zh-CN/06-faq.md
+++ b/docs/tutorials/zh-CN/06-faq.md
@@ -1,0 +1,122 @@
+# 常见问题（FAQ）
+
+## Moss 会签名或发送交易吗？
+
+不会。Moss 只构建和模拟未签名交易。私钥、签名和广播必须位于 Moss 之外的独立钱包边界。
+
+## 当前支持哪些网络？
+
+只支持 Monad 主网，chain ID `143`。Runtime 会拒绝其他 chain ID。`examples/agent-swap` 使用的本地 fork 也必须报告 `143`。
+
+## 运行示例需要账户余额或私钥吗？
+
+不需要。普通示例只模拟交易，默认使用占位账户。模拟器会为 sender 设置 balance override，以回答“交易会做什么”，而不是“账户付不付得起”。
+
+## 项目为什么没有 `.env`？
+
+仓库默认不要求 `.env`。可以在 shell 中设置 `MOSS_RPC_URL`，或在 MCP client 配置的 `env` 中设置。不要把私钥放入 `.env`；Moss 根本不需要私钥。
+
+## Node.js 和 pnpm 用什么版本？
+
+Node.js 22 或更高，pnpm 11；根目录固定 `pnpm@11.10.0`。推荐通过 Corepack 启用仓库指定版本。详见[环境配置指南](./05-environment-setup.md)。
+
+## 为什么 typecheck 前必须先 build？
+
+workspace package 会通过已构建的 `dist/*.d.ts` 解析彼此类型。如果直接 typecheck，可能因为依赖 package 的声明文件尚未生成而失败。
+
+## 如何运行离线测试？
+
+```bash
+MOSS_SKIP_E2E=1 pnpm test
+```
+
+它跳过访问 Monad 主网的 E2E。正式 Protocol PR 仍需要运行主网 happy path 并提供零 Warning 证据。
+
+## 为什么自定义 RPC 无法模拟？
+
+Moss 需要 `debug_traceCall`、call/log evidence、`prestateTracer` state diff 和 state override，并要求能够证明 Change 的精确顺序。有些免费 RPC 会屏蔽 `debug` namespace。优先使用默认的 `https://rpc.monad.xyz`，详见 [ADR 0002](../../adr/0002-simulation-via-debug-tracecall.md)。
+
+## `eth_call` 成功，为什么 Moss 仍然失败？
+
+`eth_call` 只返回函数结果，不能提供完整 logs、call tree、状态差异和多交易串联证据。Moss 宁愿失败，也不会退化为近似模拟。
+
+## Warning 可以忽略吗？
+
+不可以。回滚、trace 失败、Change 顺序不可用、Receipt 失败、coverage mismatch 或状态串联失败都必须停止。不能隐藏 Warning 或继续交给签名方。
+
+## 零 Warning 就代表可以安全签名吗？
+
+不代表。零 Warning 说明观察到的 Change 已被完整、有序地解析。Agent 或用户仍要把 sender、recipient、资产、数量、授权、滑点、Protocol 和全部 Receipt 与原始意图对齐。钱包还要独立审查。
+
+## 可以修改 action 返回的 Capability tree 吗？
+
+不可以。不能手改、重排、删除或重建 tree。如果任何参数变化，重新调用 `action`，然后重新 `simulate`。
+
+## 为什么不能只使用 token symbol？
+
+symbol 不是唯一身份，可能重复或被恶意 token 冒用。跨 MCP 的 token 必须使用明确 EVM address 或 `native`。官方常量可以来自受信任的应用上下文，例如 `@themoss/system`。
+
+## discover、load、action、simulate 能跳过其中一步吗？
+
+写操作不能跳过。先 discover 真实候选，再 load 完整参数契约，action 构建最终 Capability，simulate 验证最终 tree。Query 由 action 直接返回数据，不需要 simulate。
+
+## Capability 和 Transaction 有什么区别？
+
+Capability 表示用户语义操作，包含 metadata、params、Receipt parser 和 children；TransactionNode 只是其中的一笔未签名交易。每个 Capability 恰好拥有一笔直接 TransactionNode，其他交易属于嵌套 Capability。
+
+## Receipt text 和 Outcome 哪个更可靠？
+
+SDK 中 structured Outcome 是程序检查的权威结果，text 主要用于展示。MCP 为了缩小 Agent 接口，只暴露经过完整 coverage 验证的 ordered Receipt texts 和 Warnings。
+
+## 如何接入一个新 Protocol？
+
+从 `packages/protocols/_template` 复制，不要手工创建骨架。然后完成 ABI/地址来源、typed Handle、参数契约、Capability/Query、纯 Receipt、类型 fixture、单元测试和主网 happy path。详见[协议接入实践](./03-protocol-integration.md)。
+
+## ABI 可以手写吗？
+
+不可以。必须使用 ADR 0007 定义的 compiled、explorer 或 vendored 来源，并记录 provenance。ABI 决定 calldata 和资金流，是安全关键工件。
+
+## 为什么 Receipt 不能查询 RPC？
+
+Receipt 必须是对当前交易实际 Change 的纯解释。读取外部状态会让结果依赖模拟之外的信息，也可能用“计划发生的事实”掩盖缺失证据。
+
+## 什么改动需要 changeset？
+
+用户可见 package 的发布行为发生变化时需要 `pnpm changeset`。纯内部文档、CI 或不发布示例通常不需要；具体以 [CONTRIBUTING.md](../../../CONTRIBUTING.md) 和维护者 review 为准。
+
+## MCP client 找不到 Moss server 怎么办？
+
+依次检查：
+
+1. 是否已经运行 `pnpm build`；
+2. `packages/mcp-server/dist/cli.js` 是否存在；
+3. MCP 配置是否使用绝对路径；
+4. JSON/JSONC 格式是否正确；
+5. 修改配置后是否重启 client；
+6. 启动 client 的用户是否有权读取仓库；
+7. Node.js 是否为 22+。
+
+## Kuru quote 和 swap 为什么可能不一致？
+
+quote 是建议性结果。构建 Capability 时 Kuru 会重新发现、验证和报价，避免旧报价或被操纵的 market/path 进入请求。实际限制由最终 Capability 中重新计算的链上保护决定。
+
+## 可以把普通 Foundry Anvil 用于 Agent swap Demo 吗？
+
+不推荐。该示例要求 Monad build 的 gas model、opcode pricing、precompile 和 tracing 行为。请执行 `foundryup --network monad`。
+
+## Moss 可以直接用于生产资金吗？
+
+当前不可以。项目 README 明确标记它是未经审计的 Alpha 软件。即使未来完成审计，也仍需独立钱包审查、严格的限额、监控和应用侧安全控制。
+
+## 发现安全漏洞应该去哪里报告？
+
+按照 [SECURITY.md](../../../SECURITY.md) 使用 GitHub Private Vulnerability Reporting。不要在公开 Issue、讨论或 PR 中披露漏洞细节。
+
+## 还有哪些权威资料？
+
+- [MCP 工具契约](../../mcp-tools.md)
+- [Agent 安全规则](../../agent-skill.md)
+- [Protocol onboarding](../../protocol-onboarding.md)
+- [安全模型](../../../SECURITY.md)
+- [架构决策](../../adr/)
+- [Moss 领域词汇](../../../CONTEXT.md)

--- a/docs/tutorials/zh-CN/README.md
+++ b/docs/tutorials/zh-CN/README.md
@@ -1,0 +1,42 @@
+# Moss 新手教程
+
+这套教程面向第一次接触 Moss、Monad 或 Agent 链上交互的开发者。完成后，你将能够运行 Moss、理解它的安全边界、提交第一个 Pull Request、接入一个 Protocol，并搭建一个不接触私钥的 AI Agent Demo。
+
+> [!WARNING]
+> Moss 是未经审计的 Alpha 软件。它只构建和模拟未签名交易，**永不签名、永不发送**。任何 Warning 都必须停止，不能把交易交给签名方。
+
+## 推荐学习顺序
+
+| 顺序 | 教程 | 你会学到什么 |
+| --- | --- | --- |
+| 1 | [Moss 项目环境配置指南](./05-environment-setup.md) | 安装 Node.js、pnpm，克隆、构建并检查项目 |
+| 2 | [Moss 入门指南](./01-getting-started.md) | 理解并运行 `discover → load → action → simulate` |
+| 3 | [AI Agent Demo 搭建教程](./04-ai-agent-demo.md) | 通过 MCP 使用 Moss，并在本地 fork 上体验签名边界 |
+| 4 | [第一次提交 Pull Request 教程](./02-first-pull-request.md) | 从分支、验证、提交到发起 PR 的完整流程 |
+| 5 | [Moss 协议接入实践](./03-protocol-integration.md) | 从官方模板开发 Protocol、Capability、Query 和 Receipt |
+| 6 | [常见问题（FAQ）](./06-faq.md) | 快速排查环境、RPC、模拟、贡献和安全问题 |
+
+## 先记住四条规则
+
+1. 写操作必须完整执行 `discover → load → action → simulate`。
+2. 不猜方法名、参数单位或 token 身份；以 `load` 返回的契约为准。
+3. 不修改、重排或手工重建 `action` 返回的 Capability tree。
+4. 出现任意 Warning 就停止；零 Warning 后仍要把有序 Receipt 与用户原始意图逐项对齐。
+
+## 适合哪些读者
+
+- 想快速运行 Moss 示例的 Web3 初学者；
+- 想让 AI Agent 安全构建 Monad 交易的应用开发者；
+- 想为 Moss 增加文档、示例或 Protocol adapter 的贡献者；
+- 想了解 Capability tree、模拟证据和 Receipt 验证模型的 TypeScript 开发者。
+
+建议具备基础命令行、Git 和 TypeScript 阅读能力。不要求准备真实私钥，也不要求账户持有 MON。
+
+## 权威参考
+
+- [中文 README](../../../README.zh-CN.md)
+- [MCP 工具契约](../../mcp-tools.md)
+- [Protocol 接入指南](../../protocol-onboarding.md)
+- [Agent 安全规则](../../agent-skill.md)
+- [安全模型](../../../SECURITY.md)
+- [领域词汇](../../../CONTEXT.md)


### PR DESCRIPTION
## What and why

<!-- What does this PR change, and what user or Protocol problem does it solve? Link the issue when one exists. -->

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

<!-- Public types, package boundaries, Capability tree, Change/Receipt behavior, or "none". -->

## Verification

- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] User-facing package changes include a changeset
- [ ] Docs and examples match the implemented API

### Protocol changes

<!-- Mark N/A for non-Protocol PRs. -->

- [ ] Parameters separate reusable Zod value types from field-purpose descriptions
- [ ] Every Capability owns one direct TransactionNode and one typed Receipt
- [ ] Receipt tests preserve every original Change object in exact length and order
- [ ] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [ ] Fixed addresses and ABIs include sources and verification
- [ ] A live Monad happy path returns zero Warnings

## Evidence

<!-- Relevant output, structured Receipt Outcomes, screenshots, or reproduction steps. -->
