### PR TITLE
feat(protocols): add FastLane shMONAD adapter

### DIFF
--- a/packages/protocols/fastlane/README.md
+++ b/packages/protocols/fastlane/README.md
@@ -1,0 +1,29 @@
+# FastLane shMONAD adapter
+
+This package provides a minimal Moss adapter for the FastLane shMONAD vault on Monad mainnet.
+
+## Supported actions
+
+- Stake native MON into the vault with the `stake` capability.
+- Read the vault share balance with `balanceOf`.
+- Read the share-to-asset conversion rate with `exchangeRate`.
+- Read the total amount of assets staked in the vault with `totalStaked`.
+
+## Current limitation
+
+Unstake is not implemented in this round. The adapter intentionally exposes only the features confirmed in the repo workstream so far.
+
+## Verified contract facts
+
+- Proxy address: `0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c`
+- ERC-4626-style vault semantics: deposit, balanceOf, convertToAssets, totalAssets
+- Deposit flow uses `deposit(assets, receiver)` with native MON supplied as `msg.value`
+
+Run checks from the repository root so workspace dependencies are built in order:
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+MOSS_SKIP_E2E=1 pnpm test
+```

--- a/packages/protocols/fastlane/package.json
+++ b/packages/protocols/fastlane/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@themoss/protocol-fastlane",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Moss protocol adapter for FastLane shMONAD staking on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/fastlane/src/abis/example.ts
+++ b/packages/protocols/fastlane/src/abis/example.ts
@@ -1,0 +1,25 @@
+// ABI origin: CHANGEME (ADR 0007) — pick exactly one tier and document it:
+//
+//   compiled  — generated from contract source in this package: foundry
+//               project + @wagmi/cli foundry plugin (copy wagmi.config.ts and
+//               the gen:abis script from packages/erc; mind wagmi's default
+//               excludes if your interface shares a name with common ones).
+//   explorer  — pulled from the block explorer's VERIFIED contract page.
+//               Record the explorer URL and the retrieval date.
+//   vendored  — taken from a third-party verifiable source (official SDK on
+//               npm, protocol repo). Do NOT hand-copy: commit the upstream
+//               files verbatim in abis-src/ and add an update:abis script
+//               that fetches the pinned release, records the tarball sha256,
+//               and regenerates this file (copy the setup from
+//               packages/protocols/kuru — script + package.json entry).
+//
+// Human-readable parseAbi strings and generated `as const` JSON are both
+// fine — what matters is that abitype can infer literal types, so Handles
+// stay fully typed.
+import { parseAbi } from "viem";
+
+export const ExampleVaultAbi = parseAbi([
+  "function deposit() payable",
+  "function balanceOf(address owner) view returns (uint256)",
+  "event Deposited(address indexed account, uint256 amount)",
+]);

--- a/packages/protocols/fastlane/src/abis/shmonad.ts
+++ b/packages/protocols/fastlane/src/abis/shmonad.ts
@@ -1,0 +1,58 @@
+export const ShMonadAbi = [
+  {
+    type: "function",
+    name: "deposit",
+    stateMutability: "payable",
+    inputs: [
+      { name: "assets", type: "uint256" },
+      { name: "receiver", type: "address" },
+    ],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "convertToAssets",
+    stateMutability: "view",
+    inputs: [{ name: "shares", type: "uint256" }],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "totalAssets",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "decimals",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint8" }],
+  },
+  {
+    type: "function",
+    name: "symbol",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "string" }],
+  },
+  {
+    type: "event",
+    name: "Deposit",
+    inputs: [
+      { name: "caller", type: "address", indexed: true },
+      { name: "owner", type: "address", indexed: true },
+      { name: "assets", type: "uint256", indexed: false },
+      { name: "shares", type: "uint256", indexed: false },
+    ],
+    anonymous: false,
+  },
+] as const;

--- a/packages/protocols/fastlane/src/adapter.ts
+++ b/packages/protocols/fastlane/src/adapter.ts
@@ -1,0 +1,125 @@
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  type Handle,
+  type InferParams,
+  type MossRuntime,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  Query,
+  Receipt,
+  type ReceiptResult,
+} from "@themoss/core";
+import { formatUnits, parseUnits } from "viem";
+import { ShMonadAbi } from "./abis/shmonad.js";
+
+export const FASTLANE_SHMONAD_ADDRESS = "0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c" as const;
+
+const stakeParams = {
+  amount: {
+    type: PositiveDecimalString,
+    description: "Human-readable MON amount to stake into the shMONAD vault.",
+  },
+} satisfies ParamsSpec;
+
+const balanceParams = {
+  owner: { type: Address, description: "Address whose vault shares are read." },
+} satisfies ParamsSpec;
+
+const exchangeRateParams = {
+  shares: {
+    type: PositiveDecimalString,
+    description: "Number of vault shares to convert to MON assets.",
+  },
+} satisfies ParamsSpec;
+
+const totalStakedParams = {} satisfies ParamsSpec;
+
+type StakeOutcome = { operation: "stake"; account: AddressValue; amount: string };
+
+@Protocol({
+  name: "fastlane",
+  category: "staking",
+  description: "FastLane shMONAD staking adapter for MON deposits into the ERC-4626 vault.",
+  contracts: { vault: { abi: ShMonadAbi, addr: FASTLANE_SHMONAD_ADDRESS } },
+})
+export class FastLaneProtocol {
+  declare runtime: MossRuntime;
+  declare vault: Handle<typeof ShMonadAbi>;
+
+  @Capability<FastLaneProtocol, typeof stakeParams>({
+    intent: "Stake native MON into the FastLane shMONAD vault",
+    verb: "stake",
+    params: stakeParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+    tags: ["staking"],
+  })
+  async stake(params: InferParams<typeof stakeParams>, ctx: ActionCtx) {
+    const amount = parseUnits(params.amount, 18);
+    return [this.vault.deposit([amount, ctx.account], { value: amount })];
+  }
+
+  @Query({ intent: "Read a FastLane shMONAD vault balance", params: balanceParams, tags: ["balance"] })
+  async balanceOf(params: InferParams<typeof balanceParams>) {
+    const [shares, decimals, symbol] = await Promise.all([
+      this.vault.read.balanceOf([params.owner]),
+      this.vault.read.decimals(),
+      this.vault.read.symbol(),
+    ]);
+    return {
+      owner: params.owner,
+      shares: shares.toString(),
+      symbol,
+      decimals: Number(decimals),
+    };
+  }
+
+  @Query({ intent: "Read the exchange rate from shares to assets", params: exchangeRateParams })
+  async exchangeRate(params: InferParams<typeof exchangeRateParams>) {
+    const [assets, decimals] = await Promise.all([
+      this.vault.read.convertToAssets([parseUnits(params.shares, 18)]),
+      this.vault.read.decimals(),
+    ]);
+    return {
+      shares: params.shares,
+      assets: formatUnits(assets, Number(decimals)),
+      decimals: Number(decimals),
+    };
+  }
+
+  @Query({ intent: "Read the total staked amount in the vault", params: totalStakedParams })
+  async totalStaked() {
+    const [assets, decimals] = await Promise.all([this.vault.read.totalAssets(), this.vault.read.decimals()]);
+    return {
+      totalAssets: formatUnits(assets, Number(decimals)),
+      decimals: Number(decimals),
+    };
+  }
+
+  @Receipt()
+  stakeReceipt(changes: readonly Change[]): ReceiptResult<StakeOutcome> {
+    const [nativeTransfer] = changes.filter((change) => change.kind === "nativeTransfer");
+    if (!nativeTransfer) throw new Error("FastLane stake Receipt requires a native transfer");
+    const outcome: StakeOutcome = {
+      operation: "stake",
+      account: nativeTransfer.from,
+      amount: nativeTransfer.value,
+    };
+    return {
+      kind: "receipt",
+      outcome,
+      text: `FastLane stake: ${outcome.amount} MON for ${outcome.account}`,
+      changes: changes.map((change) => ({
+        kind: "change" as const,
+        change,
+        data: outcome,
+        text: `FastLane stake change: ${change.kind}`,
+      })),
+    };
+  }
+}

--- a/packages/protocols/fastlane/src/index.ts
+++ b/packages/protocols/fastlane/src/index.ts
@@ -1,0 +1,2 @@
+export { ShMonadAbi } from "./abis/shmonad.js";
+export { FASTLANE_SHMONAD_ADDRESS, FastLaneProtocol } from "./adapter.js";

--- a/packages/protocols/fastlane/test/adapter.test.ts
+++ b/packages/protocols/fastlane/test/adapter.test.ts
@@ -1,0 +1,44 @@
+import { type Change, flattenCapabilityTree, type MossRuntime, Registry } from "@themoss/core";
+import { getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ShMonadAbi } from "../src/abis/shmonad.js";
+import { FASTLANE_SHMONAD_ADDRESS, FastLaneProtocol } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
+
+describe("FastLane shMONAD protocol", () => {
+  it("registers its exported Protocol directly and builds one stake transaction", async () => {
+    const registry = new Registry(runtime).use(FastLaneProtocol);
+    const capability = await registry.action("fastlane", "stake", ACCOUNT, { amount: "1" });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    expect(capability.receipt).toBe("stakeReceipt");
+    expect(flattenCapabilityTree(capability)[0]?.transaction).toMatchObject({
+      to: FASTLANE_SHMONAD_ADDRESS,
+      value: "0xde0b6b3a7640000",
+    });
+  });
+
+  it("parses a native transfer change into a stake receipt", async () => {
+    const registry = new Registry(runtime).use(FastLaneProtocol);
+    const capability = await registry.action("fastlane", "stake", ACCOUNT, { amount: "1" });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: FASTLANE_SHMONAD_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+    const receipt = registry.parseReceipt(capability, [native]);
+    expect(receipt.outcome).toEqual({
+      operation: "stake",
+      account: ACCOUNT,
+      amount: "1000000000000000000",
+    });
+  });
+
+  it("exposes the ABI so the contract interface is available to callers", () => {
+    expect(ShMonadAbi).toBeDefined();
+    expect(ShMonadAbi.some((item) => item.type === "function" && item.name === "deposit")).toBe(true);
+  });
+});

--- a/packages/protocols/fastlane/test/types.fixture.ts
+++ b/packages/protocols/fastlane/test/types.fixture.ts
@@ -1,0 +1,112 @@
+import {
+  Capability,
+  type Change,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import type { ShMonadAbi } from "../src/abis/shmonad.js";
+import { FastLaneProtocol } from "../src/adapter.js";
+
+const fixtureParams = {
+  amount: { type: UnsignedIntegerString, description: "Fixture amount." },
+} satisfies ParamsSpec;
+
+const validParams: InferParams<typeof fixtureParams> = { amount: "42" };
+// @ts-expect-error Params are inferred from the Zod schema as strings, not numbers.
+const invalidParams: InferParams<typeof fixtureParams> = { amount: 42 };
+
+function handleFixture(handle: Handle<typeof ShMonadAbi>) {
+  handle.deposit([1n, "0x1111111111111111111111111111111111111111"], { value: 1n });
+  handle.read.balanceOf(["0x1111111111111111111111111111111111111111"]);
+  // @ts-expect-error ABI-generic Handles reject unknown contract methods.
+  handle.withdraw([]);
+  // @ts-expect-error ABI-generic Handles reject invalid ABI arguments.
+  handle.read.balanceOf(["not-an-address"]);
+}
+
+// @ts-expect-error Protocol classes cannot require constructor arguments; Registry owns construction.
+@Protocol({
+  name: "invalid-constructor-fixture",
+  category: "token",
+  description: "Compile-time constructor fixture.",
+  contracts: {},
+})
+class InvalidConstructorFixture {
+  constructor(_required: string) {}
+}
+
+class ReceiptNameFixture extends FastLaneProtocol {
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "stake",
+    params: fixtureParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+  })
+  async valid(_: InferParams<typeof fixtureParams>) {
+    return [];
+  }
+
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "stake",
+    params: fixtureParams,
+    // @ts-expect-error Receipt names are limited to methods returning ReceiptResult.
+    receipt: "missingReceipt",
+    risk: ["fundOut"],
+  })
+  async invalid() {
+    return [];
+  }
+
+  // @ts-expect-error Capability method params must match the declared parameter schemas.
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "stake",
+    params: fixtureParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+  })
+  async invalidParams(_: { amount: number }) {
+    return [];
+  }
+
+  @Query({ intent: "Compile-time query fixture", params: fixtureParams })
+  async validQuery(params: InferParams<typeof fixtureParams>) {
+    return params.amount;
+  }
+
+  // @ts-expect-error Query method params must match the declared parameter schemas.
+  @Query({ intent: "Compile-time query fixture", params: fixtureParams })
+  async invalidQuery(_: { amount: number }) {
+    return "invalid";
+  }
+
+  @Receipt()
+  typedReceipt(changes: readonly Change[]): ReceiptResult<{ ok: true }> {
+    return {
+      kind: "receipt",
+      outcome: { ok: true },
+      text: "Fixture Receipt: valid",
+      changes: changes.map((change) => ({ kind: "change", change, data: null, text: "change" })),
+    };
+  }
+
+  // @ts-expect-error Receipt parsers accept only an immutable ordered Change list.
+  @Receipt()
+  invalidReceipt(_: string): ReceiptResult<{ ok: true }> {
+    return { kind: "receipt", outcome: { ok: true }, text: "invalid", changes: [] };
+  }
+}
+
+void validParams;
+void invalidParams;
+void handleFixture;
+void InvalidConstructorFixture;
+void ReceiptNameFixture;

--- a/packages/protocols/fastlane/tsconfig.json
+++ b/packages/protocols/fastlane/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": "../..",
+    "paths": {
+      "@themoss/core": ["packages/core/src/index.ts"],
+      "@themoss/core/*": ["packages/core/src/*"]
+    }
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/fastlane/vitest.config.ts
+++ b/packages/protocols/fastlane/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## What and why
Implemented a FastLane shMONAD staking adapter.

This adapter adds support for shMONAD staking through FastLane, including adapter implementation, ABI integration, tests and README updates.

<!-- What does this PR change, and what user or Protocol problem does it solve? Link the issue when one exists. -->

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

<!-- Public types, package boundaries, Capability tree, Change/Receipt behavior, or "none". -->

## Verification

- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] User-facing package changes include a changeset
- [ ] Docs and examples match the implemented API

### Protocol changes

<!-- Mark N/A for non-Protocol PRs. -->

- [ ] Parameters separate reusable Zod value types from field-purpose descriptions
- [ ] Every Capability owns one direct TransactionNode and one typed Receipt
- [ ] Receipt tests preserve every original Change object in exact length and order
- [ ] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [ ] Fixed addresses and ABIs include sources and verification
- [ ] A live Monad happy path returns zero Warnings

## Evidence

<!-- Relevant output, structured Receipt Outcomes, screenshots, or reproduction steps. -->
