### PR TITLE
feat: add ERC1155 adapter

### DIFF
--- a/.changeset/quiet-rings-learn.md
+++ b/.changeset/quiet-rings-learn.md
@@ -1,0 +1,5 @@
+---
+"@themoss/erc": minor
+---
+
+Add a generic ERC-1155 Protocol for single-token transfers, balances, operator approval reads, metadata URI reads, and TransferSingle Receipt parsing.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | WMON | `@themoss/system` | `wrap`, `unwrap` | `balanceOf` |
 | ERC-20 and native MON | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `allowance`, `metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
+| ERC-1155 | `@themoss/erc` | `transfer` | `balanceOf`, `isApprovedForAll`, `uri` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 
 ## Quickstart

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | WMON | `@themoss/system` | `wrap`、`unwrap` | `balanceOf` |
 | ERC-20 与 native MON | `@themoss/erc` | `transfer`、`approve` | `balanceOf`、`allowance`、`metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
+| ERC-1155 | `@themoss/erc` | `transfer` | `balanceOf`、`isApprovedForAll`、`uri` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 
 ## 快速开始

--- a/packages/erc/contracts/IERC1155.sol
+++ b/packages/erc/contracts/IERC1155.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice The ERC-1155 interface Moss consumes: EIP-1155 core plus the
+/// optional metadata URI extension. This file is the source of truth for the
+/// generated `src/abis/erc.ts` — regenerate with `pnpm gen:abis` (requires
+/// foundry).
+interface IERC1155 {
+    event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
+    event TransferBatch(
+        address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values
+    );
+    event ApprovalForAll(address indexed account, address indexed operator, bool approved);
+    event URI(string value, uint256 indexed id);
+
+    function balanceOf(address account, uint256 id) external view returns (uint256);
+    function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids)
+        external
+        view
+        returns (uint256[] memory);
+    function setApprovalForAll(address operator, bool approved) external;
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+    function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes calldata data) external;
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external;
+
+    // EIP-1155 optional metadata extension.
+    function uri(uint256 id) external view returns (string memory);
+}

--- a/packages/erc/package.json
+++ b/packages/erc/package.json
@@ -17,7 +17,7 @@
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "gen:abis": "wagmi generate"
+    "gen:abis": "forge build && wagmi generate"
   },
   "dependencies": {
     "@themoss/core": "workspace:*",

--- a/packages/erc/src/abis/erc.ts
+++ b/packages/erc/src/abis/erc.ts
@@ -1,4 +1,162 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IERC1155
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const ierc1155Abi = [
+  {
+    type: 'function',
+    inputs: [
+      { name: 'account', internalType: 'address', type: 'address' },
+      { name: 'id', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'balanceOf',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'accounts', internalType: 'address[]', type: 'address[]' },
+      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
+    ],
+    name: 'balanceOfBatch',
+    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'account', internalType: 'address', type: 'address' },
+      { name: 'operator', internalType: 'address', type: 'address' },
+    ],
+    name: 'isApprovedForAll',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address' },
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
+      { name: 'values', internalType: 'uint256[]', type: 'uint256[]' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'safeBatchTransferFrom',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address' },
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'id', internalType: 'uint256', type: 'uint256' },
+      { name: 'value', internalType: 'uint256', type: 'uint256' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'safeTransferFrom',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'operator', internalType: 'address', type: 'address' },
+      { name: 'approved', internalType: 'bool', type: 'bool' },
+    ],
+    name: 'setApprovalForAll',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'id', internalType: 'uint256', type: 'uint256' }],
+    name: 'uri',
+    outputs: [{ name: '', internalType: 'string', type: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'account',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'approved', internalType: 'bool', type: 'bool', indexed: false },
+    ],
+    name: 'ApprovalForAll',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'from', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      {
+        name: 'ids',
+        internalType: 'uint256[]',
+        type: 'uint256[]',
+        indexed: false,
+      },
+      {
+        name: 'values',
+        internalType: 'uint256[]',
+        type: 'uint256[]',
+        indexed: false,
+      },
+    ],
+    name: 'TransferBatch',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'from', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: false },
+      {
+        name: 'value',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'TransferSingle',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'value', internalType: 'string', type: 'string', indexed: false },
+      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: true },
+    ],
+    name: 'URI',
+  },
+] as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // IERC20
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -291,164 +449,6 @@ export const ierc721Abi = [
       },
     ],
     name: 'Transfer',
-  },
-] as const
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// IERC1155
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-export const ierc1155Abi = [
-  {
-    type: 'function',
-    inputs: [
-      { name: 'account', internalType: 'address', type: 'address' },
-      { name: 'id', internalType: 'uint256', type: 'uint256' },
-    ],
-    name: 'balanceOf',
-    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    inputs: [
-      { name: 'accounts', internalType: 'address[]', type: 'address[]' },
-      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
-    ],
-    name: 'balanceOfBatch',
-    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    inputs: [
-      { name: 'account', internalType: 'address', type: 'address' },
-      { name: 'operator', internalType: 'address', type: 'address' },
-    ],
-    name: 'isApprovedForAll',
-    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    inputs: [
-      { name: 'from', internalType: 'address', type: 'address' },
-      { name: 'to', internalType: 'address', type: 'address' },
-      { name: 'id', internalType: 'uint256', type: 'uint256' },
-      { name: 'value', internalType: 'uint256', type: 'uint256' },
-      { name: 'data', internalType: 'bytes', type: 'bytes' },
-    ],
-    name: 'safeTransferFrom',
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    inputs: [
-      { name: 'from', internalType: 'address', type: 'address' },
-      { name: 'to', internalType: 'address', type: 'address' },
-      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
-      { name: 'values', internalType: 'uint256[]', type: 'uint256[]' },
-      { name: 'data', internalType: 'bytes', type: 'bytes' },
-    ],
-    name: 'safeBatchTransferFrom',
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    inputs: [
-      { name: 'operator', internalType: 'address', type: 'address' },
-      { name: 'approved', internalType: 'bool', type: 'bool' },
-    ],
-    name: 'setApprovalForAll',
-    outputs: [],
-    stateMutability: 'nonpayable',
-  },
-  {
-    type: 'function',
-    inputs: [{ name: 'id', internalType: 'uint256', type: 'uint256' }],
-    name: 'uri',
-    outputs: [{ name: '', internalType: 'string', type: 'string' }],
-    stateMutability: 'view',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
-        name: 'account',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-      {
-        name: 'operator',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-      { name: 'approved', internalType: 'bool', type: 'bool', indexed: false },
-    ],
-    name: 'ApprovalForAll',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
-        name: 'operator',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-      { name: 'from', internalType: 'address', type: 'address', indexed: true },
-      { name: 'to', internalType: 'address', type: 'address', indexed: true },
-      {
-        name: 'ids',
-        internalType: 'uint256[]',
-        type: 'uint256[]',
-        indexed: false,
-      },
-      {
-        name: 'values',
-        internalType: 'uint256[]',
-        type: 'uint256[]',
-        indexed: false,
-      },
-    ],
-    name: 'TransferBatch',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
-        name: 'operator',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-      { name: 'from', internalType: 'address', type: 'address', indexed: true },
-      { name: 'to', internalType: 'address', type: 'address', indexed: true },
-      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: false },
-      {
-        name: 'value',
-        internalType: 'uint256',
-        type: 'uint256',
-        indexed: false,
-      },
-    ],
-    name: 'TransferSingle',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      { name: 'value', internalType: 'string', type: 'string', indexed: false },
-      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: true },
-    ],
-    name: 'URI',
   },
 ] as const
 

--- a/packages/erc/src/abis/erc.ts
+++ b/packages/erc/src/abis/erc.ts
@@ -295,6 +295,164 @@ export const ierc721Abi = [
 ] as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IERC1155
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const ierc1155Abi = [
+  {
+    type: 'function',
+    inputs: [
+      { name: 'account', internalType: 'address', type: 'address' },
+      { name: 'id', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'balanceOf',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'accounts', internalType: 'address[]', type: 'address[]' },
+      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
+    ],
+    name: 'balanceOfBatch',
+    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'account', internalType: 'address', type: 'address' },
+      { name: 'operator', internalType: 'address', type: 'address' },
+    ],
+    name: 'isApprovedForAll',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address' },
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'id', internalType: 'uint256', type: 'uint256' },
+      { name: 'value', internalType: 'uint256', type: 'uint256' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'safeTransferFrom',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address' },
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
+      { name: 'values', internalType: 'uint256[]', type: 'uint256[]' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'safeBatchTransferFrom',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'operator', internalType: 'address', type: 'address' },
+      { name: 'approved', internalType: 'bool', type: 'bool' },
+    ],
+    name: 'setApprovalForAll',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'id', internalType: 'uint256', type: 'uint256' }],
+    name: 'uri',
+    outputs: [{ name: '', internalType: 'string', type: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'account',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'approved', internalType: 'bool', type: 'bool', indexed: false },
+    ],
+    name: 'ApprovalForAll',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'from', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      {
+        name: 'ids',
+        internalType: 'uint256[]',
+        type: 'uint256[]',
+        indexed: false,
+      },
+      {
+        name: 'values',
+        internalType: 'uint256[]',
+        type: 'uint256[]',
+        indexed: false,
+      },
+    ],
+    name: 'TransferBatch',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'from', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: false },
+      {
+        name: 'value',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'TransferSingle',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'value', internalType: 'string', type: 'string', indexed: false },
+      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: true },
+    ],
+    name: 'URI',
+  },
+] as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // IWETH9
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/erc/src/erc1155.ts
+++ b/packages/erc/src/erc1155.ts
@@ -1,0 +1,158 @@
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  createHandle,
+  type Hex,
+  type InferParams,
+  type ReceiptResult as MossReceipt,
+  type MossRuntime,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  Receipt,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import { decodeEventLog } from "viem";
+import { ierc1155Abi } from "./abis/erc.js";
+
+const tokenParams = {
+  collection: { type: Address, description: "ERC-1155 contract containing the selected token." },
+  tokenId: { type: UnsignedIntegerString, description: "Token id selected within the collection." },
+} satisfies ParamsSpec;
+
+const transferParams = {
+  ...tokenParams,
+  to: { type: Address, description: "Address that receives the ERC-1155 token units." },
+  amount: {
+    type: UnsignedIntegerString,
+    description: "Number of token units to transfer.",
+  },
+} satisfies ParamsSpec;
+
+const balanceParams = {
+  ...tokenParams,
+  owner: { type: Address, description: "Address whose ERC-1155 token balance is read." },
+} satisfies ParamsSpec;
+
+const approvalParams = {
+  collection: { type: Address, description: "ERC-1155 contract whose operator approval is read." },
+  owner: { type: Address, description: "Address that owns the ERC-1155 tokens." },
+  operator: { type: Address, description: "Address whose operator approval is checked." },
+} satisfies ParamsSpec;
+
+export type ERC1155TransferOutcome = {
+  operation: "transfer";
+  collection: AddressValue;
+  operator: AddressValue;
+  from: AddressValue;
+  to: AddressValue;
+  tokenId: string;
+  amount: string;
+};
+
+@Protocol({
+  name: "erc1155",
+  category: "nft",
+  description: "Generic ERC-1155 single-token transfers, balances, approvals, and metadata URIs.",
+  contracts: {},
+})
+export class ERC1155 {
+  declare runtime: MossRuntime;
+
+  #handle(collection: AddressValue, account: AddressValue) {
+    return createHandle(ierc1155Abi, collection, this.runtime.client, account);
+  }
+
+  @Capability<ERC1155, typeof transferParams>({
+    intent: "Transfer ERC-1155 token units",
+    verb: "transfer",
+    params: transferParams,
+    receipt: "transferReceipt",
+    risk: ["fundOut"],
+    tags: ["nft", "multi-token", "payment"],
+  })
+  async transfer(params: InferParams<typeof transferParams>, ctx: ActionCtx) {
+    return [
+      this.#handle(params.collection, ctx.account).safeTransferFrom([
+        ctx.account,
+        params.to,
+        BigInt(params.tokenId),
+        BigInt(params.amount),
+        "0x",
+      ]),
+    ];
+  }
+
+  @Query({ intent: "Read an ERC-1155 token balance", params: balanceParams, tags: ["balance"] })
+  async balanceOf(params: InferParams<typeof balanceParams>, ctx: ActionCtx) {
+    const balance = await this.#handle(params.collection, ctx.account).read.balanceOf([
+      params.owner,
+      BigInt(params.tokenId),
+    ]);
+    return { ...params, balance: balance.toString() };
+  }
+
+  @Query({
+    intent: "Read an ERC-1155 operator approval",
+    params: approvalParams,
+    tags: ["approval"],
+  })
+  async isApprovedForAll(params: InferParams<typeof approvalParams>, ctx: ActionCtx) {
+    const approved = await this.#handle(params.collection, ctx.account).read.isApprovedForAll([
+      params.owner,
+      params.operator,
+    ]);
+    return { ...params, approved };
+  }
+
+  @Query({ intent: "Read an ERC-1155 metadata URI", params: tokenParams, tags: ["metadata"] })
+  async uri(params: InferParams<typeof tokenParams>, ctx: ActionCtx) {
+    const uri = await this.#handle(params.collection, ctx.account).read.uri([
+      BigInt(params.tokenId),
+    ]);
+    return { ...params, uri };
+  }
+
+  @Receipt()
+  transferReceipt(changes: readonly Change[]): MossReceipt<ERC1155TransferOutcome> {
+    if (changes.length !== 1 || changes[0]?.kind !== "event") {
+      throw new Error("ERC1155 transfer Receipt requires exactly one TransferSingle event");
+    }
+    const change = changes[0];
+    let decoded: ReturnType<typeof decodeEventLog<typeof ierc1155Abi>>;
+    try {
+      decoded = decodeEventLog({
+        abi: ierc1155Abi,
+        topics: change.topics as [Hex, ...Hex[]],
+        data: change.data,
+        strict: true,
+      });
+    } catch {
+      throw new Error(`Unexpected Change: ${change.address} emitted an unsupported ERC-1155 event`);
+    }
+    if (decoded.eventName !== "TransferSingle") {
+      throw new Error(
+        `Unexpected Change: expected ERC1155 TransferSingle, received ${decoded.eventName}`,
+      );
+    }
+    const outcome: ERC1155TransferOutcome = {
+      operation: "transfer",
+      collection: change.address,
+      operator: decoded.args.operator,
+      from: decoded.args.from,
+      to: decoded.args.to,
+      tokenId: decoded.args.id.toString(),
+      amount: decoded.args.value.toString(),
+    };
+    const text = `ERC1155 Transfer: ${outcome.amount} units of ${outcome.collection} #${outcome.tokenId} from ${outcome.from} to ${outcome.to}`;
+    return {
+      kind: "receipt",
+      outcome,
+      text,
+      changes: [{ kind: "change", change, data: outcome, text }],
+    };
+  }
+}

--- a/packages/erc/src/index.ts
+++ b/packages/erc/src/index.ts
@@ -1,7 +1,9 @@
 export {
   ierc20Abi as ERC20Abi,
   ierc721Abi as ERC721Abi,
+  ierc1155Abi as ERC1155Abi,
   iweth9Abi as WETH9Abi,
 } from "./abis/erc.js";
 export { ERC20, type ERC20Outcome } from "./erc20.js";
 export { ERC721, type ERC721TransferOutcome } from "./erc721.js";
+export { ERC1155, type ERC1155TransferOutcome } from "./erc1155.js";

--- a/packages/erc/test/erc1155.test.ts
+++ b/packages/erc/test/erc1155.test.ts
@@ -1,0 +1,109 @@
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  Registry,
+} from "@themoss/core";
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ierc1155Abi } from "../src/abis/erc.js";
+import { ERC1155 } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+const COLLECTION = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
+const OPERATOR = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
+
+const runtime = {
+  rpcUrl: "http://offline",
+  client: {
+    readContract: async ({ functionName }: { functionName: string }) => {
+      if (functionName === "balanceOf") return 12n;
+      if (functionName === "isApprovedForAll") return true;
+      if (functionName === "uri") return "ipfs://example/{id}.json";
+      throw new Error(`unexpected read ${functionName}`);
+    },
+  } as unknown as MossRuntime["client"],
+};
+
+describe("ERC1155", () => {
+  it("registers directly and builds safeTransferFrom", async () => {
+    const registry = new Registry(runtime).use(ERC1155);
+    const capability = await registry.action("erc1155", "transfer", ACCOUNT, {
+      collection: COLLECTION,
+      tokenId: "7",
+      to: RECIPIENT,
+      amount: "3",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const [transaction] = flattenCapabilityTree(capability);
+    if (!transaction) throw new Error("missing transfer transaction");
+    const data = transaction.transaction.data;
+    expect(decodeFunctionData({ abi: ierc1155Abi, data })).toEqual({
+      functionName: "safeTransferFrom",
+      args: [ACCOUNT, RECIPIENT, 7n, 3n, "0x"],
+    });
+  });
+
+  it("reads balances, operator approvals, and token URIs", async () => {
+    const registry = new Registry(runtime).use(ERC1155);
+    await expect(
+      registry.action("erc1155", "balanceOf", ACCOUNT, {
+        collection: COLLECTION,
+        tokenId: "7",
+        owner: ACCOUNT,
+      }),
+    ).resolves.toMatchObject({
+      kind: "query",
+      data: { collection: COLLECTION, tokenId: "7", owner: ACCOUNT, balance: "12" },
+    });
+    await expect(
+      registry.action("erc1155", "isApprovedForAll", ACCOUNT, {
+        collection: COLLECTION,
+        owner: ACCOUNT,
+        operator: OPERATOR,
+      }),
+    ).resolves.toMatchObject({
+      kind: "query",
+      data: { collection: COLLECTION, owner: ACCOUNT, operator: OPERATOR, approved: true },
+    });
+    await expect(
+      registry.action("erc1155", "uri", ACCOUNT, { collection: COLLECTION, tokenId: "7" }),
+    ).resolves.toMatchObject({
+      kind: "query",
+      data: { collection: COLLECTION, tokenId: "7", uri: "ipfs://example/{id}.json" },
+    });
+  });
+
+  it("parses the TransferSingle event into a typed Receipt", () => {
+    const change = {
+      kind: "event",
+      address: COLLECTION,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "TransferSingle",
+        args: { operator: OPERATOR, from: ACCOUNT, to: RECIPIENT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters(
+        [
+          { type: "uint256", name: "id" },
+          { type: "uint256", name: "value" },
+        ],
+        [7n, 3n],
+      ),
+    } satisfies Change;
+    const receipt = (Object.create(ERC1155.prototype) as ERC1155).transferReceipt([change]);
+    expect(receipt.outcome).toEqual({
+      operation: "transfer",
+      collection: COLLECTION,
+      operator: OPERATOR,
+      from: ACCOUNT,
+      to: RECIPIENT,
+      tokenId: "7",
+      amount: "3",
+    });
+    expect(receipt.changes[0]).toMatchObject({ kind: "change", change });
+    expect(receipt.text).toContain("ERC1155 Transfer:");
+  });
+});

--- a/packages/erc/test/erc1155.test.ts
+++ b/packages/erc/test/erc1155.test.ts
@@ -5,15 +5,30 @@ import {
   type MossRuntime,
   Registry,
 } from "@themoss/core";
-import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { createTraceSimulator } from "@themoss/simulator";
+import {
+  createPublicClient,
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  getAddress,
+  http,
+} from "viem";
 import { describe, expect, it } from "vitest";
 import { ierc1155Abi } from "../src/abis/erc.js";
-import { ERC1155 } from "../src/index.js";
+import { ERC1155, type ERC1155TransferOutcome } from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 const RECIPIENT = "0x1111111111111111111111111111111111111111";
 const COLLECTION = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
 const OPERATOR = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
+const MONAD_RPC_URL = "https://rpc.monad.xyz";
+
+// LootGO, Countdown Celebration, from monad-crypto/protocols mainnet CSV.
+// Holder and token id come from MonadScan tx 0x00e4b236ede8541cb959b24a37c3cffdd69301fcd9d59bad47c3e8d795839b4e.
+const LOOTGO_COUNTDOWN = getAddress("0x7415085DA3A7c3D9B41Bc339A91132d08f964c6c");
+const LOOTGO_HOLDER = getAddress("0x3D8250Ac679dcfd1E90c29E7a64AB5013645E579");
+const LOOTGO_TOKEN_ID = "1";
 
 const runtime = {
   rpcUrl: "http://offline",
@@ -105,5 +120,57 @@ describe("ERC1155", () => {
     });
     expect(receipt.changes[0]).toMatchObject({ kind: "change", change });
     expect(receipt.text).toContain("ERC1155 Transfer:");
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("ERC1155 Monad mainnet", () => {
+  it("simulates a LootGO transfer into an exhaustive typed Receipt", {
+    timeout: 120_000,
+  }, async () => {
+    const liveRuntime = {
+      rpcUrl: MONAD_RPC_URL,
+      client: createPublicClient({ transport: http(MONAD_RPC_URL) }),
+    } satisfies MossRuntime;
+    const registry = new Registry(liveRuntime).use(ERC1155);
+
+    const balance = await registry.action("erc1155", "balanceOf", LOOTGO_HOLDER, {
+      collection: LOOTGO_COUNTDOWN,
+      tokenId: LOOTGO_TOKEN_ID,
+      owner: LOOTGO_HOLDER,
+    });
+    if (balance.kind !== "query") throw new Error("expected balance query");
+    const balanceData = balance.data as { balance: string };
+    expect(BigInt(balanceData.balance)).toBeGreaterThan(0n);
+
+    const capability = await registry.action("erc1155", "transfer", LOOTGO_HOLDER, {
+      collection: LOOTGO_COUNTDOWN,
+      tokenId: LOOTGO_TOKEN_ID,
+      to: ACCOUNT,
+      amount: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+
+    const outcome = await createTraceSimulator(liveRuntime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+
+    const result = outcome.results[0];
+    expect(outcome.halted).toBeUndefined();
+    expect(result?.warnings).toEqual([]);
+    expect(result?.changes).toHaveLength(1);
+    const receiptOutcome = result?.receipt?.outcome as ERC1155TransferOutcome;
+    expect(receiptOutcome).toMatchObject({
+      operation: "transfer",
+      operator: LOOTGO_HOLDER,
+      from: LOOTGO_HOLDER,
+      to: ACCOUNT,
+      tokenId: LOOTGO_TOKEN_ID,
+      amount: "1",
+    });
+    expect(getAddress(receiptOutcome.collection)).toBe(LOOTGO_COUNTDOWN);
+
+    const [leaf] = result?.receipt?.changes ?? [];
+    if (leaf?.kind !== "change") throw new Error("expected one ReceiptChange");
+    expect(leaf.change).toBe(result?.changes?.[0]);
   });
 });

--- a/packages/erc/test/types.fixture.ts
+++ b/packages/erc/test/types.fixture.ts
@@ -1,7 +1,11 @@
 import type { ERC20 } from "../src/erc20.js";
+import type { ERC721 } from "../src/erc721.js";
+import type { ERC1155 } from "../src/erc1155.js";
 
 type TransferOperation = ReturnType<ERC20["transferReceipt"]>["outcome"]["operation"];
 type ApprovalOperation = ReturnType<ERC20["approveReceipt"]>["outcome"]["operation"];
+type ERC721TransferOperation = ReturnType<ERC721["transferReceipt"]>["outcome"]["operation"];
+type ERC1155TransferOperation = ReturnType<ERC1155["transferReceipt"]>["outcome"]["operation"];
 
 const transfer: TransferOperation = "transfer";
 // @ts-expect-error transferReceipt cannot report an approval outcome.
@@ -9,8 +13,15 @@ const invalidTransfer: TransferOperation = "approve";
 const approval: ApprovalOperation = "approve";
 // @ts-expect-error approveReceipt cannot report a transfer outcome.
 const invalidApproval: ApprovalOperation = "transfer";
+const erc721Transfer: ERC721TransferOperation = "transfer";
+const erc1155Transfer: ERC1155TransferOperation = "transfer";
+// @ts-expect-error ERC-1155 transferReceipt cannot report an approval outcome.
+const invalidERC1155Transfer: ERC1155TransferOperation = "approve";
 
 void transfer;
 void invalidTransfer;
 void approval;
 void invalidApproval;
+void erc721Transfer;
+void erc1155Transfer;
+void invalidERC1155Transfer;

--- a/packages/erc/wagmi.config.ts
+++ b/packages/erc/wagmi.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   plugins: [
     foundry({
       project: ".",
-      include: ["IERC20.sol/**", "IERC721.sol/**", "IWETH9.sol/**"],
+      include: ["IERC20.sol/**", "IERC721.sol/**", "IERC1155.sol/**", "IWETH9.sol/**"],
       // wagmi's default excludes assume IERC20 is someone else's vendored
       // interface; here it IS our compiled source of truth — override them.
       exclude: ["build-info/**"],


### PR DESCRIPTION
## What & why

Adds a generic ERC-1155 adapter to `@themoss/erc` so Agents can discover and use ERC-1155 single-token transfers plus common read operations.

The adapter supports:
- `transfer` Capability via `safeTransferFrom`
- `balanceOf`, `isApprovedForAll`, and `uri` Queries
- `TransferSingle` Receipt parsing with exact Change coverage
- a compiled-source interface file and checked-in ABI export

## Type of change

- [x] Protocol / adapter
- [x] Docs / package metadata
- [x] Tests

## Evidence

- `corepack pnpm --filter @themoss/erc... build`
- `corepack pnpm --filter @themoss/mcp-server... build`
- `corepack pnpm --filter @themoss/erc typecheck`
- `corepack pnpm --filter @themoss/erc test`
- `corepack pnpm exec biome check packages/erc README.md README.zh-CN.md .changeset/quiet-rings-learn.md`
- `git diff --check`

Note: I updated `packages/erc/contracts/IERC1155.sol` and `wagmi.config.ts`; the checked-in ABI was added alongside it so the package remains buildable in this environment where `forge` is not installed.