### PR TITLE
docs: add beginner simple-flow workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Build must precede typecheck because workspace packages resolve generated declar
 | [MCP tool contracts](./docs/mcp-tools.md) | Inputs and outputs of the four MCP tools |
 | [Protocol onboarding](./docs/protocol-onboarding.md) | Build and submit a Protocol package |
 | [Agent safety rules](./docs/agent-skill.md) | Mandatory simulation and intent-alignment rules |
+| [Simple-flow examples](./examples/simple-flow/README.md) | Run the smallest real workflow and map it to the four Moss stages |
 | [Agent swap example](./examples/agent-swap/README.md) | Separate Agent and signer on a local Monad fork |
 | [Architecture decisions](./docs/adr/) | Current design decisions and trade-offs |
 | [Domain language](./CONTEXT.md) | Shared framework vocabulary |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,6 +136,7 @@ workspace package 的类型来自构建产物，因此必须先 build 再 typech
 | [MCP 工具契约](./docs/mcp-tools.md) | 四个 MCP 工具的输入输出 |
 | [Protocol 接入指南](./docs/protocol-onboarding.md) | 开发并提交一个 Protocol 包 |
 | [Agent 安全规则](./docs/agent-skill.md) | 强制模拟与意图对齐规则 |
+| [Simple-flow 示例](./examples/simple-flow/README.md) | 运行最小真实流程，并对应理解 Moss 的四个阶段 |
 | [Agent swap 示例](./examples/agent-swap/README.md) | 在本地 Monad fork 上分离 Agent 与签名方 |
 | [架构决策](./docs/adr/) | 当前设计与取舍 |
 | [领域词汇](./CONTEXT.md) | framework 统一语言 |

--- a/examples/simple-flow/README.md
+++ b/examples/simple-flow/README.md
@@ -38,8 +38,12 @@ examples read current Monad mainnet state.
 
 ## The workflow
 
-The examples start after an application or Agent has already recorded the
-user's request. Moss does not turn natural language into an intent by itself.
+For the WMON example, the recorded user request is:
+
+> Wrap 1.5 MON into WMON for this account.
+
+The examples start after an application or Agent has recorded the user's
+request. Moss does not turn natural language into an intent by itself.
 
 ```text
 Recorded user request

--- a/examples/simple-flow/README.md
+++ b/examples/simple-flow/README.md
@@ -1,10 +1,8 @@
 # Moss simple-flow examples
 
 This directory contains two small, runnable examples for the current Moss
-workflow. They read live Monad mainnet state, but they only build and simulate
+workflow. They read live Monad mainnet state, but only build and simulate
 **unsigned** transactions.
-
-Moss never asks for a private key, signs a transaction, or sends a transaction.
 
 ## Before you run
 
@@ -19,15 +17,17 @@ The examples use the default Monad RPC unless `MOSS_RPC_URL` is set. You may
 optionally set `MOSS_ACCOUNT` to the address whose transactions should be
 simulated; otherwise the examples use a placeholder address.
 
-## Run an example
+## Run the examples
 
-Run the smallest complete workflow:
+Run the complete WMON workflow in
+[`src/wmon-wrap.ts`](./src/wmon-wrap.ts):
 
 ```bash
 pnpm --filter @themoss/example-simple-flow wrap
 ```
 
-Run a Kuru MON-to-USDC quote and swap simulation:
+Run the Kuru MON-to-USDC quote and swap simulation in
+[`src/kuru-swap.ts`](./src/kuru-swap.ts):
 
 ```bash
 pnpm --filter @themoss/example-simple-flow swap
@@ -42,9 +42,6 @@ For the WMON example, the recorded user request is:
 
 > Wrap 1.5 MON into WMON for this account.
 
-The examples start after an application or Agent has recorded the user's
-request. Moss does not turn natural language into an intent by itself.
-
 ```text
 Recorded user request
         |
@@ -54,7 +51,7 @@ Find matching Capability or Query coordinates
         |
         v
 load
-Read the selected operation's intent, risks, and parameter contract
+Read the selected operation contract
         |
         v
 action
@@ -62,135 +59,22 @@ Run a Query or build an unsigned Capability tree
         |
         v
 simulate
-Execute the Capability tree against current chain state
+Check the Capability against current chain state
         |
         v
-Receipt texts and Warnings
-        |
-        v
-User or Agent compares the evidence with the original request
-        |
-        v
-Optional wallet review and signing outside Moss
+Receipt / Warning
 ```
+
+## Safety boundary
+
+These examples do not ask for a private key, sign a transaction, or send a
+transaction. `action` builds an unsigned Capability tree, and `simulate` checks
+it before any optional wallet review outside Moss.
 
 A Warning is a stop signal. Do not hand a Capability tree to a signer when
-simulation halts or produces any Warning.
+simulation halts or produces any Warning. After a clean simulation, compare the
+Receipt with the original user request before considering a signature.
 
-## `wrap`: the complete four-stage example
+For the full step-by-step Registry API tutorial and detailed workflow
+explanations, continue with [Getting started](../../docs/getting-started.md).
 
-`src/wmon-wrap.ts` is the smallest example that explicitly shows every Moss
-stage.
-
-### 1. Discover
-
-```ts
-registry.discover({ verb: "wrap" });
-```
-
-`discover` returns small coordinates describing available operations. It helps
-the caller select an operation, but does not return a full parameter schema or
-construct a transaction.
-
-### 2. Load
-
-```ts
-registry.load([{ protocol: "wmon", method: "wrap" }]);
-```
-
-`load` returns the selected operation's intent, risk labels, and parameter
-declarations. Read these contracts before supplying values to `action`; do not
-guess units or field meanings from parameter names.
-
-### 3. Action
-
-```ts
-const capability = await registry.action("wmon", "wrap", ACCOUNT, {
-  amount: "1.5",
-});
-```
-
-For a write operation, `action` returns a Capability tree. Each Capability owns
-one direct unsigned transaction and one named Receipt parser. The returned tree
-is not signed, sent, or safe to edit by hand.
-
-### 4. Simulate
-
-```ts
-const outcome = await simulator.simulate(capability);
-```
-
-`simulate` executes the Capability tree against current chain state. It returns
-transaction results, Warnings, and verified Receipts.
-
-A clean result requires both of the following:
-
-- `outcome.halted` is not set;
-- every result has an empty `warnings` array.
-
-Only then should an Agent or user compare the ordered Receipt text with the
-original request before optional wallet review.
-
-## `swap`: quote, Capability, and simulation
-
-`src/kuru-swap.ts` demonstrates a Kuru MON-to-USDC flow.
-
-It first runs a read-only Query:
-
-```ts
-const quote = await registry.action("kuru", "quote", ACCOUNT, {
-  tokenIn: NATIVE,
-  tokenOut: USDC_ADDRESS,
-  amountIn: "1",
-});
-```
-
-A Query returns data immediately and never creates a transaction.
-
-The example then builds a swap Capability:
-
-```ts
-const capability = await registry.action("kuru", "swap", ACCOUNT, {
-  tokenIn: NATIVE,
-  tokenOut: USDC_ADDRESS,
-  amountIn: "1",
-  slippage: 50,
-});
-```
-
-Finally, it simulates that Capability and stops if a Warning appears.
-
-This script starts from a known Kuru method to keep the code small. To see
-`discover` and `load` used with the Kuru swap itself, continue with the
-[Getting started guide](../../docs/getting-started.md).
-
-## Expected console structure
-
-The wrap example prints these stages:
-
-```text
-1. discover
-2. load
-3. action
-4. simulate
-```
-
-After a clean simulation, it prints Receipt text and reminds the caller to
-compare the Receipt with the user's intent before signing.
-
-The swap example prints:
-
-```text
-quote
-capability
-simulation
-```
-
-Neither output means that a transaction was sent. They describe a simulated
-result only.
-
-## Continue learning
-
-- [Getting started](../../docs/getting-started.md) rebuilds the full workflow one stage at a time.
-- [MCP tools reference](../../docs/mcp-tools.md) documents `discover`, `load`, `action`, and `simulate`.
-- [Agent safety rules](../../docs/agent-skill.md) explains mandatory simulation, Warning handling, and intent alignment.

--- a/examples/simple-flow/README.md
+++ b/examples/simple-flow/README.md
@@ -1,0 +1,192 @@
+# Moss simple-flow examples
+
+This directory contains two small, runnable examples for the current Moss
+workflow. They read live Monad mainnet state, but they only build and simulate
+**unsigned** transactions.
+
+Moss never asks for a private key, signs a transaction, or sends a transaction.
+
+## Before you run
+
+Use Node.js 22+ and pnpm 11+.
+
+```bash
+pnpm install
+pnpm build
+```
+
+The examples use the default Monad RPC unless `MOSS_RPC_URL` is set. You may
+optionally set `MOSS_ACCOUNT` to the address whose transactions should be
+simulated; otherwise the examples use a placeholder address.
+
+## Run an example
+
+Run the smallest complete workflow:
+
+```bash
+pnpm --filter @themoss/example-simple-flow wrap
+```
+
+Run a Kuru MON-to-USDC quote and swap simulation:
+
+```bash
+pnpm --filter @themoss/example-simple-flow swap
+```
+
+The exact quote, Receipt text, and simulation result can change because the
+examples read current Monad mainnet state.
+
+## The workflow
+
+The examples start after an application or Agent has already recorded the
+user's request. Moss does not turn natural language into an intent by itself.
+
+```text
+Recorded user request
+        |
+        v
+discover
+Find matching Capability or Query coordinates
+        |
+        v
+load
+Read the selected operation's intent, risks, and parameter contract
+        |
+        v
+action
+Run a Query or build an unsigned Capability tree
+        |
+        v
+simulate
+Execute the Capability tree against current chain state
+        |
+        v
+Receipt texts and Warnings
+        |
+        v
+User or Agent compares the evidence with the original request
+        |
+        v
+Optional wallet review and signing outside Moss
+```
+
+A Warning is a stop signal. Do not hand a Capability tree to a signer when
+simulation halts or produces any Warning.
+
+## `wrap`: the complete four-stage example
+
+`src/wmon-wrap.ts` is the smallest example that explicitly shows every Moss
+stage.
+
+### 1. Discover
+
+```ts
+registry.discover({ verb: "wrap" });
+```
+
+`discover` returns small coordinates describing available operations. It helps
+the caller select an operation, but does not return a full parameter schema or
+construct a transaction.
+
+### 2. Load
+
+```ts
+registry.load([{ protocol: "wmon", method: "wrap" }]);
+```
+
+`load` returns the selected operation's intent, risk labels, and parameter
+declarations. Read these contracts before supplying values to `action`; do not
+guess units or field meanings from parameter names.
+
+### 3. Action
+
+```ts
+const capability = await registry.action("wmon", "wrap", ACCOUNT, {
+  amount: "1.5",
+});
+```
+
+For a write operation, `action` returns a Capability tree. Each Capability owns
+one direct unsigned transaction and one named Receipt parser. The returned tree
+is not signed, sent, or safe to edit by hand.
+
+### 4. Simulate
+
+```ts
+const outcome = await simulator.simulate(capability);
+```
+
+`simulate` executes the Capability tree against current chain state. It returns
+transaction results, Warnings, and verified Receipts.
+
+A clean result requires both of the following:
+
+- `outcome.halted` is not set;
+- every result has an empty `warnings` array.
+
+Only then should an Agent or user compare the ordered Receipt text with the
+original request before optional wallet review.
+
+## `swap`: quote, Capability, and simulation
+
+`src/kuru-swap.ts` demonstrates a Kuru MON-to-USDC flow.
+
+It first runs a read-only Query:
+
+```ts
+const quote = await registry.action("kuru", "quote", ACCOUNT, {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1",
+});
+```
+
+A Query returns data immediately and never creates a transaction.
+
+The example then builds a swap Capability:
+
+```ts
+const capability = await registry.action("kuru", "swap", ACCOUNT, {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1",
+  slippage: 50,
+});
+```
+
+Finally, it simulates that Capability and stops if a Warning appears.
+
+This script starts from a known Kuru method to keep the code small. To see
+`discover` and `load` used with the Kuru swap itself, continue with the
+[Getting started guide](../../docs/getting-started.md).
+
+## Expected console structure
+
+The wrap example prints these stages:
+
+```text
+1. discover
+2. load
+3. action
+4. simulate
+```
+
+After a clean simulation, it prints Receipt text and reminds the caller to
+compare the Receipt with the user's intent before signing.
+
+The swap example prints:
+
+```text
+quote
+capability
+simulation
+```
+
+Neither output means that a transaction was sent. They describe a simulated
+result only.
+
+## Continue learning
+
+- [Getting started](../../docs/getting-started.md) rebuilds the full workflow one stage at a time.
+- [MCP tools reference](../../docs/mcp-tools.md) documents `discover`, `load`, `action`, and `simulate`.
+- [Agent safety rules](../../docs/agent-skill.md) explains mandatory simulation, Warning handling, and intent alignment.


### PR DESCRIPTION
## What and why

Adds a beginner-facing guide beside `examples/simple-flow` and links to it from both documentation indexes. It explains the current `discover → load → action → simulate` workflow through the runnable WMON wrap example, and distinguishes read-only Queries, unsigned Capability trees, verified Receipts, and stop-on-Warning behavior.

This resolves the gap identified in #55: new contributors could see individual concepts, but the simple-flow directory did not explain how they work together in a real workflow.

Closes #55

## Type of change

- [x] Documentation / example

## Framework and package impact

None. This PR documents the existing public API and does not change framework behavior or package boundaries.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] User-facing package changes include a changeset (not applicable: documentation only)
- [x] Docs and examples match the implemented API

### Protocol changes

N/A — no Protocol behavior changes.

## Evidence

Ran both examples against Monad mainnet state:

- `pnpm --filter @themoss/example-simple-flow wrap`
- `pnpm --filter @themoss/example-simple-flow swap`

Both simulations completed with zero Warnings. No private key, signing, or transaction submission was used.