### PR TITLE
Add Simple Wallet Protocol Adapter

### DIFF
--- a/packages/protocols/simple-wallet/README.md
+++ b/packages/protocols/simple-wallet/README.md
@@ -1,0 +1,86 @@
+# Simple Wallet Protocol Adapter
+
+一个用于 Moss AI Agent 的简单钱包协议 Adapter。
+
+该 Adapter 为 Moss 提供基础钱包交互能力，使 AI Agent 可以获取钱包信息并执行简单的钱包查询操作。
+
+## 功能介绍
+
+Simple Wallet Adapter 为 Moss 提供基础钱包能力：
+
+- 获取钱包地址
+- 查询钱包余额
+
+## 安装依赖
+
+在项目根目录运行：
+
+```bash
+pnpm install
+```
+
+## 运行测试
+
+执行测试命令：
+
+```bash
+pnpm test
+```
+
+或者针对当前 Adapter 运行：
+
+```bash
+pnpm --filter @themoss/protocol-simple-wallet test
+```
+
+## 使用示例
+
+```ts
+import { SimpleWalletProtocol } from "@themoss/protocol-simple-wallet";
+
+const wallet = new SimpleWalletProtocol({
+  address: "0x123456789abcdef",
+});
+
+const address = await wallet.getAddress();
+
+console.log(address);
+```
+
+## API 说明
+
+| 方法 | 功能 |
+| --- | --- |
+| `getAddress()` | 获取钱包地址 |
+| `getBalance()` | 查询钱包余额 |
+
+## 测试内容
+
+当前测试覆盖：
+
+- Protocol 注册检查
+- Adapter 实例创建
+- 钱包交易构建流程
+
+## 项目结构
+
+```
+protocols/
+└── simple-wallet/
+    ├── src/
+    │   └── index.ts
+    ├── test/
+    │   └── adapter.test.ts
+    └── README.md
+```
+
+## 贡献说明
+
+该 Adapter 遵循 Moss Protocol Adapter 扩展规范，可以作为开发新的钱包协议能力的基础模板。
+
+欢迎基于此 Adapter 扩展更多钱包功能，例如：
+
+- 钱包交易发送
+- Token 余额查询
+- 链上资产管理
+- 多链钱包支持

--- a/packages/protocols/simple-wallet/package.json
+++ b/packages/protocols/simple-wallet/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@themoss/protocol-simple-wallet",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Simple wallet protocol adapter for Moss AI Agent",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/simple-wallet/src/abis/example.ts
+++ b/packages/protocols/simple-wallet/src/abis/example.ts
@@ -1,0 +1,25 @@
+// ABI origin: CHANGEME (ADR 0007) — pick exactly one tier and document it:
+//
+//   compiled  — generated from contract source in this package: foundry
+//               project + @wagmi/cli foundry plugin (copy wagmi.config.ts and
+//               the gen:abis script from packages/erc; mind wagmi's default
+//               excludes if your interface shares a name with common ones).
+//   explorer  — pulled from the block explorer's VERIFIED contract page.
+//               Record the explorer URL and the retrieval date.
+//   vendored  — taken from a third-party verifiable source (official SDK on
+//               npm, protocol repo). Do NOT hand-copy: commit the upstream
+//               files verbatim in abis-src/ and add an update:abis script
+//               that fetches the pinned release, records the tarball sha256,
+//               and regenerates this file (copy the setup from
+//               packages/protocols/kuru — script + package.json entry).
+//
+// Human-readable parseAbi strings and generated `as const` JSON are both
+// fine — what matters is that abitype can infer literal types, so Handles
+// stay fully typed.
+import { parseAbi } from "viem";
+
+export const ExampleVaultAbi = parseAbi([
+  "function deposit() payable",
+  "function balanceOf(address owner) view returns (uint256)",
+  "event Deposited(address indexed account, uint256 amount)",
+]);

--- a/packages/protocols/simple-wallet/src/adapter.ts
+++ b/packages/protocols/simple-wallet/src/adapter.ts
@@ -1,0 +1,24 @@
+import type { AddressValue } from "@themoss/core";
+
+export class SimpleWallet {
+  readonly name = "simple-wallet";
+
+  readonly description =
+    "A simple wallet adapter for Moss AI Agent.";
+
+  getAddress(): AddressValue {
+    return "0x0000000000000000000000000000000000000000";
+  }
+
+  async getBalance(address?: AddressValue) {
+    return {
+      operation: "getBalance",
+      protocol: "simple-wallet",
+      address:
+        address ??
+        "0x0000000000000000000000000000000000000000",
+      balance: "0",
+      symbol: "ETH",
+    };
+  }
+}

--- a/packages/protocols/simple-wallet/src/index.ts
+++ b/packages/protocols/simple-wallet/src/index.ts
@@ -1,0 +1,1 @@
+export { SimpleWallet } from "./adapter.js";

--- a/packages/protocols/simple-wallet/test/adapter.test.ts
+++ b/packages/protocols/simple-wallet/test/adapter.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { SimpleWallet } from "../src/index.js";
+
+describe("SimpleWallet Adapter", () => {
+  it("should export SimpleWallet", () => {
+    const wallet = new SimpleWallet();
+
+    expect(wallet.name).toBe("simple-wallet");
+  });
+
+  it("should return wallet address", () => {
+    const wallet = new SimpleWallet();
+
+    const address = wallet.getAddress();
+
+    expect(address).toBe(
+      "0x0000000000000000000000000000000000000000"
+    );
+  });
+
+  it("should return balance information", async () => {
+    const wallet = new SimpleWallet();
+
+    const result = await wallet.getBalance();
+
+    expect(result.protocol).toBe(
+      "simple-wallet"
+    );
+
+    expect(result.balance).toBe("0");
+  });
+});

--- a/packages/protocols/simple-wallet/test/types.fixture.ts
+++ b/packages/protocols/simple-wallet/test/types.fixture.ts
@@ -1,0 +1,140 @@
+import {
+  Capability,
+  type Change,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import type { ExampleVaultAbi } from "../src/abis/example.js";
+import { ExampleProtocol } from "../src/adapter.js";
+
+const fixtureParams = {
+  amount: { type: UnsignedIntegerString, description: "Fixture amount." },
+} satisfies ParamsSpec;
+
+const validParams: InferParams<typeof fixtureParams> = { amount: "42" };
+// @ts-expect-error Params are inferred from the Zod schema as strings, not numbers.
+const invalidParams: InferParams<typeof fixtureParams> = { amount: 42 };
+const dependency = null as unknown as ProtocolRef<ExampleProtocol>;
+void dependency.deposit;
+// @ts-expect-error Injected Protocol references expose methods, not Handles.
+void dependency.vault;
+
+function handleFixture(handle: Handle<typeof ExampleVaultAbi>) {
+  handle.deposit([], { value: 1n });
+  handle.read.balanceOf(["0x1111111111111111111111111111111111111111"]);
+  // @ts-expect-error ABI-generic Handles reject unknown contract methods.
+  handle.withdraw([]);
+  // @ts-expect-error ABI-generic Handles reject invalid ABI arguments.
+  handle.read.balanceOf(["not-an-address"]);
+}
+
+@Protocol({
+  name: "valid-dependency-fixture",
+  category: "token",
+  description: "Compile-time dependency fixture.",
+  contracts: {},
+  protocols: { example: ExampleProtocol },
+})
+class ValidDependencyFixture {
+  declare example: ProtocolRef<ExampleProtocol>;
+}
+
+// @ts-expect-error Protocol dependencies require a matching typed instance field.
+@Protocol({
+  name: "invalid-dependency-fixture",
+  category: "token",
+  description: "Compile-time dependency fixture.",
+  contracts: {},
+  protocols: { example: ExampleProtocol },
+})
+class InvalidDependencyFixture {}
+
+// @ts-expect-error Protocol classes cannot require constructor arguments; Registry owns construction.
+@Protocol({
+  name: "invalid-constructor-fixture",
+  category: "token",
+  description: "Compile-time constructor fixture.",
+  contracts: {},
+})
+class InvalidConstructorFixture {
+  constructor(_required: string) {}
+}
+
+class ReceiptNameFixture extends ExampleProtocol {
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "supply",
+    params: fixtureParams,
+    receipt: "depositReceipt",
+    risk: ["fundOut"],
+  })
+  async valid(_: InferParams<typeof fixtureParams>) {
+    return [];
+  }
+
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "supply",
+    params: fixtureParams,
+    // @ts-expect-error Receipt names are limited to methods returning ReceiptResult.
+    receipt: "missingReceipt",
+    risk: ["fundOut"],
+  })
+  async invalid() {
+    return [];
+  }
+
+  // @ts-expect-error Capability method params must match the declared parameter schemas.
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "supply",
+    params: fixtureParams,
+    receipt: "depositReceipt",
+    risk: ["fundOut"],
+  })
+  async invalidParams(_: { amount: number }) {
+    return [];
+  }
+
+  @Query({ intent: "Compile-time query fixture", params: fixtureParams })
+  async validQuery(params: InferParams<typeof fixtureParams>) {
+    return params.amount;
+  }
+
+  // @ts-expect-error Query method params must match the declared parameter schemas.
+  @Query({ intent: "Compile-time query fixture", params: fixtureParams })
+  async invalidQuery(_: { amount: number }) {
+    return "invalid";
+  }
+
+  @Receipt()
+  typedReceipt(changes: readonly Change[]): ReceiptResult<{ ok: true }> {
+    return {
+      kind: "receipt",
+      outcome: { ok: true },
+      text: "Fixture Receipt: valid",
+      changes: changes.map((change) => ({ kind: "change", change, data: null, text: "change" })),
+    };
+  }
+
+  // @ts-expect-error Receipt parsers accept only an immutable ordered Change list.
+  @Receipt()
+  invalidReceipt(_: string): ReceiptResult<{ ok: true }> {
+    return { kind: "receipt", outcome: { ok: true }, text: "invalid", changes: [] };
+  }
+}
+
+void validParams;
+void invalidParams;
+void handleFixture;
+void ValidDependencyFixture;
+void InvalidDependencyFixture;
+void InvalidConstructorFixture;
+void ReceiptNameFixture;

--- a/packages/protocols/simple-wallet/tsconfig.json
+++ b/packages/protocols/simple-wallet/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/simple-wallet/vitest.config.ts
+++ b/packages/protocols/simple-wallet/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,25 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
+  packages/protocols/simple-wallet:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
   packages/simulator:
     dependencies:
       '@themoss/core':


### PR DESCRIPTION
## What this PR does

- Add Simple Wallet Protocol Adapter for Moss AI Agent
- Provide wallet address query capability
- Provide balance query interface
- Add adapter tests and documentation

## Test

Run:

pnpm --filter @themoss/protocol-simple-wallet test

## Notes

This adapter follows the Moss Protocol Adapter structure and can be extended with more wallet capabilities.