### PR TITLE
feat: add Monadscan ABI fetcher

### DIFF
--- a/docs/adr/0007-abi-origin.md
+++ b/docs/adr/0007-abi-origin.md
@@ -8,7 +8,15 @@ ABIs are load-bearing security artifacts — one wrong function signature means 
 
 If none of the three is possible, the protocol does not get an adapter.
 
+For Monad mainnet contracts using the `explorer` tier, use the repository CLI instead of copying from the page by hand:
+
+```bash
+MONADSCAN_API_KEY=... pnpm fetch:abi <address> <ExportBaseName> > packages/protocols/<name>/src/abis/<name>.ts
+```
+
 ## Mechanics worth recording
+
+- The explorer tier uses the root `fetch:abi` command against Etherscan API V2 with Monad `chainid=143`, emits TypeScript to stdout, and records the public Monadscan URL plus retrieval date in the generated header.
 
 - **Generated ABIs are committed TypeScript, not JSON.** abitype's type inference — the thing that makes Handles fully typed — requires `as const` literals, which JSON imports cannot provide. Generation scripts emit `export const XAbi = [...] as const` files; human-readable `parseAbi` string arrays are equally acceptable for explorer/vendored tiers.
 - Contributors never need foundry: compiled ABIs are regenerated only when `contracts/` changes. Foundry projects (`contracts/`, `out/`, `cache/`) are excluded from npm (`files: ["dist"]`) and build outputs are gitignored.

--- a/docs/protocol-onboarding.md
+++ b/docs/protocol-onboarding.md
@@ -24,6 +24,13 @@ Every ABI under `src/abis/` declares one origin:
 - `vendored`: generated deterministically from committed full upstream artifacts with package version and tarball digest.
 
 Follow [ADR 0007](./adr/0007-abi-origin.md). Never hand-transcribe an ABI or generate a hand-selected function subset.
+For Monad mainnet verified contracts that use the `explorer` origin, fetch the full ABI through the root CLI and redirect stdout into the protocol package:
+
+```bash
+MONADSCAN_API_KEY=... pnpm fetch:abi 0x1234567890abcdef1234567890abcdef12345678 MyRouter > packages/protocols/myprotocol/src/abis/myrouter.ts
+```
+
+The second argument is the export base name; the command emits `export const MyRouterAbi = [...] as const`. It uses Etherscan API V2 with Monad mainnet `chainid=143`, writes diagnostics to stderr, and does not write files itself.
 
 Every fixed address cites a canonical source and has an on-chain bytecode check. Fixed token constants additionally verify expected metadata. Dynamic pools and tokens come from chain state and do not become global constants.
 
@@ -88,7 +95,7 @@ Registry parses action input with the composed schemas. `load` returns JSON-safe
 
 ## 4. Author one transaction per Capability
 
-Every Capability owns exactly one direct transaction and one registered Receipt parser. More transactions require nested Capabilities. The serialized Capability tree carries `protocol + method`; Registry resolves the Receipt name from the registered Capability metadata.
+Every Capability owns exactly one direct transaction and one named Receipt parser. More transactions require nested Capabilities.
 
 ```ts
 @Capability<MyProtocol, typeof swapParams>({

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   },
   "scripts": {
     "build": "pnpm -r build",
-    "test": "pnpm -r test",
-    "test:offline": "MOSS_SKIP_E2E=1 pnpm test",
+    "test": "pnpm test:fetch-abi && pnpm -r test",
+    "test:fetch-abi": "node --test scripts/fetch-abi.test.mjs",
+    "fetch:abi": "node scripts/fetch-abi.mjs",
     "typecheck": "pnpm -r typecheck",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/scripts/fetch-abi.mjs
+++ b/scripts/fetch-abi.mjs
@@ -1,0 +1,124 @@
+import { fileURLToPath } from "node:url";
+
+const ENDPOINT = "https://api.etherscan.io/v2/api";
+const MONAD_CHAIN_ID = "143";
+const API_KEY_ENV = "MONADSCAN_API_KEY";
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const EXPORT_BASE_RE = /^[A-Za-z_$][0-9A-Za-z_$]*$/;
+
+export async function runCli({
+  argv = process.argv.slice(2),
+  env = process.env,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  fetchImpl = globalThis.fetch,
+  now = new Date(),
+} = {}) {
+  try {
+    const output = await fetchAbiModule({ argv, env, fetchImpl, now });
+    stdout.write(output);
+    return 0;
+  } catch (error) {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+export async function fetchAbiModule({ argv, env, fetchImpl, now }) {
+  const { address, exportBaseName } = parseArgs(argv);
+  const apiKey = env[API_KEY_ENV];
+  if (!apiKey) {
+    throw new Error(`missing ${API_KEY_ENV}; create a Monadscan/Etherscan API key first`);
+  }
+  if (typeof fetchImpl !== "function") {
+    throw new Error("global fetch is unavailable; Node 22+ is required");
+  }
+
+  const abi = await fetchContractAbi({ address, apiKey, fetchImpl });
+  return formatAbiModule({
+    abi,
+    address,
+    exportName: `${exportBaseName}Abi`,
+    retrievedDate: now.toISOString().slice(0, 10),
+  });
+}
+
+export function parseArgs(argv) {
+  if (argv.length !== 2) {
+    throw new Error("usage: pnpm fetch:abi <contractAddress> <exportBaseName>");
+  }
+  const [rawAddress, rawExportBaseName] = argv;
+  if (!ADDRESS_RE.test(rawAddress ?? "")) {
+    throw new Error("contractAddress must be a 20-byte 0x-prefixed hexadecimal address");
+  }
+  if (!EXPORT_BASE_RE.test(rawExportBaseName ?? "")) {
+    throw new Error("exportBaseName must be a valid TypeScript identifier, such as KuruRouter");
+  }
+  return {
+    address: rawAddress.toLowerCase(),
+    exportBaseName: rawExportBaseName,
+  };
+}
+
+async function fetchContractAbi({ address, apiKey, fetchImpl }) {
+  const url = new URL(ENDPOINT);
+  url.searchParams.set("chainid", MONAD_CHAIN_ID);
+  url.searchParams.set("module", "contract");
+  url.searchParams.set("action", "getabi");
+  url.searchParams.set("address", address);
+  url.searchParams.set("apikey", apiKey);
+
+  let response;
+  try {
+    response = await fetchImpl(url);
+  } catch (error) {
+    throw new Error(`failed to reach Monadscan ABI endpoint: ${redact(String(error), apiKey)}`);
+  }
+  if (!response?.ok) {
+    throw new Error(`Monadscan ABI endpoint returned HTTP ${response?.status ?? "unknown"}`);
+  }
+
+  let envelope;
+  try {
+    envelope = await response.json();
+  } catch (error) {
+    throw new Error(
+      `Monadscan ABI endpoint returned invalid JSON: ${redact(String(error), apiKey)}`,
+    );
+  }
+  if (envelope?.status !== "1" || typeof envelope.result !== "string") {
+    const message = envelope?.message ? ` (${envelope.message})` : "";
+    throw new Error(`Monadscan ABI endpoint did not return a verified ABI${message}`);
+  }
+
+  let abi;
+  try {
+    abi = JSON.parse(envelope.result);
+  } catch (error) {
+    throw new Error(`Monadscan ABI result is not valid JSON: ${redact(String(error), apiKey)}`);
+  }
+  if (!Array.isArray(abi)) {
+    throw new Error("Monadscan ABI result must parse to an ABI array");
+  }
+  return abi;
+}
+
+export function formatAbiModule({ abi, address, exportName, retrievedDate }) {
+  return `// GENERATED FILE - do not edit by hand.
+//   regenerate from Monadscan: pnpm fetch:abi ${address} ${exportName.replace(/Abi$/, "")}
+// ABI origin: explorer (ADR 0007)
+//   source:    https://monadscan.com/address/${address}
+//   endpoint:  Etherscan API V2 Get Contract ABI, chainid ${MONAD_CHAIN_ID}
+//   retrieved: ${retrievedDate}
+
+export const ${exportName} = ${JSON.stringify(abi, null, 2)} as const;
+`;
+}
+
+function redact(message, secret) {
+  return secret ? message.split(secret).join("[REDACTED]") : message;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exitCode = await runCli();
+}

--- a/scripts/fetch-abi.test.mjs
+++ b/scripts/fetch-abi.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runCli } from "./fetch-abi.mjs";
+
+const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const KEY = "secret-monadscan-key";
+const NOW = new Date("2026-07-17T00:00:00.000Z");
+const SAMPLE_ABI = [
+  {
+    type: "function",
+    name: "balanceOf",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+];
+
+test("fetches a verified ABI and emits deterministic TypeScript to stdout", async () => {
+  const calls = [];
+  const result = await run({
+    fetchImpl: async (url) => {
+      calls.push(url);
+      return ok({ status: "1", message: "OK", result: JSON.stringify(SAMPLE_ABI) });
+    },
+  });
+
+  assert.equal(result.code, 0);
+  assert.equal(result.stderr, "");
+  assert.match(result.stdout, /ABI origin: explorer \(ADR 0007\)/);
+  assert.match(result.stdout, new RegExp(`https://monadscan.com/address/${ADDRESS}`));
+  assert.match(result.stdout, /Etherscan API V2 Get Contract ABI, chainid 143/);
+  assert.match(result.stdout, /retrieved: 2026-07-17/);
+  assert.match(result.stdout, /export const KuruRouterAbi = \[/);
+  assert.match(result.stdout, /"balanceOf"/);
+  assert.match(result.stdout, / as const;\n$/);
+
+  const url = calls[0];
+  assert.equal(url.origin + url.pathname, "https://api.etherscan.io/v2/api");
+  assert.equal(url.searchParams.get("chainid"), "143");
+  assert.equal(url.searchParams.get("module"), "contract");
+  assert.equal(url.searchParams.get("action"), "getabi");
+  assert.equal(url.searchParams.get("address"), ADDRESS);
+  assert.equal(url.searchParams.get("apikey"), KEY);
+});
+
+test("rejects an invalid address before making a network request", async () => {
+  let called = false;
+  const result = await run({
+    argv: ["0xabc", "KuruRouter"],
+    fetchImpl: async () => {
+      called = true;
+      return ok({});
+    },
+  });
+  assert.equal(called, false);
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /20-byte/);
+});
+
+test("rejects an invalid export base name before making a network request", async () => {
+  let called = false;
+  const result = await run({
+    argv: [ADDRESS, "123Router"],
+    fetchImpl: async () => {
+      called = true;
+      return ok({});
+    },
+  });
+  assert.equal(called, false);
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /valid TypeScript identifier/);
+});
+
+test("requires MONADSCAN_API_KEY", async () => {
+  const result = await run({ env: {}, fetchImpl: async () => ok({}) });
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /missing MONADSCAN_API_KEY/);
+});
+
+test("reports HTTP failures without leaking the API key", async () => {
+  const result = await run({
+    fetchImpl: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+  });
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /HTTP 500/);
+  assert.doesNotMatch(result.stderr, new RegExp(KEY));
+});
+
+test("reports API failure envelopes without emitting TypeScript", async () => {
+  const result = await run({
+    fetchImpl: async () => ok({ status: "0", message: "NOTOK", result: "Missing/Invalid API Key" }),
+  });
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /did not return a verified ABI/);
+});
+
+test("rejects malformed ABI JSON", async () => {
+  const result = await run({
+    fetchImpl: async () => ok({ status: "1", message: "OK", result: "not json" }),
+  });
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /not valid JSON/);
+});
+
+test("rejects ABI results that are not arrays", async () => {
+  const result = await run({
+    fetchImpl: async () => ok({ status: "1", message: "OK", result: JSON.stringify({}) }),
+  });
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /ABI array/);
+});
+
+test("redacts the API key from network error messages", async () => {
+  const result = await run({
+    fetchImpl: async () => {
+      throw new Error(`request failed with ${KEY}`);
+    },
+  });
+  assert.equal(result.code, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /\[REDACTED\]/);
+  assert.doesNotMatch(result.stderr, new RegExp(KEY));
+});
+
+async function run({
+  argv = [ADDRESS, "KuruRouter"],
+  env = { MONADSCAN_API_KEY: KEY },
+  fetchImpl,
+} = {}) {
+  let stdout = "";
+  let stderr = "";
+  const code = await runCli({
+    argv,
+    env,
+    fetchImpl,
+    now: NOW,
+    stdout: { write: (chunk) => (stdout += chunk) },
+    stderr: { write: (chunk) => (stderr += chunk) },
+  });
+  return { code, stdout, stderr };
+}
+
+function ok(body) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #28.

- adds a root `pnpm fetch:abi <contractAddress> <exportBaseName>` CLI for Monad mainnet verified contract ABIs
- uses Etherscan API V2 with Monad `chainid=143` and `MONADSCAN_API_KEY`
- emits `export const <ExportBaseName>Abi = [...] as const` to stdout with an ADR 0007 explorer provenance header
- adds mocked Node test coverage for success, argument validation, API failures, malformed results, and API-key redaction
- documents the explorer-origin workflow in ADR 0007 and protocol onboarding

## Notes

The command intentionally writes generated TypeScript to stdout and diagnostics to stderr so contributors can review and redirect output into a protocol package. It does not scrape Monadscan HTML, batch requests, cache results, or merge proxy implementation ABIs.

## Verification

- `corepack pnpm lint`
- `corepack pnpm -r build`
- `corepack pnpm -r typecheck`
- `corepack pnpm test:fetch-abi`
- `MOSS_SKIP_E2E=1 corepack pnpm -r test`
- `git diff --check`

I did not run a live Monadscan smoke test because no `MONADSCAN_API_KEY` is available in this environment.