### PR TITLE
Core: add Bound Protocol construction to Registry

### DIFF
--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -4,11 +4,13 @@ import type { MossRuntime } from "./runtime.js";
 import type { InferParams, ParamsSpec } from "./semantics.js";
 import type {
   Address,
+  BoundProtocolRef,
   CapabilityResult,
   Category,
   Change,
   JsonSafeValue,
   ProtocolRef,
+  ReceiptRef,
   Receipt as ReceiptResult,
   RiskLabel,
   Verb,
@@ -20,17 +22,54 @@ export interface ContractConfig {
 }
 
 export type ProtocolCtor = new () => object;
-export type ProtocolDependencies = Record<string, ProtocolCtor>;
+export interface ProtocolBinding<Binding extends ParamsSpec> {
+  params: Binding;
+  contracts: (binding: InferParams<Binding>) => Record<string, ContractConfig>;
+}
+
+export interface ProtocolFactory<Instance extends object, Binding extends ParamsSpec> {
+  create(binding: InferParams<Binding>): BoundProtocolRef<Instance>;
+  readonly receipts: ReceiptRef<Instance>;
+}
+
+interface ProtocolFactoryMarker<Instance extends object, Binding extends ParamsSpec> {
+  protocol: ProtocolCtor;
+  binding: Binding;
+  readonly __instance?: Instance;
+}
+
+export const PROTOCOL_FACTORY_META = Symbol.for("moss.protocol.factory");
+
+export interface ProtocolFactoryDefinition<
+  Instance extends object = object,
+  Binding extends ParamsSpec = ParamsSpec,
+> extends ProtocolFactory<Instance, Binding> {
+  readonly [PROTOCOL_FACTORY_META]: ProtocolFactoryMarker<Instance, Binding>;
+}
+
+export type ProtocolDependency = ProtocolCtor | ProtocolFactoryDefinition;
+export type ProtocolDependencies = Record<string, ProtocolDependency>;
 type InjectedProtocols<Dependencies extends ProtocolDependencies> = {
-  [K in keyof Dependencies]: ProtocolRef<InstanceType<Dependencies[K]>>;
+  [K in keyof Dependencies]: Dependencies[K] extends ProtocolFactoryDefinition<
+    infer Instance,
+    infer Binding
+  >
+    ? ProtocolFactoryDefinition<Instance, Binding>
+    : Dependencies[K] extends ProtocolCtor
+      ? ProtocolRef<InstanceType<Dependencies[K]>>
+      : never;
 };
 
-export interface ProtocolConfig<Dependencies extends ProtocolDependencies = Record<never, never>> {
+export interface ProtocolConfig<
+  Dependencies extends ProtocolDependencies = Record<never, never>,
+  Binding extends ParamsSpec = Record<never, never>,
+> {
   name: string;
   category: Category;
   description: string;
   contracts: Record<string, ContractConfig>;
   protocols?: Dependencies;
+  binding?: ProtocolBinding<Binding>;
 }
 
 type ReceiptNames<This> = {
@@ -64,9 +103,35 @@ export const PROTOCOL_TARGET = Symbol.for("moss.protocol.target");
 export const METHOD_META = Symbol.for("moss.method");
 export const RECEIPT_META = Symbol.for("moss.receipt");
 
-export function Protocol<Dependencies extends ProtocolDependencies = Record<never, never>>(
-  config: ProtocolConfig<Dependencies>,
-) {
+export function createProtocolFactory<Ctor extends ProtocolCtor, Binding extends ParamsSpec>(
+  protocol: Ctor,
+  binding: Binding,
+): ProtocolFactoryDefinition<InstanceType<Ctor>, Binding> {
+  const config = (protocol as unknown as Record<symbol, ProtocolConfig | undefined>)[PROTOCOL_META];
+  if (!config?.binding) {
+    throw new Error(`${protocol.name} does not declare a Protocol binding`);
+  }
+  if (config.binding.params !== binding) {
+    throw new Error(`${protocol.name} factory must use its declared binding schema`);
+  }
+  const unavailable = (): never => {
+    throw new Error("Protocol factories must be injected by Registry before use");
+  };
+  const factory: ProtocolFactoryDefinition<InstanceType<Ctor>, Binding> = {
+    create: unavailable,
+    receipts: Object.freeze({}) as ReceiptRef<InstanceType<Ctor>>,
+    [PROTOCOL_FACTORY_META]: {
+      protocol,
+      binding,
+    } satisfies ProtocolFactoryMarker<InstanceType<Ctor>, Binding>,
+  };
+  return Object.freeze(factory);
+}
+
+export function Protocol<
+  Dependencies extends ProtocolDependencies = Record<never, never>,
+  Binding extends ParamsSpec = Record<never, never>,
+>(config: ProtocolConfig<Dependencies, Binding>) {
   if (!/^[a-z][a-z0-9-]*$/.test(config.name)) {
     throw new Error(`protocol name "${config.name}" must be a lowercase slug`);
   }
@@ -79,15 +144,36 @@ export function Protocol<Dependencies extends ProtocolDependencies = Record<neve
     const injected = class extends Base {
       constructor(...args: unknown[]) {
         super();
-        const [runtime, account, dependencies = {}] = args as [
+        const [runtime, account, dependencies = {}, binding] = args as [
           MossRuntime,
           Address,
           Record<string, object>?,
+          InferParams<Binding>?,
         ];
         if (!runtime?.client || !account) {
           throw new Error(`protocol "${config.name}" must be constructed by Registry`);
         }
-        for (const [key, contract] of Object.entries(config.contracts)) {
+        let contracts = config.contracts;
+        if (config.binding) {
+          if (!binding) {
+            throw new Error(`protocol "${config.name}" binding was not supplied by Registry`);
+          }
+          const dynamic = config.binding.contracts(binding);
+          if (
+            !dynamic ||
+            typeof dynamic !== "object" ||
+            typeof (dynamic as { then?: unknown }).then === "function"
+          ) {
+            throw new Error(`protocol "${config.name}" binding contracts must be synchronous`);
+          }
+          for (const key of Object.keys(dynamic)) {
+            if (Object.hasOwn(config.contracts, key)) {
+              throw new Error(`protocol "${config.name}" declares duplicate contract "${key}"`);
+            }
+          }
+          contracts = { ...config.contracts, ...dynamic };
+        }
+        for (const [key, contract] of Object.entries(contracts)) {
           Object.defineProperty(this, key, {
             value: createHandle(contract.abi, contract.addr, runtime.client, account),
             writable: false,

--- a/packages/core/src/framework.ts
+++ b/packages/core/src/framework.ts
@@ -70,6 +70,7 @@ export function flattenCapabilityTree(root: CapabilityNode): ExecutableCapabilit
     }
     requireText(node.protocol, `${path}.protocol`);
     requireText(node.method, `${path}.method`);
+    if (node.binding !== undefined) assertJsonSafe(node.binding, `${path}.binding`);
     assertJsonSafe(node.params, `${path}.params`);
     if (!Array.isArray(node.children)) throw new Error(`${path}.children must be an array`);
     const direct = node.children.filter(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,9 +2,13 @@ export {
   Capability,
   type CapabilitySpec,
   type ContractConfig,
+  createProtocolFactory,
   Protocol,
+  type ProtocolBinding,
   type ProtocolConfig,
   type ProtocolCtor,
+  type ProtocolFactory,
+  type ProtocolFactoryDefinition,
   Query,
   type QuerySpec,
   Receipt,
@@ -30,6 +34,7 @@ export { createRuntime, type MossRuntime } from "./runtime.js";
 export {
   Address,
   BasisPoints,
+  BindingError,
   describeParams,
   type InferParams,
   type ParameterDeclaration,
@@ -42,6 +47,7 @@ export {
 } from "./semantics.js";
 export {
   type Address as AddressValue,
+  type BoundProtocolRef,
   CATEGORIES,
   type CapabilityNode,
   type CapabilityResult,
@@ -53,6 +59,7 @@ export {
   type ProtocolRef,
   type Receipt as ReceiptResult,
   type ReceiptChange,
+  type ReceiptRef,
   RISK_LABELS,
   type RiskLabel,
   type TokenRef,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,16 +1,25 @@
 import {
   METHOD_META,
   type MethodMeta,
+  PROTOCOL_FACTORY_META,
   PROTOCOL_META,
   PROTOCOL_TARGET,
   type ProtocolConfig,
   type ProtocolCtor,
   type ProtocolDependencies,
+  type ProtocolFactoryDefinition,
   RECEIPT_META,
 } from "./decorators.js";
 import { flattenCapabilityTree, toJsonSafe, verifyReceiptCoverage } from "./framework.js";
 import type { MossRuntime } from "./runtime.js";
-import { describeParams, parameterTypeDescription, parseParams } from "./semantics.js";
+import {
+  BindingError,
+  describeParams,
+  type ParamsSpec,
+  parameterTypeDescription,
+  parseBinding,
+  parseParams,
+} from "./semantics.js";
 import type {
   Address,
   CapabilityNode,
@@ -52,6 +61,7 @@ export interface Stub {
   category: Category;
   risk: RiskLabel[];
   tags: string[];
+  binding?: Record<string, LoadedParameter>;
   params: Record<string, LoadedParameter>;
 }
 
@@ -65,21 +75,37 @@ export interface QueryResult {
 interface Registered {
   ctor: ProtocolCtor;
   receiptCtor: ProtocolCtor;
-  config: ProtocolConfig<ProtocolDependencies>;
+  config: ProtocolConfig<ProtocolDependencies, ParamsSpec>;
   methods: Record<string, MethodMeta>;
   receipts: Set<string>;
 }
 
 type CapabilityMethodMeta = Extract<MethodMeta, { kind: "capability" }>;
 
-export type ProtocolSource = ProtocolCtor | Record<string, unknown>;
+export type ProtocolSource = ProtocolCtor | ProtocolFactoryDefinition | Record<string, unknown>;
 
-function configOf(value: unknown): ProtocolConfig<ProtocolDependencies> | undefined {
+function configOf(value: unknown): ProtocolConfig<ProtocolDependencies, ParamsSpec> | undefined {
   if (typeof value !== "function") return undefined;
   if (!Object.hasOwn(value, PROTOCOL_META)) return undefined;
-  return (value as unknown as Record<symbol, ProtocolConfig<ProtocolDependencies> | undefined>)[
-    PROTOCOL_META
-  ];
+  return (
+    value as unknown as Record<symbol, ProtocolConfig<ProtocolDependencies, ParamsSpec> | undefined>
+  )[PROTOCOL_META];
+}
+
+interface FactoryMarker {
+  protocol: ProtocolCtor;
+  binding: ParamsSpec;
+}
+
+function factoryOf(value: unknown): FactoryMarker | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  return (value as Record<symbol, FactoryMarker | undefined>)[PROTOCOL_FACTORY_META];
+}
+
+function dependencyCtor(value: unknown): ProtocolCtor | undefined {
+  const factory = factoryOf(value);
+  if (factory) return factory.protocol;
+  return configOf(value) ? (value as ProtocolCtor) : undefined;
 }
 
 function requireMetadataText(value: unknown, path: string): void {
@@ -102,14 +128,23 @@ export class Registry {
         this.register(source as ProtocolCtor);
         continue;
       }
+      const sourceFactory = factoryOf(source);
+      if (sourceFactory) {
+        this.register(sourceFactory.protocol);
+        continue;
+      }
       if (!source || typeof source !== "object") {
-        throw new Error("Registry.use() expects a decorated Protocol class or module namespace");
+        throw new Error(
+          "Registry.use() expects a decorated Protocol class, Protocol factory, or module namespace",
+        );
       }
-      const protocols = [...new Set(Object.values(source).filter((value) => configOf(value)))];
+      const protocols = [
+        ...new Set(Object.values(source).map(dependencyCtor).filter(Boolean)),
+      ] as ProtocolCtor[];
       if (protocols.length === 0) {
-        throw new Error("module namespace exports no decorated Protocol classes");
+        throw new Error("module namespace exports no decorated Protocol classes or factories");
       }
-      for (const protocol of protocols) this.register(protocol as ProtocolCtor);
+      for (const protocol of protocols) this.register(protocol);
     }
     return this;
   }
@@ -137,7 +172,13 @@ export class Registry {
       throw new Error(`Protocol dependency cycle: ${[...stack, config.name].join(" -> ")}`);
     }
     for (const dependency of Object.values(config.protocols ?? {})) {
-      this.register(dependency, [...stack, config.name]);
+      const ctor = dependencyCtor(dependency);
+      if (!ctor) {
+        const dependencyName =
+          typeof dependency === "function" ? dependency.name : "Protocol dependency";
+        throw new Error(`${dependencyName} is not decorated with @Protocol`);
+      }
+      this.register(ctor, [...stack, config.name]);
     }
 
     const methods: Record<string, MethodMeta> = {};
@@ -163,24 +204,18 @@ export class Registry {
     if (Object.keys(methods).length === 0) {
       throw new Error(`protocol "${config.name}" declares no @Capability or @Query methods`);
     }
+    if (config.binding) {
+      if (typeof config.binding.contracts !== "function") {
+        throw new Error(`protocol "${config.name}" binding must declare a contracts function`);
+      }
+      this.#validateDeclarations(config.binding.params, "binding", config.name);
+    }
     for (const [name, meta] of Object.entries(methods)) {
       requireMetadataText(meta.spec.intent, `method "${config.name}.${name}" intent`);
       if (meta.spec.tags?.some((tag) => typeof tag !== "string" || tag.trim().length === 0)) {
         throw new Error(`method "${config.name}.${name}" has an invalid tag`);
       }
-      for (const [param, field] of Object.entries(meta.spec.params)) {
-        requireMetadataText(
-          field.description,
-          `parameter "${config.name}.${name}.${param}" description`,
-        );
-        if (!field.type || typeof field.type.safeParseAsync !== "function") {
-          throw new Error(`parameter "${config.name}.${name}.${param}" has an invalid type`);
-        }
-        requireMetadataText(
-          parameterTypeDescription(field.type),
-          `parameter "${config.name}.${name}.${param}" type description`,
-        );
-      }
+      this.#validateDeclarations(meta.spec.params, "parameter", `${config.name}.${name}`);
       if (meta.kind !== "capability") continue;
       if (!VERBS.includes(meta.spec.verb)) {
         throw new Error(`capability "${config.name}.${name}" has an invalid verb`);
@@ -238,6 +273,9 @@ export class Registry {
         category: registered.config.category,
         risk: meta.kind === "capability" ? meta.spec.risk : [],
         tags: meta.spec.tags ?? [],
+        ...(registered.config.binding
+          ? { binding: describeParams(registered.config.binding.params) }
+          : {}),
         params: describeParams(meta.spec.params),
       };
     });
@@ -248,6 +286,7 @@ export class Registry {
     method: string,
     account: Address,
     rawParams: Record<string, unknown>,
+    rawBinding?: Record<string, unknown>,
   ): Promise<QueryResult | CapabilityNode> {
     const meta = this.#get(protocol).methods[method];
     if (!meta) throw new Error(`protocol "${protocol}" has no method "${method}"`);
@@ -256,10 +295,10 @@ export class Registry {
         kind: "query",
         protocol,
         method,
-        data: await this.#runQuery(protocol, method, account, rawParams),
+        data: await this.#runQuery(protocol, method, account, rawParams, rawBinding),
       };
     }
-    return this.#buildCapability(protocol, method, account, rawParams);
+    return this.#buildCapability(protocol, method, account, rawParams, rawBinding);
   }
 
   parseReceipt(node: CapabilityNode, changes: readonly Change[]): Receipt {
@@ -279,14 +318,27 @@ export class Registry {
     method: string,
     account: Address,
     rawParams: Record<string, unknown>,
+    rawBinding?: Record<string, unknown>,
   ): Promise<CapabilityNode> {
     const registered = this.#get(protocol);
     const meta = registered.methods[method];
     if (meta?.kind !== "capability") {
       throw new Error(`"${protocol}.${method}" is not a Capability`);
     }
+    const binding = this.#parseProtocolBinding(registered, rawBinding);
+    return this.#buildCapabilityWithBinding(meta, protocol, method, account, rawParams, binding);
+  }
+
+  async #buildCapabilityWithBinding(
+    meta: CapabilityMethodMeta,
+    protocol: string,
+    method: string,
+    account: Address,
+    rawParams: Record<string, unknown>,
+    binding: Record<string, unknown> | undefined,
+  ): Promise<CapabilityNode> {
     const params = await parseParams(meta.spec.params, rawParams);
-    const instance = this.#instantiate(protocol, account);
+    const instance = this.#instantiate(protocol, account, binding);
     // biome-ignore lint/suspicious/noExplicitAny: metadata validates dynamic method dispatch
     const result = (await (instance as any)[method](params, { account } satisfies ActionCtx)) as
       | CapabilityResult
@@ -296,6 +348,7 @@ export class Registry {
       kind: "capability",
       protocol,
       method,
+      ...(binding ? { binding: toJsonSafe(binding) } : {}),
       params: toJsonSafe(params),
       children,
     };
@@ -308,12 +361,25 @@ export class Registry {
     method: string,
     account: Address,
     rawParams: Record<string, unknown>,
+    rawBinding?: Record<string, unknown>,
   ): Promise<JsonSafeValue> {
     const registered = this.#get(protocol);
     const meta = registered.methods[method];
     if (meta?.kind !== "query") throw new Error(`"${protocol}.${method}" is not a Query`);
+    const binding = this.#parseProtocolBinding(registered, rawBinding);
+    return this.#runQueryWithBinding(meta, protocol, method, account, rawParams, binding);
+  }
+
+  async #runQueryWithBinding(
+    meta: Extract<MethodMeta, { kind: "query" }>,
+    protocol: string,
+    method: string,
+    account: Address,
+    rawParams: Record<string, unknown>,
+    binding: Record<string, unknown> | undefined,
+  ): Promise<JsonSafeValue> {
     const params = await parseParams(meta.spec.params, rawParams);
-    const instance = this.#instantiate(protocol, account);
+    const instance = this.#instantiate(protocol, account, binding);
     // biome-ignore lint/suspicious/noExplicitAny: metadata validates dynamic method dispatch
     return toJsonSafe(await (instance as any)[method](params, { account } satisfies ActionCtx));
   }
@@ -335,46 +401,60 @@ export class Registry {
     const ReceiptCtor = registered.receiptCtor as unknown as new () => object;
     const instance = new ReceiptCtor();
     for (const [key, dependency] of Object.entries(registered.config.protocols ?? {})) {
-      const name = configOf(dependency)?.name;
+      const ctor = dependencyCtor(dependency);
+      const name = ctor && configOf(ctor)?.name;
       if (!name) throw new Error(`protocol "${protocol}" has an undecorated dependency`);
       Object.defineProperty(instance, key, {
-        value: this.#receiptDependency(name),
+        value: factoryOf(dependency)
+          ? this.#receiptFactory(dependency, name)
+          : this.#receiptDependency(name),
         writable: false,
       });
     }
     return instance;
   }
 
-  #instantiate(protocol: string, account: Address): object {
+  #instantiate(protocol: string, account: Address, binding?: Record<string, unknown>): object {
     const registered = this.#get(protocol);
     const dependencies = Object.fromEntries(
       Object.entries(registered.config.protocols ?? {}).map(([key, dependency]) => {
-        const name = configOf(dependency)?.name;
+        const marker = factoryOf(dependency);
+        const ctor = dependencyCtor(dependency);
+        const name = ctor && configOf(ctor)?.name;
         if (!name) throw new Error(`protocol "${protocol}" has an undecorated dependency`);
-        return [key, this.#dependency(name, account)];
+        return [key, marker ? this.#factory(dependency, account) : this.#dependency(name, account)];
       }),
     );
     const Ctor = registered.ctor as unknown as new (
       runtime: MossRuntime,
       account: Address,
       dependencies: Record<string, object>,
+      binding?: Record<string, unknown>,
     ) => object;
-    return new Ctor(this.runtime, account, dependencies);
+    return new Ctor(this.runtime, account, dependencies, binding);
   }
 
-  #dependency(protocol: string, account: Address): object {
+  #dependency(
+    protocol: string,
+    account: Address,
+    binding?: Record<string, unknown>,
+    includeReceipts = true,
+  ): object {
     const registered = this.#get(protocol);
     const dependency: Record<string, unknown> = {};
     for (const [method, meta] of Object.entries(registered.methods)) {
       dependency[method] =
         meta.kind === "capability"
           ? (params: Record<string, unknown>) =>
-              this.#buildCapability(protocol, method, account, params)
-          : (params: Record<string, unknown>) => this.#runQuery(protocol, method, account, params);
+              this.#buildCapabilityWithBinding(meta, protocol, method, account, params, binding)
+          : (params: Record<string, unknown>) =>
+              this.#runQueryWithBinding(meta, protocol, method, account, params, binding);
     }
-    for (const receipt of registered.receipts) {
-      dependency[receipt] = (changes: readonly Change[]) =>
-        this.#runReceipt(protocol, receipt, changes);
+    if (includeReceipts) {
+      for (const receipt of registered.receipts) {
+        dependency[receipt] = (changes: readonly Change[]) =>
+          this.#runReceipt(protocol, receipt, changes);
+      }
     }
     return Object.freeze(dependency);
   }
@@ -386,6 +466,62 @@ export class Registry {
         this.#runReceipt(protocol, receipt, changes);
     }
     return Object.freeze(dependency);
+  }
+
+  #factory(definition: unknown, account: Address): object {
+    const marker = factoryOf(definition);
+    const name = marker && configOf(marker.protocol)?.name;
+    if (!marker || !name) throw new Error("invalid Protocol factory definition");
+    const factory: Record<PropertyKey, unknown> = {
+      create: (rawBinding: Record<string, unknown>) => {
+        const registered = this.#get(name);
+        const binding = this.#parseProtocolBinding(registered, rawBinding);
+        return this.#dependency(name, account, binding, false);
+      },
+      receipts: this.#receiptDependency(name),
+    };
+    Object.defineProperty(factory, PROTOCOL_FACTORY_META, { value: marker });
+    return Object.freeze(factory);
+  }
+
+  #receiptFactory(definition: unknown, protocol: string): object {
+    const marker = factoryOf(definition);
+    if (!marker) throw new Error("invalid Protocol factory definition");
+    const factory: Record<PropertyKey, unknown> = {
+      create: () => {
+        throw new Error("Protocol factory create() is unavailable inside Receipt parsers");
+      },
+      receipts: this.#receiptDependency(protocol),
+    };
+    Object.defineProperty(factory, PROTOCOL_FACTORY_META, { value: marker });
+    return Object.freeze(factory);
+  }
+
+  #parseProtocolBinding(
+    registered: Registered,
+    rawBinding: Record<string, unknown> | undefined,
+  ): Record<string, unknown> | undefined {
+    if (!registered.config.binding) {
+      if (rawBinding !== undefined) {
+        throw new BindingError(`protocol "${registered.config.name}" does not accept a binding`);
+      }
+      return undefined;
+    }
+    if (!rawBinding || typeof rawBinding !== "object" || Array.isArray(rawBinding)) {
+      throw new BindingError(`protocol "${registered.config.name}" requires a binding object`);
+    }
+    return parseBinding(registered.config.binding.params, rawBinding);
+  }
+
+  #validateDeclarations(spec: ParamsSpec, kind: "binding" | "parameter", scope: string): void {
+    for (const [name, field] of Object.entries(spec)) {
+      const path = `${kind} "${scope}.${name}"`;
+      requireMetadataText(field.description, `${path} description`);
+      if (!field.type || typeof field.type.safeParseAsync !== "function") {
+        throw new Error(`${path} has an invalid type`);
+      }
+      requireMetadataText(parameterTypeDescription(field.type), `${path} type description`);
+    }
   }
 
   #capabilityMeta(protocol: string, method: string): CapabilityMethodMeta {

--- a/packages/core/src/semantics.ts
+++ b/packages/core/src/semantics.ts
@@ -22,6 +22,13 @@ export class ParameterError extends Error {
   }
 }
 
+export class BindingError extends Error {
+  constructor(message: string) {
+    super(`invalid binding: ${message}`);
+    this.name = "BindingError";
+  }
+}
+
 export const Address = z
   .string()
   .refine((value) => isAddress(value, { strict: false }), "Expected a 20-byte 0x address.")
@@ -61,6 +68,36 @@ export async function parseParams<S extends ParamsSpec>(
   const result = await schema.safeParseAsync(raw);
   if (!result.success) {
     throw new ParameterError(z.prettifyError(result.error));
+  }
+  return result.data as InferParams<S>;
+}
+
+/**
+ * Parse Protocol identity synchronously before any Protocol is constructed.
+ * Async refinements are intentionally unsupported: binding validation must be
+ * externally pure and cannot depend on RPC or other asynchronous state.
+ */
+export function parseBinding<S extends ParamsSpec>(
+  spec: S,
+  raw: Record<string, unknown>,
+): InferParams<S> {
+  const schema = z
+    .object(Object.fromEntries(Object.entries(spec).map(([name, field]) => [name, field.type])))
+    .strict();
+  let result: z.ZodSafeParseResult<Record<string, unknown>>;
+  try {
+    result = schema.safeParse(raw);
+  } catch (error) {
+    throw new BindingError(
+      error instanceof Error && error.message.includes("Encountered Promise")
+        ? "binding schemas must be synchronous"
+        : error instanceof Error
+          ? error.message
+          : String(error),
+    );
+  }
+  if (!result.success) {
+    throw new BindingError(z.prettifyError(result.error));
   }
   return result.data as InferParams<S>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,7 @@ export interface CapabilityNode {
   kind: "capability";
   protocol: string;
   method: string;
+  binding?: JsonSafeValue;
   params: JsonSafeValue;
   children: readonly (CapabilityNode | TransactionNode)[];
 }
@@ -71,6 +72,35 @@ export type ProtocolRef<T> = {
       : Result extends Receipt
         ? T[K]
         : (params: Params) => Promise<Awaited<Result>>
+    : never;
+};
+
+/**
+ * Execution-only reference returned by a bound Protocol factory.
+ *
+ * Receipt parsers deliberately live on the factory's separate `receipts`
+ * surface so a binding can never become parser input.
+ */
+export type BoundProtocolRef<T> = {
+  [K in keyof T as T[K] extends (...args: never[]) => infer Result
+    ? Awaited<Result> extends Receipt
+      ? never
+      : K
+    : never]: T[K] extends (params: infer Params, ...args: infer _Rest) => infer Result
+    ? Awaited<Result> extends CapabilityResult
+      ? (params: Params) => Promise<CapabilityNode>
+      : (params: Params) => Promise<Awaited<Result>>
+    : never;
+};
+
+/** Pure, binding-free Receipt parser references exposed by a Protocol factory. */
+export type ReceiptRef<T> = {
+  [K in keyof T as T[K] extends (...args: never[]) => infer Result
+    ? Result extends Receipt
+      ? K
+      : never
+    : never]: T[K] extends (changes: infer Changes) => infer Result
+    ? (changes: Changes) => Result
     : never;
 };
 

--- a/packages/core/test/binding.test.ts
+++ b/packages/core/test/binding.test.ts
@@ -1,0 +1,412 @@
+import { parseAbi } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod/v4";
+import {
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  createProtocolFactory,
+  flattenCapabilityTree,
+  type Handle,
+  type InferParams,
+  type MossRuntime,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  Registry,
+  transaction,
+  UnsignedIntegerString,
+} from "../src/index.js";
+
+const AssetAbi = parseAbi(["function transfer(address recipient, uint256 amount) returns (bool)"]);
+const ACCOUNT = "0x1111111111111111111111111111111111111111" as const;
+const TOKEN_A = "0x2222222222222222222222222222222222222222" as const;
+const TOKEN_B = "0x3333333333333333333333333333333333333333" as const;
+const RECIPIENT = "0x4444444444444444444444444444444444444444" as const;
+const ROOT_TARGET = "0x5555555555555555555555555555555555555555" as const;
+
+const assetBinding = {
+  token: { type: Address, description: "ERC-compatible token contract bound to this instance." },
+} satisfies ParamsSpec;
+
+const moveParams = {
+  recipient: { type: Address, description: "Address that receives the bound asset." },
+  amount: { type: UnsignedIntegerString, description: "Raw token amount to transfer." },
+} satisfies ParamsSpec;
+
+const inspectParams = {} satisfies ParamsSpec;
+
+let bindingContractCalls = 0;
+
+@Protocol({
+  name: "bound-asset",
+  category: "token",
+  description: "Parameterized asset fixture.",
+  contracts: {},
+  binding: {
+    params: assetBinding,
+    contracts: ({ token }) => {
+      bindingContractCalls += 1;
+      return { asset: { abi: AssetAbi, addr: token } };
+    },
+  },
+})
+class BoundAsset {
+  declare asset: Handle<typeof AssetAbi>;
+
+  @Capability<BoundAsset, typeof moveParams>({
+    intent: "Move the bound asset",
+    verb: "transfer",
+    params: moveParams,
+    receipt: "moveReceipt",
+    risk: ["fundOut"],
+  })
+  async move(params: InferParams<typeof moveParams>) {
+    return [this.asset.transfer([params.recipient, BigInt(params.amount)])];
+  }
+
+  @Query({ intent: "Inspect the bound asset", params: inspectParams })
+  async inspect() {
+    return { token: this.asset.address };
+  }
+
+  @Receipt()
+  moveReceipt(changes: readonly Change[]): ReceiptResult<{ operation: "move" }> {
+    if ("runtime" in this || "asset" in this) {
+      throw new Error("Receipt references must not expose Runtime or bound Handles");
+    }
+    return {
+      kind: "receipt",
+      outcome: { operation: "move" },
+      text: "Moved a bound asset",
+      changes: changes.map((change) => ({
+        kind: "change",
+        change,
+        data: { operation: "move" },
+        text: "Observed a bound asset Change",
+      })),
+    };
+  }
+}
+
+const BoundAssetFactory = createProtocolFactory(BoundAsset, assetBinding);
+
+let bindingDecodeCalls = 0;
+let lastDecodedRevision: string | undefined;
+
+const transformingBinding = {
+  token: { type: Address, description: "Token contract bound to the transform fixture." },
+  revision: {
+    type: z
+      .string()
+      .overwrite((value) => {
+        bindingDecodeCalls += 1;
+        return `${value}!`;
+      })
+      .describe("A revision string decoded once by the binding schema."),
+    description: "Revision used to detect repeated binding decoding.",
+  },
+} satisfies ParamsSpec;
+
+@Protocol({
+  name: "transforming-binding",
+  category: "token",
+  description: "Fixture with a non-idempotent binding transform.",
+  contracts: {},
+  binding: {
+    params: transformingBinding,
+    contracts: ({ token, revision }) => {
+      lastDecodedRevision = revision;
+      return { asset: { abi: AssetAbi, addr: token } };
+    },
+  },
+})
+class TransformingBindingProtocol {
+  declare asset: Handle<typeof AssetAbi>;
+
+  @Query({ intent: "Inspect the transformed binding", params: inspectParams })
+  async inspect() {
+    return { token: this.asset.address };
+  }
+}
+
+const TransformingBindingFactory = createProtocolFactory(
+  TransformingBindingProtocol,
+  transformingBinding,
+);
+
+const composeParams = {
+  first: { type: Address, description: "First token binding used by the composition." },
+  second: { type: Address, description: "Second token binding used by the composition." },
+} satisfies ParamsSpec;
+
+@Protocol({
+  name: "bound-composer",
+  category: "dex",
+  description: "Fixture that composes independent bound Protocol references.",
+  contracts: {},
+  protocols: { assets: BoundAssetFactory, transformed: TransformingBindingFactory },
+})
+class BoundComposer {
+  declare assets: typeof BoundAssetFactory;
+  declare transformed: typeof TransformingBindingFactory;
+
+  @Capability<BoundComposer, typeof composeParams>({
+    intent: "Compose two bound asset movements",
+    verb: "swap",
+    params: composeParams,
+    receipt: "composeReceipt",
+    risk: ["fundOut"],
+  })
+  async compose(params: InferParams<typeof composeParams>, ctx: { account: AddressValue }) {
+    const first = this.assets.create({ token: params.first });
+    const second = this.assets.create({ token: params.second });
+    if (first === second) throw new Error("factory cached a bound Protocol reference");
+    return [
+      await first.move({ recipient: RECIPIENT, amount: "1" }),
+      await second.move({ recipient: RECIPIENT, amount: "2" }),
+      transaction(ctx.account, ROOT_TARGET, { data: "0xcafe" }),
+    ];
+  }
+
+  @Query({ intent: "Inspect independent bound references", params: composeParams })
+  async inspect(params: InferParams<typeof composeParams>) {
+    const first = this.assets.create({ token: params.first });
+    const second = this.assets.create({ token: params.second });
+    return {
+      independent: first !== second,
+      first: await first.inspect({}),
+      second: await second.inspect({}),
+    };
+  }
+
+  @Query({ intent: "Exercise runtime factory validation", params: inspectParams })
+  async rejectInvalidFactoryBinding() {
+    // @ts-expect-error Deliberately bypass the public type contract to exercise runtime validation.
+    this.assets.create({ token: "not-an-address" });
+    return null;
+  }
+
+  @Query({ intent: "Inspect one transformed bound reference", params: inspectParams })
+  async inspectTransformed() {
+    const bound = this.transformed.create({ token: TOKEN_A, revision: "v1" });
+    return bound.inspect({});
+  }
+
+  @Receipt()
+  composeReceipt(changes: readonly Change[]): ReceiptResult<{ operation: "compose" }> {
+    return {
+      kind: "receipt",
+      outcome: { operation: "compose" },
+      text: "Composed bound assets",
+      changes: [this.assets.receipts.moveReceipt(changes)],
+    };
+  }
+}
+
+const asyncBinding = {
+  identity: {
+    type: z
+      .string()
+      .refine(async () => true)
+      .describe("A fixture identity whose validation is incorrectly asynchronous."),
+    description: "Identity used to prove binding validation is synchronous.",
+  },
+} satisfies ParamsSpec;
+
+@Protocol({
+  name: "async-binding",
+  category: "token",
+  description: "Invalid asynchronous binding fixture.",
+  contracts: {},
+  binding: { params: asyncBinding, contracts: () => ({}) },
+})
+class AsyncBindingProtocol {
+  @Query({ intent: "Inspect the invalid binding fixture", params: inspectParams })
+  async inspect() {
+    return null;
+  }
+}
+
+const undescribedBinding = {
+  identity: {
+    type: z.string(),
+    description: "Identity with an intentionally undescribed binding type.",
+  },
+} satisfies ParamsSpec;
+
+@Protocol({
+  name: "undescribed-binding",
+  category: "token",
+  description: "Invalid binding metadata fixture.",
+  contracts: {},
+  binding: { params: undescribedBinding, contracts: () => ({}) },
+})
+class UndescribedBindingProtocol {
+  @Query({ intent: "Inspect the invalid binding metadata", params: inspectParams })
+  async inspect() {
+    return null;
+  }
+}
+
+const runtime = (): MossRuntime => ({
+  rpcUrl: "http://offline",
+  client: {
+    readContract: vi.fn(),
+    call: vi.fn(),
+  } as unknown as MossRuntime["client"],
+});
+
+describe("bound Protocol Registry seam", () => {
+  it("requires an explicit factory alias tied to the declared binding schema", () => {
+    expect(typeof BoundAssetFactory).toBe("object");
+    expect(() => createProtocolFactory(BoundAsset, { ...assetBinding })).toThrow(
+      "must use its declared binding schema",
+    );
+    expect(() => createProtocolFactory(BoundComposer, {})).toThrow(
+      "does not declare a Protocol binding",
+    );
+  });
+
+  it("describes binding separately and serializes canonical binding on CapabilityNodes", async () => {
+    bindingContractCalls = 0;
+    const registry = new Registry(runtime()).use(BoundAssetFactory);
+    const [loaded] = registry.load([{ protocol: "bound-asset", method: "move" }]);
+
+    expect(loaded?.binding).toEqual({
+      token: {
+        description: "ERC-compatible token contract bound to this instance.",
+        type: expect.objectContaining({ description: expect.stringContaining("20-byte EVM") }),
+      },
+    });
+    expect(loaded?.params).toHaveProperty("recipient");
+    expect(loaded?.params).not.toHaveProperty("token");
+
+    const result = await registry.action(
+      "bound-asset",
+      "move",
+      ACCOUNT,
+      { recipient: RECIPIENT, amount: "7" },
+      { token: TOKEN_A },
+    );
+    if (result.kind !== "capability") throw new Error("expected Capability");
+    expect(result.binding).toEqual({ token: TOKEN_A });
+    expect(result.params).toEqual({ recipient: RECIPIENT, amount: "7" });
+    expect(flattenCapabilityTree(result)[0]?.transaction.to).toBe(TOKEN_A);
+    expect(bindingContractCalls).toBe(1);
+
+    const query = await registry.action("bound-asset", "inspect", ACCOUNT, {}, { token: TOKEN_B });
+    expect(query).toEqual({
+      kind: "query",
+      protocol: "bound-asset",
+      method: "inspect",
+      data: { token: TOKEN_B },
+    });
+  });
+
+  it("injects non-callable factories with independent references and pure Receipts", async () => {
+    const registry = new Registry(runtime()).use(BoundComposer);
+    const capability = await registry.action("bound-composer", "compose", ACCOUNT, {
+      first: TOKEN_A,
+      second: TOKEN_B,
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+
+    expect(capability.binding).toBeUndefined();
+    expect(capability.children.slice(0, 2)).toMatchObject([
+      { kind: "capability", protocol: "bound-asset", binding: { token: TOKEN_A } },
+      { kind: "capability", protocol: "bound-asset", binding: { token: TOKEN_B } },
+    ]);
+    expect(flattenCapabilityTree(capability).map(({ transaction: tx }) => tx.to)).toEqual([
+      TOKEN_A,
+      TOKEN_B,
+      ROOT_TARGET,
+    ]);
+
+    const query = await registry.action("bound-composer", "inspect", ACCOUNT, {
+      first: TOKEN_A,
+      second: TOKEN_A,
+    });
+    expect(query).toMatchObject({
+      kind: "query",
+      data: {
+        independent: true,
+        first: { token: TOKEN_A },
+        second: { token: TOKEN_A },
+      },
+    });
+    expect(registry.parseReceipt(capability, [])).toMatchObject({
+      outcome: { operation: "compose" },
+      changes: [{ outcome: { operation: "move" } }],
+    });
+  });
+
+  it("decodes factory bindings exactly once before reusing the validated value", async () => {
+    bindingDecodeCalls = 0;
+    lastDecodedRevision = undefined;
+    const registry = new Registry(runtime()).use(BoundComposer);
+
+    await expect(
+      registry.action("bound-composer", "inspectTransformed", ACCOUNT, {}),
+    ).resolves.toMatchObject({ data: { token: TOKEN_A } });
+    expect(bindingDecodeCalls).toBe(1);
+    expect(lastDecodedRevision).toBe("v1!");
+  });
+
+  it("rejects malformed binding before construction, Protocol execution, or RPC", async () => {
+    bindingContractCalls = 0;
+    const mossRuntime = runtime();
+    const registry = new Registry(mossRuntime).use(BoundAssetFactory, BoundComposer);
+
+    await expect(
+      registry.action(
+        "bound-asset",
+        "move",
+        ACCOUNT,
+        { recipient: "also-invalid", amount: -1 },
+        { token: "not-an-address" },
+      ),
+    ).rejects.toThrow("invalid binding");
+    await expect(
+      registry.action("bound-asset", "inspect", ACCOUNT, {}, { token: TOKEN_A, extra: true }),
+    ).rejects.toThrow("invalid binding");
+    await expect(registry.action("bound-asset", "inspect", ACCOUNT, {})).rejects.toThrow(
+      "requires a binding object",
+    );
+    await expect(
+      registry.action(
+        "bound-composer",
+        "inspect",
+        ACCOUNT,
+        {
+          first: TOKEN_A,
+          second: TOKEN_B,
+        },
+        { token: TOKEN_A },
+      ),
+    ).rejects.toThrow("does not accept a binding");
+    await expect(
+      registry.action("bound-composer", "rejectInvalidFactoryBinding", ACCOUNT, {}),
+    ).rejects.toThrow("invalid binding");
+
+    expect(bindingContractCalls).toBe(0);
+    expect(mossRuntime.client.readContract).not.toHaveBeenCalled();
+    expect(mossRuntime.client.call).not.toHaveBeenCalled();
+  });
+
+  it("rejects asynchronous binding schemas", async () => {
+    const registry = new Registry(runtime()).use(AsyncBindingProtocol);
+    await expect(
+      registry.action("async-binding", "inspect", ACCOUNT, {}, { identity: "fixture" }),
+    ).rejects.toThrow("binding schemas must be synchronous");
+  });
+
+  it("keeps declaration names inside the quoted metadata path", () => {
+    expect(() => new Registry(runtime()).use(UndescribedBindingProtocol)).toThrow(
+      'binding "undescribed-binding.identity" type description must be a non-empty string',
+    );
+  });
+});

--- a/packages/core/test/framework.test.ts
+++ b/packages/core/test/framework.test.ts
@@ -396,7 +396,7 @@ describe("framework core seam", () => {
     );
     expect(() => new Registry(runtime).use(InvalidMetadataProtocol)).toThrow("non-empty string");
     expect(() => new Registry(runtime).use(UndescribedParameterProtocol)).toThrow(
-      "type description",
+      'parameter "undescribed-parameter.inspect.value" type description must be a non-empty string',
     );
   });
 

--- a/packages/core/test/types.fixture.ts
+++ b/packages/core/test/types.fixture.ts
@@ -1,0 +1,143 @@
+import { parseAbi } from "viem";
+import {
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  createProtocolFactory,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  UnsignedIntegerString,
+} from "../src/index.js";
+
+const FixtureAbi = parseAbi(["function transfer(address recipient, uint256 amount)"]);
+const TOKEN = "0x1111111111111111111111111111111111111111" as const;
+const RECIPIENT = "0x2222222222222222222222222222222222222222" as const;
+
+const fixtureBinding = {
+  token: { type: Address, description: "Token contract bound to this compile-time fixture." },
+} satisfies ParamsSpec;
+
+const fixtureParams = {
+  recipient: { type: Address, description: "Recipient of the fixture transfer." },
+  amount: { type: UnsignedIntegerString, description: "Raw fixture transfer amount." },
+} satisfies ParamsSpec;
+
+const noParams = {} satisfies ParamsSpec;
+
+type FixtureBinding = InferParams<typeof fixtureBinding>;
+const validBinding: FixtureBinding = { token: TOKEN };
+// @ts-expect-error Binding values are inferred from the runtime Address schema.
+const invalidBinding: FixtureBinding = { token: 123 };
+
+@Protocol({
+  name: "bound-types-fixture",
+  category: "token",
+  description: "Compile-time bound Protocol fixture.",
+  contracts: {},
+  binding: {
+    params: fixtureBinding,
+    contracts: (binding) => {
+      const token: AddressValue = binding.token;
+      // @ts-expect-error Binding fields come only from the declared runtime schema.
+      void binding.collection;
+      return { token: { abi: FixtureAbi, addr: token } };
+    },
+  },
+})
+class BoundTypesFixture {
+  declare token: Handle<typeof FixtureAbi>;
+
+  @Capability<BoundTypesFixture, typeof fixtureParams>({
+    intent: "Move the bound fixture token",
+    verb: "transfer",
+    params: fixtureParams,
+    receipt: "transferReceipt",
+    risk: ["fundOut"],
+  })
+  async transfer(params: InferParams<typeof fixtureParams>) {
+    return [this.token.transfer([params.recipient, BigInt(params.amount)])];
+  }
+
+  @Query({ intent: "Read the bound fixture token", params: noParams })
+  async inspect() {
+    return { token: this.token.address };
+  }
+
+  @Receipt()
+  transferReceipt(changes: readonly Change[]): ReceiptResult<{ operation: "transfer" }> {
+    return {
+      kind: "receipt",
+      outcome: { operation: "transfer" },
+      text: "fixture",
+      changes: changes.map((change) => ({ kind: "change", change, data: null, text: "change" })),
+    };
+  }
+}
+
+const BoundTypesFactory = createProtocolFactory(BoundTypesFixture, fixtureBinding);
+const bound = BoundTypesFactory.create(validBinding);
+bound.transfer({ recipient: RECIPIENT, amount: "1" });
+bound.inspect({});
+BoundTypesFactory.receipts.transferReceipt([]);
+
+// @ts-expect-error ProtocolFactory is an object, not a callable function.
+BoundTypesFactory(validBinding);
+// @ts-expect-error Factory binding requires the schema-derived token field.
+BoundTypesFactory.create({});
+// @ts-expect-error Factory binding rejects fields not declared by the schema.
+BoundTypesFactory.create({ token: TOKEN, collection: TOKEN });
+// @ts-expect-error Address binding rejects non-address string literals.
+BoundTypesFactory.create({ token: "not-an-address" });
+// @ts-expect-error Bound references expose Capability and Query methods, not Receipt parsers.
+bound.transferReceipt([]);
+// @ts-expect-error Receipt references expose parsers only, not execution methods.
+BoundTypesFactory.receipts.transfer({ recipient: RECIPIENT, amount: "1" });
+// @ts-expect-error Bound method params do not contain Protocol identity.
+bound.transfer({ token: TOKEN, recipient: RECIPIENT, amount: "1" });
+// @ts-expect-error Bound method params retain their schema-derived value types.
+bound.transfer({ recipient: RECIPIENT, amount: 1 });
+
+@Protocol({
+  name: "valid-factory-dependency-fixture",
+  category: "token",
+  description: "Compile-time ProtocolFactory dependency fixture.",
+  contracts: {},
+  protocols: { assets: BoundTypesFactory },
+})
+class ValidFactoryDependencyFixture {
+  declare assets: typeof BoundTypesFactory;
+}
+
+// @ts-expect-error Protocol factory dependencies require a matching typed instance field.
+@Protocol({
+  name: "invalid-factory-dependency-fixture",
+  category: "token",
+  description: "Invalid compile-time ProtocolFactory dependency fixture.",
+  contracts: {},
+  protocols: { assets: BoundTypesFactory },
+})
+class InvalidFactoryDependencyFixture {}
+
+@Protocol({
+  name: "invalid-async-contracts-fixture",
+  category: "token",
+  description: "Invalid asynchronous binding construction fixture.",
+  contracts: {},
+  binding: {
+    params: fixtureBinding,
+    // @ts-expect-error Bound Handle construction must be synchronous.
+    contracts: async ({ token }) => ({ token: { abi: FixtureAbi, addr: token } }),
+  },
+})
+class InvalidAsyncContractsFixture {}
+
+void invalidBinding;
+void ValidFactoryDependencyFixture;
+void InvalidFactoryDependencyFixture;
+void InvalidAsyncContractsFixture;


### PR DESCRIPTION
Closes #61.

## What & why

Add end-to-end Bound Protocol construction to the core Registry so Protocol identity can be supplied separately from operation parameters and reused safely through injected factories.

- Let parameterized Protocols declare a synchronous binding schema and derive its TypeScript type.
- Add explicit, non-callable Protocol factories that validate bindings and return independent Registry-managed references without caching.
- Build dynamic ABI-typed Handles from validated bindings.
- Keep Capability composition, Query results, and binding-free Receipt parser references on separate surfaces.
- Expose binding separately in Registry load/action and serialize it on parameterized CapabilityNodes while leaving unbound nodes unchanged.
- Reject malformed or asynchronous bindings before Protocol execution or RPC.
- Add runtime and compile-time coverage for decorator, factory, binding, method, and Receipt-reference contracts.

## Review notes

Binding input is decoded exactly once before the validated value is reused. This preserves semantic schemas with non-idempotent decode transforms. Existing parameter metadata error paths are also retained byte-for-byte.

Documentation, ADR alignment, and release metadata remain scoped to follow-up issue #67.

## Validation

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test:offline` — 49 passed, 4 skipped
- `git diff --check`

The live Monad checks could not complete locally because the RPC TLS chain failed with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`; the complete offline suite is green.