### PR TITLE
feat(erc): add ERC-1155 protocol and ordered receipts

### DIFF
--- a/.changeset/fuzzy-tokens-transfer.md
+++ b/.changeset/fuzzy-tokens-transfer.md
@@ -1,0 +1,5 @@
+---
+"@themoss/erc": minor
+---
+
+Add an address-free ERC-1155 Protocol with typed transfer and balance methods, generated standard ABI exports, and exhaustive ordered TransferSingle/TransferBatch Receipts.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | WMON | `@themoss/system` | `wrap`, `unwrap` | `balanceOf` |
 | ERC-20 and native MON | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `allowance`, `metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
+| ERC-1155 | `@themoss/erc` | `transfer` | `balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+
+ERC-1155 `transfer` accepts a collection, token ID, amount, and recipient. Token IDs and amounts are base-10 uint256 strings, including zero. The Capability builds one `safeTransferFrom`; batch transfer construction is not currently exposed. Receipts still decode both `TransferSingle` and `TransferBatch` Changes without aggregating or reordering their items.
 
 ## Quickstart
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,10 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | WMON | `@themoss/system` | `wrap`、`unwrap` | `balanceOf` |
 | ERC-20 与 native MON | `@themoss/erc` | `transfer`、`approve` | `balanceOf`、`allowance`、`metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
+| ERC-1155 | `@themoss/erc` | `transfer` | `balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+
+ERC-1155 `transfer` 接收 collection、token ID、amount 和 recipient。token ID 与 amount 使用十进制 uint256 字符串（允许零）。该 Capability 只构建一笔 `safeTransferFrom`，目前不暴露批量转账构建；Receipt 仍会解析 `TransferSingle` 和 `TransferBatch` Change，并保留批量条目的原始顺序，不做聚合。
 
 ## 快速开始
 

--- a/packages/erc/contracts/IERC1155.sol
+++ b/packages/erc/contracts/IERC1155.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice The EIP-1155 core interface consumed by Moss. This contract is the
+/// source of truth for the generated `src/abis/erc.ts` ABI.
+interface IERC1155 {
+    event TransferSingle(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256 id,
+        uint256 value
+    );
+    event TransferBatch(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256[] ids,
+        uint256[] values
+    );
+    event ApprovalForAll(address indexed account, address indexed operator, bool approved);
+    event URI(string value, uint256 indexed id);
+
+    function balanceOf(address account, uint256 id) external view returns (uint256);
+    function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids)
+        external
+        view
+        returns (uint256[] memory);
+    function setApprovalForAll(address operator, bool approved) external;
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    ) external;
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external;
+}

--- a/packages/erc/src/abis/erc.ts
+++ b/packages/erc/src/abis/erc.ts
@@ -1,4 +1,155 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IERC1155
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const ierc1155Abi = [
+  {
+    type: 'function',
+    inputs: [
+      { name: 'account', internalType: 'address', type: 'address' },
+      { name: 'id', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'balanceOf',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'accounts', internalType: 'address[]', type: 'address[]' },
+      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
+    ],
+    name: 'balanceOfBatch',
+    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'account', internalType: 'address', type: 'address' },
+      { name: 'operator', internalType: 'address', type: 'address' },
+    ],
+    name: 'isApprovedForAll',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address' },
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'ids', internalType: 'uint256[]', type: 'uint256[]' },
+      { name: 'values', internalType: 'uint256[]', type: 'uint256[]' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'safeBatchTransferFrom',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address' },
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'id', internalType: 'uint256', type: 'uint256' },
+      { name: 'value', internalType: 'uint256', type: 'uint256' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'safeTransferFrom',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'operator', internalType: 'address', type: 'address' },
+      { name: 'approved', internalType: 'bool', type: 'bool' },
+    ],
+    name: 'setApprovalForAll',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'account',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'approved', internalType: 'bool', type: 'bool', indexed: false },
+    ],
+    name: 'ApprovalForAll',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'from', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      {
+        name: 'ids',
+        internalType: 'uint256[]',
+        type: 'uint256[]',
+        indexed: false,
+      },
+      {
+        name: 'values',
+        internalType: 'uint256[]',
+        type: 'uint256[]',
+        indexed: false,
+      },
+    ],
+    name: 'TransferBatch',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'from', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: false },
+      {
+        name: 'value',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'TransferSingle',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'value', internalType: 'string', type: 'string', indexed: false },
+      { name: 'id', internalType: 'uint256', type: 'uint256', indexed: true },
+    ],
+    name: 'URI',
+  },
+] as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // IERC20
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/erc/src/erc1155.ts
+++ b/packages/erc/src/erc1155.ts
@@ -1,0 +1,212 @@
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  createHandle,
+  type Hex,
+  type InferParams,
+  type ReceiptResult as MossReceipt,
+  type MossRuntime,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  Receipt,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import { decodeEventLog } from "viem";
+import { ierc1155Abi } from "./abis/erc.js";
+
+const MAX_UINT256 = (1n << 256n) - 1n;
+
+const ERC1155Uint256String = UnsignedIntegerString.refine((value) => {
+  try {
+    return BigInt(value) <= MAX_UINT256;
+  } catch {
+    return false;
+  }
+}, "Expected an integer no greater than uint256 max.").describe(
+  "A base-10 uint256 integer string, from 0 through 2^256 - 1.",
+);
+
+const erc1155TransferParams = {
+  collection: { type: Address, description: "Collection containing the requested token." },
+  tokenId: { type: ERC1155Uint256String, description: "Token selected within the collection." },
+  amount: { type: ERC1155Uint256String, description: "Number of token units to transfer." },
+  to: { type: Address, description: "Address that receives the token units." },
+} satisfies ParamsSpec;
+
+const erc1155BalanceParams = {
+  collection: { type: Address, description: "Collection whose balance is requested." },
+  tokenId: { type: ERC1155Uint256String, description: "Token selected within the collection." },
+  owner: { type: Address, description: "Address whose token balance is read." },
+} satisfies ParamsSpec;
+
+export type ERC1155TransferItem = {
+  tokenId: string;
+  amount: string;
+};
+
+export type ERC1155Outcome =
+  | {
+      operation: "transfer";
+      event: "TransferSingle";
+      collection: AddressValue;
+      operator: AddressValue;
+      from: AddressValue;
+      to: AddressValue;
+      tokenId: string;
+      amount: string;
+    }
+  | {
+      operation: "transfer";
+      event: "TransferBatch";
+      collection: AddressValue;
+      operator: AddressValue;
+      from: AddressValue;
+      to: AddressValue;
+      items: readonly ERC1155TransferItem[];
+    };
+
+export type ERC1155TransferOutcome = Extract<ERC1155Outcome, { event: "TransferSingle" }>;
+
+@Protocol({
+  name: "erc1155",
+  category: "nft",
+  description: "Generic ERC-1155 transfers, balances, and ordered transfer evidence.",
+  contracts: {},
+})
+export class ERC1155 {
+  declare runtime: MossRuntime;
+
+  #handle(collection: AddressValue, account: AddressValue) {
+    return createHandle(ierc1155Abi, collection, this.runtime.client, account);
+  }
+
+  @Capability<ERC1155, typeof erc1155TransferParams>({
+    intent: "Transfer ERC-1155 token units",
+    verb: "transfer",
+    params: erc1155TransferParams,
+    receipt: "transferReceipt",
+    risk: ["fundOut"],
+    tags: ["nft", "payment"],
+  })
+  async transfer(params: InferParams<typeof erc1155TransferParams>, ctx: ActionCtx) {
+    return [
+      this.#handle(params.collection, ctx.account).safeTransferFrom([
+        ctx.account,
+        params.to,
+        BigInt(params.tokenId),
+        BigInt(params.amount),
+        "0x",
+      ]),
+    ];
+  }
+
+  @Query({
+    intent: "Read an ERC-1155 token balance",
+    params: erc1155BalanceParams,
+    tags: ["balance"],
+  })
+  async balanceOf(params: InferParams<typeof erc1155BalanceParams>, ctx: ActionCtx) {
+    const balance = await this.#handle(params.collection, ctx.account).read.balanceOf([
+      params.owner,
+      BigInt(params.tokenId),
+    ]);
+    return { ...params, balance: balance.toString() };
+  }
+
+  @Receipt()
+  transferReceipt(changes: readonly Change[]): MossReceipt<ERC1155TransferOutcome> {
+    const receipt = this.changesReceipt(changes);
+    const [outcome] = receipt.outcome;
+    if (!outcome || receipt.outcome.length !== 1 || outcome.event !== "TransferSingle") {
+      throw new Error("ERC1155 transfer Receipt requires exactly one TransferSingle Change");
+    }
+    return { ...receipt, outcome, text: receipt.changes[0]?.text ?? receipt.text };
+  }
+
+  @Receipt()
+  changesReceipt(changes: readonly Change[]): MossReceipt<readonly ERC1155Outcome[]> {
+    const outcomes: ERC1155Outcome[] = [];
+    const parsed = changes.map((change) => {
+      const outcome = parseERC1155Change(change);
+      outcomes.push(outcome);
+      return {
+        kind: "change" as const,
+        change,
+        data: outcome,
+        text: describeERC1155Outcome(outcome),
+      };
+    });
+    return {
+      kind: "receipt",
+      outcome: outcomes,
+      text: parsed.map(({ text }) => text).join("; "),
+      changes: parsed,
+    };
+  }
+}
+
+function parseERC1155Change(change: Change): ERC1155Outcome {
+  if (change.kind !== "event") {
+    throw new Error("Unexpected Change: ERC1155 Receipts only accept contract events");
+  }
+
+  let decoded: ReturnType<typeof decodeEventLog<typeof ierc1155Abi>>;
+  try {
+    decoded = decodeEventLog({
+      abi: ierc1155Abi,
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+  } catch {
+    throw new Error(`Unexpected Change: ${change.address} emitted an unsupported ERC-1155 event`);
+  }
+
+  if (decoded.eventName === "TransferSingle") {
+    return {
+      operation: "transfer",
+      event: "TransferSingle",
+      collection: change.address,
+      operator: decoded.args.operator,
+      from: decoded.args.from,
+      to: decoded.args.to,
+      tokenId: decoded.args.id.toString(),
+      amount: decoded.args.value.toString(),
+    };
+  }
+
+  if (decoded.eventName === "TransferBatch") {
+    if (decoded.args.ids.length !== decoded.args.values.length) {
+      throw new Error("Unexpected Change: ERC1155 TransferBatch ids and values lengths differ");
+    }
+    return {
+      operation: "transfer",
+      event: "TransferBatch",
+      collection: change.address,
+      operator: decoded.args.operator,
+      from: decoded.args.from,
+      to: decoded.args.to,
+      items: decoded.args.ids.map((tokenId, index) => {
+        const amount = decoded.args.values[index];
+        if (amount === undefined) {
+          throw new Error("Unexpected Change: ERC1155 TransferBatch is missing a value");
+        }
+        return { tokenId: tokenId.toString(), amount: amount.toString() };
+      }),
+    };
+  }
+
+  throw new Error(`Unexpected Change: ${change.address} emitted an unsupported ERC-1155 event`);
+}
+
+function describeERC1155Outcome(outcome: ERC1155Outcome): string {
+  if (outcome.event === "TransferSingle") {
+    return `ERC1155 TransferSingle: ${outcome.amount} of ${outcome.collection} #${outcome.tokenId} from ${outcome.from} to ${outcome.to} by ${outcome.operator}`;
+  }
+  const items = outcome.items.map(({ tokenId, amount }) => `${amount} of #${tokenId}`).join(", ");
+  return `ERC1155 TransferBatch: ${items} from ${outcome.from} to ${outcome.to} by ${outcome.operator} in ${outcome.collection}`;
+}

--- a/packages/erc/src/index.ts
+++ b/packages/erc/src/index.ts
@@ -1,7 +1,14 @@
 export {
   ierc20Abi as ERC20Abi,
   ierc721Abi as ERC721Abi,
+  ierc1155Abi as ERC1155Abi,
   iweth9Abi as WETH9Abi,
 } from "./abis/erc.js";
 export { ERC20, type ERC20Outcome } from "./erc20.js";
 export { ERC721, type ERC721TransferOutcome } from "./erc721.js";
+export {
+  ERC1155,
+  type ERC1155Outcome,
+  type ERC1155TransferItem,
+  type ERC1155TransferOutcome,
+} from "./erc1155.js";

--- a/packages/erc/test/erc1155.test.ts
+++ b/packages/erc/test/erc1155.test.ts
@@ -1,0 +1,364 @@
+import {
+  type Change,
+  createRuntime,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  Registry,
+  verifyReceiptCoverage,
+} from "@themoss/core";
+import { createTraceSimulator } from "@themoss/simulator";
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ierc1155Abi } from "../src/abis/erc.js";
+import { ERC1155, type ERC1155TransferOutcome } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const OPERATOR = getAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+const RECIPIENT = getAddress("0x1111111111111111111111111111111111111111");
+const COLLECTION = getAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+const MAX_UINT256 = ((1n << 256n) - 1n).toString();
+
+function registry(readBalance = 9n) {
+  const runtime: MossRuntime = {
+    rpcUrl: "http://offline",
+    client: {
+      readContract: async ({ functionName }: { functionName: string }) => {
+        if (functionName === "balanceOf") return readBalance;
+        throw new Error(`unexpected read ${functionName}`);
+      },
+    } as unknown as MossRuntime["client"],
+  };
+  return new Registry(runtime).use(ERC1155);
+}
+
+function transferSingle(
+  tokenId: bigint,
+  amount: bigint,
+  overrides: Partial<{
+    operator: typeof OPERATOR;
+    from: typeof ACCOUNT;
+    to: typeof RECIPIENT;
+  }> = {},
+) {
+  const operator = overrides.operator ?? OPERATOR;
+  const from = overrides.from ?? ACCOUNT;
+  const to = overrides.to ?? RECIPIENT;
+  return {
+    kind: "event",
+    address: COLLECTION,
+    topics: encodeEventTopics({
+      abi: ierc1155Abi,
+      eventName: "TransferSingle",
+      args: { operator, from, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [
+        { type: "uint256", name: "id" },
+        { type: "uint256", name: "value" },
+      ],
+      [tokenId, amount],
+    ),
+  } satisfies Change;
+}
+
+function transferBatch(ids: readonly bigint[], values: readonly bigint[]) {
+  return {
+    kind: "event",
+    address: COLLECTION,
+    topics: encodeEventTopics({
+      abi: ierc1155Abi,
+      eventName: "TransferBatch",
+      args: { operator: OPERATOR, from: ACCOUNT, to: RECIPIENT },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [
+        { type: "uint256[]", name: "ids" },
+        { type: "uint256[]", name: "values" },
+      ],
+      [ids, values],
+    ),
+  } satisfies Change;
+}
+
+describe("ERC1155", () => {
+  it("self-registers, describes typed methods, and builds one direct safeTransferFrom", async () => {
+    const instance = registry();
+    expect(instance.discover({ protocol: "erc1155" })).toEqual([
+      expect.objectContaining({
+        protocol: "erc1155",
+        method: "transfer",
+        kind: "capability",
+        verb: "transfer",
+      }),
+      expect.objectContaining({ protocol: "erc1155", method: "balanceOf", kind: "query" }),
+    ]);
+    expect(
+      Object.keys(instance.load([{ protocol: "erc1155", method: "transfer" }])[0]?.params ?? {}),
+    ).toEqual(["collection", "tokenId", "amount", "to"]);
+
+    const capability = await instance.action("erc1155", "transfer", ACCOUNT, {
+      collection: COLLECTION,
+      tokenId: MAX_UINT256,
+      amount: "0",
+      to: RECIPIENT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    expect(capability.receipt).toBe("transferReceipt");
+    const flattened = flattenCapabilityTree(capability);
+    expect(flattened).toHaveLength(1);
+    const [transfer] = flattened;
+    if (!transfer) throw new Error("missing transfer transaction");
+    expect(
+      decodeFunctionData({
+        abi: ierc1155Abi,
+        data: transfer.transaction.data,
+      }),
+    ).toEqual({
+      functionName: "safeTransferFrom",
+      args: [ACCOUNT, RECIPIENT, (1n << 256n) - 1n, 0n, "0x"],
+    });
+  });
+
+  it("runs the typed balance query and returns a JSON-safe decimal string", async () => {
+    await expect(
+      registry(17n).action("erc1155", "balanceOf", ACCOUNT, {
+        collection: COLLECTION,
+        tokenId: "42",
+        owner: RECIPIENT,
+      }),
+    ).resolves.toEqual({
+      kind: "query",
+      protocol: "erc1155",
+      method: "balanceOf",
+      data: { collection: COLLECTION, tokenId: "42", owner: RECIPIENT, balance: "17" },
+    });
+  });
+
+  it("rejects uint256 overflow and non-string parameters before calldata construction", async () => {
+    const overflow = (1n << 256n).toString();
+    await expect(
+      registry().action("erc1155", "transfer", ACCOUNT, {
+        collection: COLLECTION,
+        tokenId: overflow,
+        amount: "1",
+        to: RECIPIENT,
+      }),
+    ).rejects.toThrow("uint256 max");
+    await expect(
+      registry().action("erc1155", "transfer", ACCOUNT, {
+        collection: COLLECTION,
+        tokenId: "1",
+        amount: 1,
+        to: RECIPIENT,
+      }),
+    ).rejects.toThrow("invalid parameters");
+    await expect(
+      registry().action("erc1155", "transfer", ACCOUNT, {
+        collection: COLLECTION,
+        tokenId: "not-a-token-id",
+        amount: "1",
+        to: RECIPIENT,
+      }),
+    ).rejects.toThrow("invalid parameters");
+  });
+
+  it("parses single, batch, and single Changes exhaustively in original order", () => {
+    const first = transferSingle(7n, 0n, { operator: ACCOUNT, from: ACCOUNT, to: ACCOUNT });
+    const batch = transferBatch([9n, 9n, 2n], [3n, 0n, 4n]);
+    const last = transferSingle(11n, 5n);
+    const changes = [first, batch, last] as const;
+    const receipt = (Object.create(ERC1155.prototype) as ERC1155).changesReceipt(changes);
+
+    expect(receipt.outcome).toEqual([
+      {
+        operation: "transfer",
+        event: "TransferSingle",
+        collection: COLLECTION,
+        operator: ACCOUNT,
+        from: ACCOUNT,
+        to: ACCOUNT,
+        tokenId: "7",
+        amount: "0",
+      },
+      {
+        operation: "transfer",
+        event: "TransferBatch",
+        collection: COLLECTION,
+        operator: OPERATOR,
+        from: ACCOUNT,
+        to: RECIPIENT,
+        items: [
+          { tokenId: "9", amount: "3" },
+          { tokenId: "9", amount: "0" },
+          { tokenId: "2", amount: "4" },
+        ],
+      },
+      {
+        operation: "transfer",
+        event: "TransferSingle",
+        collection: COLLECTION,
+        operator: OPERATOR,
+        from: ACCOUNT,
+        to: RECIPIENT,
+        tokenId: "11",
+        amount: "5",
+      },
+    ]);
+    expect(receipt.changes).toHaveLength(changes.length);
+    for (const [index, entry] of receipt.changes.entries()) {
+      expect(entry.kind).toBe("change");
+      if (entry.kind === "change") expect(entry.change).toBe(changes[index]);
+    }
+    expect(() => verifyReceiptCoverage(changes, receipt)).not.toThrow();
+    expect(receipt.text).toContain("TransferSingle");
+    expect(receipt.text).toContain("TransferBatch");
+  });
+
+  it("narrows a direct transfer Receipt to exactly one TransferSingle", () => {
+    const single = transferSingle(42n, 3n);
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    const receipt = protocol.transferReceipt([single]);
+    expect(receipt.outcome).toMatchObject({
+      event: "TransferSingle",
+      tokenId: "42",
+      amount: "3",
+    });
+    expect(receipt.changes[0]).toMatchObject({ kind: "change", change: single });
+    expect(() => protocol.transferReceipt([])).toThrow("exactly one TransferSingle");
+    expect(() => protocol.transferReceipt([single, transferSingle(43n, 1n)])).toThrow(
+      "exactly one TransferSingle",
+    );
+    expect(() => protocol.transferReceipt([transferBatch([42n], [3n])])).toThrow(
+      "exactly one TransferSingle",
+    );
+  });
+
+  it("fails closed for native transfers, unsupported events, malformed data, and uneven batches", () => {
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: RECIPIENT,
+      value: "1",
+    } satisfies Change;
+    expect(() => protocol.changesReceipt([native])).toThrow("only accept contract events");
+
+    const approval = {
+      kind: "event",
+      address: COLLECTION,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "ApprovalForAll",
+        args: { account: ACCOUNT, operator: OPERATOR },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "bool", name: "approved" }], [true]),
+    } satisfies Change;
+    expect(() => protocol.changesReceipt([approval])).toThrow("unsupported ERC-1155 event");
+
+    const malformed = { ...transferSingle(1n, 1n), data: "0x" as Hex } satisfies Change;
+    expect(() => protocol.changesReceipt([malformed])).toThrow("unsupported ERC-1155 event");
+    expect(() => protocol.changesReceipt([transferBatch([1n, 2n], [3n])])).toThrow(
+      "ids and values lengths differ",
+    );
+  });
+
+  it("lets the framework detect missing, copied, duplicated, and reordered coverage", () => {
+    const first = transferSingle(1n, 1n);
+    const second = transferSingle(2n, 2n);
+    const receipt = (Object.create(ERC1155.prototype) as ERC1155).changesReceipt([first, second]);
+    const [firstLeaf, secondLeaf] = receipt.changes;
+    if (firstLeaf?.kind !== "change" || secondLeaf?.kind !== "change") {
+      throw new Error("expected direct Receipt Change leaves");
+    }
+    expect(() =>
+      verifyReceiptCoverage([first, second], { ...receipt, changes: [firstLeaf] }),
+    ).toThrow("covered 1 Changes");
+    expect(() =>
+      verifyReceiptCoverage([first, second], {
+        ...receipt,
+        changes: [firstLeaf, firstLeaf],
+      }),
+    ).toThrow("original object");
+    const copiedLeaf = { ...firstLeaf, change: { ...first } };
+    expect(() =>
+      verifyReceiptCoverage([first, second], { ...receipt, changes: [copiedLeaf, secondLeaf] }),
+    ).toThrow("original object");
+    expect(() =>
+      verifyReceiptCoverage([first, second], {
+        ...receipt,
+        changes: [secondLeaf, firstLeaf],
+      }),
+    ).toThrow("original object");
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("ERC1155 on Monad mainnet", () => {
+  // LootGO Looties Logs is listed in Monad's official protocol registry, and
+  // MonadScan identifies item #4 as ERC-1155:
+  // https://github.com/monad-developers/protocols/blob/main/mainnet/lootgo.jsonc
+  // https://monadscan.com/nft/0xd2c7fd8e7ab1527a2cb5a7177d1a29393f416a6d/4
+  const collection = getAddress("0xD2C7FD8e7Ab1527a2cb5A7177d1A29393F416A6d");
+  const tokenId = "4";
+  const holderCandidates = [
+    "0x745098b2c028BA7490452b3A13049a7Fe10b6a87",
+    "0xBB78A151673FaC1A0A2162Abc7BEE3a39b3767b5",
+    "0xf26de9DD7D737243089648633d62641Ff238d51f",
+    "0xd4bF7BF399c752F4fD97b6976035DcA3FD2E012B",
+    "0xB350D7cb33dB07E00FF5074461Ab3ac9Aa989926",
+    "0x3D8250Ac679dcfd1E90c29E7a64AB5013645E579",
+    "0xc498067D0831e6Ae3Ea9f83c958f704521025CD2",
+    "0x747c63e713843117Ef99CE689D9F029E3F10da96",
+    "0x8b59Ba7533f0F451c58B6EAFfc1860C0B9034810",
+    "0x36B55a8C16bEc8CBe1Ec58cB190A8a25F32d2682",
+  ].map((address) => getAddress(address));
+
+  it("simulates the happy path with zero Warnings and exhaustive Receipt coverage", {
+    timeout: 120_000,
+  }, async () => {
+    const runtime = await createRuntime({ rpcUrl: "https://rpc.monad.xyz" });
+    expect((await runtime.client.getCode({ address: collection }))?.length).toBeGreaterThan(2);
+    const registry = new Registry(runtime).use(ERC1155);
+
+    let holder: (typeof holderCandidates)[number] | undefined;
+    for (const candidate of holderCandidates) {
+      const result = await registry.action("erc1155", "balanceOf", candidate, {
+        collection,
+        tokenId,
+        owner: candidate,
+      });
+      if (result.kind === "query" && BigInt((result.data as { balance: string }).balance) > 0n) {
+        holder = candidate;
+        break;
+      }
+    }
+    if (!holder) throw new Error("no live ERC-1155 fixture holder has a positive balance");
+
+    const capability = await registry.action("erc1155", "transfer", holder, {
+      collection,
+      tokenId,
+      amount: "1",
+      to: RECIPIENT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const simulation = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+
+    expect(simulation.halted).toBeUndefined();
+    expect(simulation.results[0]?.warnings).toEqual([]);
+    const receiptOutcome = simulation.results[0]?.receipt?.outcome as
+      | ERC1155TransferOutcome
+      | undefined;
+    expect(receiptOutcome).toMatchObject({
+      operation: "transfer",
+      event: "TransferSingle",
+      operator: holder,
+      from: holder,
+      to: RECIPIENT,
+      tokenId,
+      amount: "1",
+    });
+    expect(receiptOutcome?.collection?.toLowerCase()).toBe(collection.toLowerCase());
+  });
+});

--- a/packages/erc/test/types.fixture.ts
+++ b/packages/erc/test/types.fixture.ts
@@ -1,4 +1,7 @@
+import type { Change, ReceiptResult } from "@themoss/core";
+import { Receipt } from "@themoss/core";
 import type { ERC20 } from "../src/erc20.js";
+import type { ERC1155, ERC1155Outcome } from "../src/erc1155.js";
 
 type TransferOperation = ReturnType<ERC20["transferReceipt"]>["outcome"]["operation"];
 type ApprovalOperation = ReturnType<ERC20["approveReceipt"]>["outcome"]["operation"];
@@ -14,3 +17,57 @@ void transfer;
 void invalidTransfer;
 void approval;
 void invalidApproval;
+
+type ERC1155TransferParams = Parameters<ERC1155["transfer"]>[0];
+const erc1155Params: ERC1155TransferParams = {
+  collection: "0x1111111111111111111111111111111111111111",
+  tokenId: "42",
+  amount: "3",
+  to: "0x2222222222222222222222222222222222222222",
+};
+const invalidTokenId: ERC1155TransferParams = {
+  ...erc1155Params,
+  // @ts-expect-error ERC1155 token IDs are decimal strings, not bigint values.
+  tokenId: 42n,
+};
+// @ts-expect-error ERC1155 transfer params require a recipient.
+const missingRecipient: ERC1155TransferParams = {
+  collection: erc1155Params.collection,
+  tokenId: "42",
+  amount: "3",
+};
+
+type ERC1155DirectOutcome = ReturnType<ERC1155["transferReceipt"]>["outcome"];
+const directEvent: ERC1155DirectOutcome["event"] = "TransferSingle";
+// @ts-expect-error The direct transfer Receipt cannot report a TransferBatch event.
+const invalidDirectEvent: ERC1155DirectOutcome["event"] = "TransferBatch";
+const batchOutcome: ERC1155Outcome = {
+  operation: "transfer",
+  event: "TransferBatch",
+  collection: erc1155Params.collection,
+  operator: erc1155Params.collection,
+  from: erc1155Params.collection,
+  to: erc1155Params.to,
+  items: [{ tokenId: "1", amount: "2" }],
+};
+
+class ERC1155CompileFixture {
+  @Receipt()
+  validReceipt(changes: readonly Change[]): ReceiptResult<ERC1155DirectOutcome> {
+    throw new Error(String(changes.length));
+  }
+
+  // @ts-expect-error Receipt parsers accept only an immutable ordered Change list.
+  @Receipt()
+  invalidReceipt(_: string): ReceiptResult<ERC1155DirectOutcome> {
+    throw new Error("compile fixture");
+  }
+}
+
+void erc1155Params;
+void invalidTokenId;
+void missingRecipient;
+void directEvent;
+void invalidDirectEvent;
+void batchOutcome;
+void ERC1155CompileFixture;

--- a/packages/erc/wagmi.config.ts
+++ b/packages/erc/wagmi.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   plugins: [
     foundry({
       project: ".",
-      include: ["IERC20.sol/**", "IERC721.sol/**", "IWETH9.sol/**"],
+      include: ["IERC20.sol/**", "IERC721.sol/**", "IERC1155.sol/**", "IWETH9.sol/**"],
       // wagmi's default excludes assume IERC20 is someone else's vendored
       // interface; here it IS our compiled source of truth — override them.
       exclude: ["build-info/**"],


### PR DESCRIPTION
## Summary

- add the compiled `IERC1155.sol` derivation chain and public `ERC1155Abi`
- add an address-free, self-describing `ERC1155` Protocol with a typed `transfer` Capability and `balanceOf` Query
- parse raw ordered `TransferSingle` and `TransferBatch` Changes exhaustively into typed, JSON-safe Receipts
- add uint256 boundary validation, valid/invalid compile fixtures, ordered coverage and fail-closed tests, Monad mainnet e2e coverage, documentation, and a changeset

## Context

This replaces #23 after the framework redesign in #31. It is rebuilt from current `main` and does not restore the removed Plan/flows/expects, effects extraction, or reconciliation architecture. ERC-1155-specific behavior remains entirely in `@themoss/erc`; core, simulator reconciliation, and MCP validation are unchanged.

The transfer Capability intentionally exposes one `safeTransferFrom` transaction. Its direct Receipt requires exactly one `TransferSingle`, while the reusable `changesReceipt` parser supports ordered `TransferSingle` and `TransferBatch` evidence without aggregating, deduplicating, or reordering batch items.

## Verification

- `pnpm --filter @themoss/erc gen:abis`
- `pnpm lint`
- `pnpm -r build`
- `pnpm -r typecheck`
- `MOSS_SKIP_E2E=1 pnpm -r test`
- `NODE_USE_ENV_PROXY=1 pnpm --filter @themoss/erc test` — 13/13 passed, including a Monad mainnet simulation with zero Warnings and exhaustive Receipt coverage

Closes #14.
Supersedes #23.
