### PR TITLE
docs: document offline test verification in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@
 - [ ] `pnpm typecheck`
 - [ ] `pnpm lint`
 - [ ] `pnpm test`
+- [ ] If live Monad RPC is unavailable: `pnpm test:offline`, with skipped live checks noted
 - [ ] User-facing package changes include a changeset
 - [ ] Docs and examples match the implemented API
 


### PR DESCRIPTION
## What and why

This change aligns the pull request verification checklist with the repository's existing offline test command, `pnpm test:offline`.

Moss includes live Monad RPC tests, but contributors may work in offline, sandboxed, or network-restricted environments. The PR template currently only lists `pnpm test`, so it does not clearly tell contributors how to report validation when live RPC checks cannot run.

Adding this line makes the expected fallback explicit: contributors can run `pnpm test:offline` and note that live checks were skipped. This improves review clarity without changing runtime behavior, package code, or test logic.

## Type of change

- [x] Documentation / example

## Framework and package impact

None. PR template only.

## Verification

- [x] `git diff --check`
- [x] `pnpm lint`
- [x] `pnpm test:offline`
- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

### Protocol changes

N/A.

## Evidence

- `git diff --check` passed.
- `pnpm lint` passed: Biome checked 83 files with no fixes applied.
- `pnpm test:offline` passed across the workspace; live Monad checks were skipped by design.