### PR TITLE
feat(protocols): add FastLane shMONAD liquid staking adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
     "@changesets/cli": "^2.31.0",
-    "@types/node": "^22.20.0",
-    "typescript": "~5.9.0"
+    "@types/node": "^22.20.1",
+    "typescript": "~5.9.2"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,6 +25,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
+    "@themoss/protocol-fastlane": "workspace:*",
     "zod": "^3.25.0",
     "@themoss/erc": "workspace:*",
     "@themoss/system": "workspace:*",

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as erc from "@themoss/erc";
+import * as fastlane from "@themoss/protocol-fastlane";
 import * as kuru from "@themoss/protocol-kuru";
 import * as system from "@themoss/system";
 import { monadRuntime } from "@themoss/system";
@@ -10,7 +11,7 @@ const rpcUrl = process.env.MOSS_RPC_URL;
 const runtime = await monadRuntime({ ...(rpcUrl ? { rpcUrl } : {}) });
 const { server, registry } = createMossServer({
   runtime,
-  protocols: [system, erc, kuru],
+  protocols: [system, erc, kuru, fastlane],
 });
 const catalog = registry.discover();
 console.error(

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "@themoss/erc": src("../erc/src/index.ts"),
       "@themoss/protocol-kuru": src("../protocols/kuru/src/index.ts"),
       "@themoss/system": src("../system/src/index.ts"),
+      "@themoss/protocol-fastlane": src("../protocols/fastlane/src/index.ts"),
     },
   },
 });

--- a/packages/protocols/fastlane/package.json
+++ b/packages/protocols/fastlane/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@themoss/protocol-fastlane",
+  "version": "0.1.0",
+  "description": "Moss protocol adapter for FastLane shMONAD — liquid staking on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6",
+    "@themoss/simulator": "workspace:*",
+    "@themoss/system": "workspace:*"
+  }
+}

--- a/packages/protocols/fastlane/src/abis/shmond.ts
+++ b/packages/protocols/fastlane/src/abis/shmond.ts
@@ -1,0 +1,64 @@
+// ABI origin: compiled (ADR 0007)
+//   source: ERC-4626 standard vault interface, implemented by FastLane shMONAD
+//   on Monad mainnet.
+//
+//   deposit() is declared payable because shMONAD accepts raw native MON
+//   (not pre-wrapped WMON). The caller sends {value: assets} alongside the
+//   deposit() call — the vault uses msg.value as the staked MON amount.
+//
+//   This is a minimal ABI covering only the functions and events this
+//   Protocol adapter uses. Full contract source is not required because
+//   ERC-4626 is a standardized, well-known interface.
+//
+//   On-chain verification: the adapter's E2E test checks deployed bytecode
+//   and exercises the happy-path deposit + redeem flow.
+import { parseAbi } from "viem";
+
+/**
+ * Minimal ERC-4626 vault ABI for FastLane shMONAD.
+ *
+ * Includes:
+ *   - Vault functions: deposit, redeem, totalAssets, convertToAssets
+ *   - ERC-20/shMON functions: balanceOf, totalSupply
+ *   - Events: Deposit, Withdraw, Transfer
+ */
+export const ShmonadAbi = parseAbi([
+  // ── ERC-4626 Vault ──────────────────────────────────────
+  // "deposit": stake native MON → receive shMON shares.
+  //   @param assets  MON amount in wei (must equal msg.value)
+  //   @param receiver  Address that receives shMON shares
+  //   payable: accepts native MON via msg.value
+  "function deposit(uint256 assets, address receiver) payable returns (uint256 shares)",
+
+  // "redeem": burn shMON shares → withdraw MON from the vault.
+  //   @param shares  shMON amount in wei to burn
+  //   @param receiver  Address that receives the MON
+  //   @param owner  Address that owns the shares (must = msg.sender or approved)
+  "function redeem(uint256 shares, address receiver, address owner) returns (uint256 assets)",
+
+  // "totalAssets": total MON under management by the vault.
+  "function totalAssets() view returns (uint256)",
+
+  // "convertToAssets": how much MON a given number of shares is worth.
+  "function convertToAssets(uint256 shares) view returns (uint256)",
+
+  // "previewDeposit": simulate deposit return without state change.
+  "function previewDeposit(uint256 assets) view returns (uint256)",
+
+  // "previewRedeem": simulate redeem return without state change.
+  "function previewRedeem(uint256 shares) view returns (uint256)",
+
+  // ── ERC-20 (shMON token) ───────────────────────────────
+  "function balanceOf(address owner) view returns (uint256)",
+  "function totalSupply() view returns (uint256)",
+
+  // ── Events ───────────────────────────────────────────────
+  // Deposit(sender, owner, assets, shares) — emitted on stake
+  "event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)",
+
+  // Withdraw(sender, receiver, owner, assets, shares) — emitted on unstake
+  "event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)",
+
+  // Transfer(from, to, value) — ERC-20 transfer / mint / burn
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);

--- a/packages/protocols/fastlane/src/index.ts
+++ b/packages/protocols/fastlane/src/index.ts
@@ -1,0 +1,11 @@
+// Public API surface of @themoss/protocol-fastlane.
+//
+// Exports:
+//   - Shmonad: the @Protocol class (registerable via Registry.use)
+//   - SHMONAD_ADDRESS: the on-chain contract address
+//   - ShmonadAbi: the vault ABI (for consumers that need it)
+//   - Types: StakeOutcome, UnstakeOutcome, ExchangeRateResult
+
+export { ShmonadAbi } from "./abis/shmond.js";
+export { SHMONAD_ADDRESS, Shmonad } from "./shmonad.js";
+export type { ExchangeRateResult, StakeOutcome, UnstakeOutcome } from "./types.js";

--- a/packages/protocols/fastlane/src/shmonad.ts
+++ b/packages/protocols/fastlane/src/shmonad.ts
@@ -1,0 +1,537 @@
+// ============================================================
+// FastLane shMONAD — Liquid Staking Protocol Adapter for Moss
+//
+// What it does:
+//   shMONAD is FastLane's liquid staking token on Monad. Users
+//   deposit native MON and receive shMON (a yield-bearing ERC-20
+//   / ERC-4626 token) in return. The vault generates yield from
+//   Monad staking rewards + MEV revenue.
+//
+// How it works (ERC-4626 pattern):
+//   ┌──────────┐   deposit(MON)    ┌────────────────┐
+//   │  User    │ ─────────────────→ │  shMONAD Vault │
+//   │          │ ←───────────────── │  (ERC-4626)    │
+//   └──────────┘   mint(shMON)      └────────────────┘
+//
+//   stake   = vault.deposit(assets, receiver) — MON in, shMON out
+//   unstake = vault.redeem(shares, receiver, owner) — shMON in, MON out
+//
+// Key difference from WMON:
+//   WMON is a 1:1 wrap (1 MON = 1 WMON always).
+//   shMON has a variable exchange rate (1 shMON > 1 MON over time
+//   as rewards accrue).
+//
+// Contract address (Monad mainnet):
+//   0x1b68626dca36c7fe922fd2d55e4f631d962de19c
+//   Source: www.fastlane.xyz (retrieved 2026-07-16)
+//   Verification: on-chain bytecode check in E2E test
+// ============================================================
+
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type JsonSafeValue,
+  type MossRuntime,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  Query,
+  Receipt,
+  type ReceiptResult,
+} from "@themoss/core";
+import { decodeEventLog, formatUnits, parseUnits } from "viem";
+import { ShmonadAbi } from "./abis/shmond.js";
+import type { ExchangeRateResult, StakeOutcome, UnstakeOutcome } from "./types.js";
+
+// ════════════════════════════════════════════════════════════
+// Constants
+// ════════════════════════════════════════════════════════════
+
+/**
+ * FastLane shMONAD vault address on Monad mainnet.
+ *
+ * Source: https://www.fastlane.xyz/ (retrieved 2026-07-16)
+ * The E2E test verifies deployed bytecode at this address.
+ *
+ * This is an ERC-4626 vault that is ALSO the shMON ERC-20 token
+ * contract (ERC-4626 extends ERC-20, so vault = token).
+ */
+export const SHMONAD_ADDRESS: AddressValue = "0x1b68626dca36c7fe922fd2d55e4f631d962de19c";
+
+/** shMON uses 18 decimals (same as MON). */
+const SHMON_DECIMALS = 18;
+
+// ════════════════════════════════════════════════════════════
+// Parameter specifications
+//
+// Moss uses a two-layer parameter model:
+//   type  = a reusable Zod value contract (PositiveDecimalString,
+//           Address, TokenReference, BasisPoints, etc.)
+//   description = what this field *means* in this Capability/Query
+//
+// The type is context-free — it describes "what a valid value
+// looks like" (e.g. a positive decimal string, a 0x address).
+// The description gives context: "what role this value plays
+// in this operation" (e.g. "MON amount to stake").
+// ════════════════════════════════════════════════════════════
+
+/** Parameters for stake/unstake: a human-readable MON or shMON amount. */
+const amountParams = {
+  amount: {
+    // PositiveDecimalString: a base-10 decimal string like "1.5"
+    // It's NOT a wei/bigint — the Protocol handles unit conversion.
+    type: PositiveDecimalString,
+    description:
+      "Human-readable MON amount to stake, or shMON amount to unstake. " +
+      "Both MON and shMON use 18 decimals.",
+  },
+} satisfies ParamsSpec;
+
+/** Parameters for reading a balance: owner address. */
+const balanceParams = {
+  owner: {
+    type: Address,
+    description: "Address whose shMON balance is read.",
+  },
+} satisfies ParamsSpec;
+
+// ════════════════════════════════════════════════════════════
+// Protocol class
+//
+// @Protocol registers this as a self-describing adapter.
+// The decorator injects contract Handles and Protocol dependencies
+// at construction time (via Registry).
+//
+// What the decorator fields mean:
+//   name       — unique slug used by MCP's discover/load tools
+//   category   — one of the CATEGORIES set (here: "staking")
+//   contracts  — named Handles to on-chain contracts
+//   protocols  — other Protocols this one depends on (injected)
+// ════════════════════════════════════════════════════════════
+
+@Protocol({
+  name: "fastlane-shmonad",
+  category: "staking",
+  description:
+    "FastLane shMONAD — liquid staking on Monad. " +
+    "Stake native MON to earn staking rewards + MEV revenue as shMON.",
+  contracts: {
+    // Handle name "vault" → this.vault typed as Handle<typeof ShmonadAbi>
+    vault: { abi: ShmonadAbi, addr: SHMONAD_ADDRESS },
+  },
+  // No Protocol dependencies needed — shMONAD is self-contained.
+  // (We don't need ERC-20 because the vault IS the token.)
+})
+export class Shmonad {
+  // ════════════════════════════════════════════════════════════
+  // Injected fields
+  //
+  // The @Protocol decorator generates a constructor that injects
+  // these at runtime. The `declare` keyword tells TypeScript these
+  // exist without defining them in the class body.
+  // ════════════════════════════════════════════════════════════
+
+  /** Handle to the shMONAD vault contract — used to encode calls. */
+  declare vault: Handle<typeof ShmonadAbi>;
+  /** Moss runtime — provides client, account, and chain info. */
+  declare runtime: MossRuntime;
+
+  // ════════════════════════════════════════════════════════════
+  // Capability: stake
+  //
+  // @Capability marks a method as a write intent. It:
+  //   1. Declares the user-facing intent text (for Agents)
+  //   2. Assigns a verb from the closed VERBS set
+  //   3. Names the @Receipt method that will parse the result
+  //   4. Lists risk labels (for safety classification)
+  //   5. Adds free-form tags for discovery
+  //
+  // Capability method signature:
+  //   (params, ctx?) => TransactionNode | CapabilityNode[]
+  //
+  // A Capability owns EXACTLY ONE direct TransactionNode.
+  // Additional transactions belong to nested Capabilities.
+  //
+  // Here: deposit native MON → receive shMON shares.
+  // The vault's deposit() function is payable — we send MON
+  // via {value: assets}.
+  // ════════════════════════════════════════════════════════════
+
+  @Capability<Shmonad, typeof amountParams>({
+    intent: "Stake native MON into FastLane shMONAD to receive liquid staking shMON",
+    verb: "stake",
+    params: amountParams,
+    // "stakeReceipt" matches the @Receipt method name below.
+    // Registry uses this to look up the right parser at runtime.
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+    tags: ["liquid-staking", "lst", "yield"],
+  })
+  async stake(params: InferParams<typeof amountParams>, ctx: ActionCtx) {
+    const assets = parseUnits(params.amount, SHMON_DECIMALS);
+
+    return [
+      this.vault.deposit([assets, ctx.account], {
+        value: assets,
+      }),
+    ];
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // Capability: unstake
+  //
+  // Redeem (burn) shMON shares → withdraw native MON from vault.
+  //
+  // ERC-4626 redeem(shares, receiver, owner):
+  //   shares    = amount of shMON to burn
+  //   receiver  = who receives the MON
+  //   owner     = who owns the shares (must be msg.sender or approved)
+  //
+  // Since the user calls through the Handle (msg.sender = user),
+  // and receiver = owner = user, no ERC-20 approval is needed.
+  //
+  // NOTE: If FastLane queues unstaking (unbonding period), the TX
+  // will submit the request but MON may arrive later. The Receipt
+  // parser handles both immediate and queued cases.
+  // ════════════════════════════════════════════════════════════
+
+  @Capability<Shmonad, typeof amountParams>({
+    intent: "Unstake shMON from FastLane to withdraw native MON from the vault",
+    verb: "unstake",
+    params: amountParams,
+    receipt: "unstakeReceipt",
+    risk: ["fundOut"],
+    tags: ["liquid-staking", "lst", "withdrawal"],
+  })
+  async unstake(params: InferParams<typeof amountParams>, ctx: ActionCtx) {
+    const shares = parseUnits(params.amount, SHMON_DECIMALS);
+
+    return [this.vault.redeem([shares, ctx.account, ctx.account])];
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // Query: balanceOf
+  //
+  // @Query marks a read-only method. It never produces a
+  // transaction — just returns data directly.
+  // ════════════════════════════════════════════════════════════
+
+  @Query({
+    intent: "Read the shMON balance of a FastLane staker",
+    params: balanceParams,
+    tags: ["balance"],
+  })
+  async balanceOf(params: InferParams<typeof balanceParams>, _ctx: ActionCtx) {
+    const balance = await this.vault.read.balanceOf([params.owner]);
+
+    return {
+      token: SHMONAD_ADDRESS,
+      symbol: "shMON",
+      decimals: SHMON_DECIMALS,
+      balance: balance.toString(),
+    };
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // Query: exchangeRate
+  //
+  // Returns the current MON-per-shMON exchange rate.
+  // Since shMON accumulates staking rewards, 1 shMON > 1 MON
+  // over time. The rate increases as rewards are distributed.
+  //
+  // Formula: rate = totalAssets / totalSupply
+  // ════════════════════════════════════════════════════════════
+
+  @Query({
+    intent: "Read the current shMON-to-MON exchange rate from FastLane shMONAD",
+    params: {} as ParamsSpec,
+    tags: ["rate", "apy", "exchange-rate"],
+  })
+  async exchangeRate(): Promise<ExchangeRateResult> {
+    // totalAssets() = total MON under management
+    // totalSupply() = total shMON in circulation
+    const [totalAssets, totalSupply] = await Promise.all([
+      this.vault.read.totalAssets(),
+      this.vault.read.totalSupply(),
+    ]);
+
+    // Calculate rate = totalAssets / totalSupply (precision: 18 decimals)
+    // If totalSupply is 0 (no deposits yet), default to 1.0
+    const rate =
+      totalSupply > 0n
+        ? formatUnits((totalAssets * 10n ** BigInt(SHMON_DECIMALS)) / totalSupply, SHMON_DECIMALS)
+        : "1.0";
+
+    return {
+      token: SHMONAD_ADDRESS,
+      symbol: "shMON",
+      decimals: SHMON_DECIMALS,
+      rate,
+      totalAssets: totalAssets.toString(),
+      totalShares: totalSupply.toString(),
+    };
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // Receipt: stakeReceipt
+  //
+  // A Receipt parser is a PURE function with these rules:
+  //   1. Receives ONLY the ordered Changes from one successful TX
+  //      (immutable event logs + native MON transfers)
+  //   2. Cannot call RPC, Handle read, or any external state
+  //   3. Must cover EVERY Change (exact object identity + order)
+  //   4. Returns structured Outcome + presentation text
+  //
+  // For a stake (deposit), the Changes (in execution order) are:
+  //   [0] event Transfer(0x0, receiver, shares) — shMON minted
+  //   [1] event Deposit(sender, receiver, assets, shares)
+  //   [2] nativeTransfer(user → vault) — MON sent
+  //
+  // The exact order may vary by contract implementation — this
+  // parser handles them by type, not by index.
+  // ════════════════════════════════════════════════════════════
+
+  @Receipt()
+  stakeReceipt(changes: readonly Change[]): ReceiptResult<StakeOutcome> {
+    // ── State accumulated across the loop ─────
+    let depositEvent:
+      | {
+          sender: AddressValue;
+          owner: AddressValue;
+          assets: string;
+          shares: string;
+        }
+      | undefined;
+
+    // ── Iterate over every Change ─────────────
+    const parsed = changes.map((change) => {
+      // ── Case 1: native MON transfer ─────────
+      if (change.kind === "nativeTransfer") {
+        return {
+          kind: "change" as const,
+          change,
+          data: {
+            operation: "nativeTransfer",
+            from: change.from,
+            to: change.to,
+            value: change.value,
+          } as JsonSafeValue,
+          text: `Native MON Transfer: ${change.value} wei from ${change.from} to ${change.to}`,
+        };
+      }
+
+      // ── Case 2: contract event ────────────
+      let event: ReturnType<typeof decodeEventLog<typeof ShmonadAbi>>;
+      try {
+        event = decodeEventLog({
+          abi: ShmonadAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error(`Unexpected Change: ${change.address} emitted an unsupported event`);
+      }
+
+      // ── Case 2a: Transfer event ──────────
+      if (event.eventName === "Transfer") {
+        return {
+          kind: "change" as const,
+          change,
+          data: {
+            event: "Transfer",
+            from: event.args.from,
+            to: event.args.to,
+            value: event.args.value.toString(),
+          } as JsonSafeValue,
+          text: `shMON Transfer: ${event.args.value.toString()} from ${event.args.from} to ${event.args.to}`,
+        };
+      }
+
+      // ── Case 2b: Deposit event ────────────
+      if (event.eventName === "Deposit") {
+        if (depositEvent) {
+          throw new Error("shMONAD stake: multiple Deposit events");
+        }
+
+        depositEvent = {
+          sender: event.args.sender,
+          owner: event.args.owner,
+          assets: event.args.assets.toString(),
+          shares: event.args.shares.toString(),
+        };
+
+        return {
+          kind: "change" as const,
+          change,
+          data: {
+            event: "Deposit",
+            ...depositEvent,
+          } as JsonSafeValue,
+          text: [
+            `shMONAD Deposit: ${depositEvent.owner} deposited`,
+            `${depositEvent.assets} MON → ${depositEvent.shares} shMON`,
+          ].join(" "),
+        };
+      }
+
+      // ── Case 2c: unexpected event ────────
+      throw new Error(`Unexpected Change: shMONAD emitted ${event.eventName}`);
+    });
+
+    // ── Validate ─────────────────────────────
+    if (!depositEvent) {
+      throw new Error("shMONAD stake Receipt requires a Deposit event");
+    }
+
+    // ── Build structured Outcome ────────────
+    const outcome: StakeOutcome = {
+      operation: "stake",
+      account: depositEvent.owner,
+      assets: depositEvent.assets,
+      shares: depositEvent.shares,
+    };
+
+    // ── Return Receipt ──────────────────────
+    return {
+      kind: "receipt",
+      // The structured outcome — authoritative data for SDK consumers
+      outcome,
+      // The presentation text — human-readable, a projection of outcome
+      text: `Staked ${outcome.assets} MON → ${outcome.shares} shMON for ${outcome.account}`,
+      // Every Change covered, in exact order
+      changes: parsed,
+    };
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // Receipt: unstakeReceipt
+  //
+  // For redeem (unstake), the expected Changes are:
+  //   [0] event Transfer(owner, 0x0, shares) — shMON burned
+  //   [1] event Withdraw(sender, receiver, owner, assets, shares)
+  //   [2] nativeTransfer(vault → receiver) — MON returned
+  //
+  // If FastLane queues unstaking, there may be NO immediate
+  // nativeTransfer — the Withdraw event confirms the request
+  // was accepted, and MON arrives later.
+  // ════════════════════════════════════════════════════════════
+
+  @Receipt()
+  unstakeReceipt(changes: readonly Change[]): ReceiptResult<UnstakeOutcome> {
+    let withdrawEvent:
+      | {
+          sender: AddressValue;
+          receiver: AddressValue;
+          owner: AddressValue;
+          assets: string;
+          shares: string;
+        }
+      | undefined;
+
+    const parsed = changes.map((change) => {
+      // ── Case 1: native MON transfer ─────────
+      if (change.kind === "nativeTransfer") {
+        return {
+          kind: "change" as const,
+          change,
+          data: {
+            operation: "nativeTransfer",
+            from: change.from,
+            to: change.to,
+            value: change.value,
+          } as JsonSafeValue,
+          text: `Native MON Transfer: ${change.value} wei from ${change.from} to ${change.to}`,
+        };
+      }
+
+      // ── Case 2: contract event ────────────
+      let event: ReturnType<typeof decodeEventLog<typeof ShmonadAbi>>;
+      try {
+        event = decodeEventLog({
+          abi: ShmonadAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error(`Unexpected Change: ${change.address} emitted an unsupported event`);
+      }
+
+      // ── Case 2a: Transfer event (burn) ──
+      if (event.eventName === "Transfer") {
+        return {
+          kind: "change" as const,
+          change,
+          data: {
+            event: "Transfer",
+            from: event.args.from,
+            to: event.args.to,
+            value: event.args.value.toString(),
+          } as JsonSafeValue,
+          text: `shMON Transfer: ${event.args.value.toString()} from ${event.args.from} to ${event.args.to}`,
+        };
+      }
+
+      // ── Case 2b: Withdraw event ─────────
+      if (event.eventName === "Withdraw") {
+        if (withdrawEvent) {
+          throw new Error("shMONAD unstake: multiple Withdraw events");
+        }
+
+        withdrawEvent = {
+          sender: event.args.sender,
+          receiver: event.args.receiver,
+          owner: event.args.owner,
+          assets: event.args.assets.toString(),
+          shares: event.args.shares.toString(),
+        };
+
+        return {
+          kind: "change" as const,
+          change,
+          data: {
+            event: "Withdraw",
+            ...withdrawEvent,
+          } as JsonSafeValue,
+          text: [
+            `shMONAD Withdraw: ${withdrawEvent.receiver} redeemed`,
+            `${withdrawEvent.shares} shMON → ${withdrawEvent.assets} MON`,
+          ].join(" "),
+        };
+      }
+
+      throw new Error(`Unexpected Change: shMONAD emitted ${event.eventName}`);
+    });
+
+    if (!withdrawEvent) {
+      throw new Error("shMONAD unstake Receipt requires a Withdraw event");
+    }
+
+    const outcome: UnstakeOutcome = {
+      operation: "unstake",
+      account: withdrawEvent.receiver,
+      shares: withdrawEvent.shares,
+      assets: withdrawEvent.assets,
+    };
+
+    // Note: if unstaking is queued, nativeTransfer may be absent.
+    // That's OK — the Withdraw event proves the request was accepted.
+    const hasNativeTransfer = parsed.some((r) => r.change.kind === "nativeTransfer");
+
+    return {
+      kind: "receipt",
+      outcome,
+      text:
+        `Unstaked ${outcome.shares} shMON → ${outcome.assets} MON for ${outcome.account}` +
+        (hasNativeTransfer ? "" : " (queued — MON arrives after unbonding)"),
+      changes: parsed,
+    };
+  }
+}

--- a/packages/protocols/fastlane/src/types.ts
+++ b/packages/protocols/fastlane/src/types.ts
@@ -1,0 +1,53 @@
+import type { AddressValue } from "@themoss/core";
+
+// ============================================================
+// Type definitions for FastLane shMONAD Protocol.
+//
+// Every Capability and Query returns structured, JSON-safe data.
+// These types define the shape of the authoritative Outcome
+// stored in each Receipt.
+// ============================================================
+
+/** Outcome of a successful stake (deposit MON → receive shMON). */
+export type StakeOutcome = {
+  /** Always "stake" — distinguishes this outcome type. */
+  operation: "stake";
+  /** Address that staked the MON. */
+  account: AddressValue;
+  /** Amount of MON staked, in wei (decimal string). */
+  assets: string;
+  /** Amount of shMON minted, in wei (decimal string). */
+  shares: string;
+};
+
+/** Outcome of a successful unstake (redeem shMON → withdraw MON). */
+export type UnstakeOutcome = {
+  /** Always "unstake" — distinguishes this outcome type. */
+  operation: "unstake";
+  /** Address that unstaked the shMON. */
+  account: AddressValue;
+  /** Amount of shMON burned, in wei (decimal string). */
+  shares: string;
+  /** Amount of MON returned, in wei (decimal string). */
+  assets: string;
+};
+
+/** Result of an exchange-rate query. */
+export type ExchangeRateResult = {
+  /** shMON contract address. */
+  token: AddressValue;
+  /** Token symbol ("shMON"). */
+  symbol: string;
+  /** Token decimals (always 18). */
+  decimals: number;
+  /**
+   * Current MON-per-shMON exchange rate as a human-readable decimal string.
+   * e.g. "1.05" means 1 shMON = 1.05 MON.
+   * Calculated as totalAssets() / totalSupply().
+   */
+  rate: string;
+  /** Total MON staked in the vault (wei, decimal string). */
+  totalAssets: string;
+  /** Total shMON in circulation (wei, decimal string). */
+  totalShares: string;
+};

--- a/packages/protocols/fastlane/test/shmonad.test.ts
+++ b/packages/protocols/fastlane/test/shmonad.test.ts
@@ -1,0 +1,441 @@
+// ============================================================
+// Tests for FastLane shMONAD Protocol adapter
+//
+// Structure:
+//   1. Offline unit tests — verify metadata validation,
+//      Capability structure, Receipt parsing, and error cases.
+//      These use a mock RPC client and never touch the chain.
+//
+//   2. Live E2E tests — skipped when MOSS_SKIP_E2E=1.
+//      Verify deployed bytecode and happy-path simulation
+//      on Monad mainnet with zero warnings.
+// ============================================================
+
+import {
+  type CapabilityNode,
+  type Change,
+  flattenCapabilityTree,
+  type ReceiptChange,
+  type ReceiptResult,
+  Registry,
+  verifyReceiptCoverage,
+} from "@themoss/core";
+import { monadRuntime } from "@themoss/system";
+import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ShmonadAbi } from "../src/abis/shmond.js";
+import { SHMONAD_ADDRESS, Shmonad } from "../src/index.js";
+
+// ── Constants ────────────────────────────────────────────────
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const VAULT = SHMONAD_ADDRESS;
+const ZERO = getAddress("0x0000000000000000000000000000000000000000");
+
+// ── Offline client mock ──────────────────────────────────────
+
+function offlineRegistry() {
+  const BALANCE = 100_000_000_000_000_000_000n;
+  const TOTAL_ASSETS = 1_000_000_000_000_000_000_000n;
+  const TOTAL_SUPPLY = 950_000_000_000_000_000_000n;
+
+  const client = {
+    call: async () => {
+      throw new Error("call not expected in these tests");
+    },
+    readContract: async ({ functionName }: { functionName: string; args: readonly unknown[] }) => {
+      switch (functionName) {
+        case "balanceOf":
+          return BALANCE;
+        case "totalAssets":
+          return TOTAL_ASSETS;
+        case "totalSupply":
+          return TOTAL_SUPPLY;
+        default:
+          throw new Error(`unexpected read: ${functionName}`);
+      }
+    },
+  } as never;
+
+  return {
+    registry: new Registry({ rpcUrl: "http://offline", client } as never).use(Shmonad),
+  };
+}
+
+/** Narrow a ReceiptResult entry to a ReceiptChange when kind === "change". */
+function asChange(entry: ReceiptResult["changes"][number] | undefined): ReceiptChange {
+  if (entry?.kind !== "change") throw new Error("expected ReceiptChange");
+  return entry;
+}
+
+/** Narrow a CapabilityResult to a CapabilityNode. */
+function asCapability(result: Awaited<ReturnType<Registry["action"]>>): CapabilityNode {
+  if (result.kind !== "capability") throw new Error("expected CapabilityNode");
+  return result;
+}
+
+// ── Test helpers ─────────────────────────────────────────────
+
+function nativeTransferChange(from: string, to: string, value: bigint): Change {
+  return {
+    kind: "nativeTransfer",
+    from: getAddress(from),
+    to: getAddress(to),
+    value: value.toString(),
+  };
+}
+
+function eventChange(
+  address: string,
+  eventName: "Deposit" | "Withdraw" | "Transfer",
+  args: Record<string, unknown>,
+): Change {
+  const topics = encodeEventTopics({
+    abi: ShmonadAbi,
+    eventName,
+    args,
+  } as never) as readonly [`0x${string}`, ...`0x${string}`[]];
+
+  let data: `0x${string}` = "0x";
+
+  if (eventName === "Deposit" || eventName === "Withdraw") {
+    data = encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }],
+      [args.assets as bigint, args.shares as bigint],
+    );
+  } else if (eventName === "Transfer") {
+    data = encodeAbiParameters([{ type: "uint256" }], [args.value as bigint]);
+  }
+
+  return {
+    kind: "event",
+    address: getAddress(address),
+    topics,
+    data,
+  };
+}
+
+function mintTransfer(receiver: string, shares: bigint): Change {
+  return eventChange(VAULT, "Transfer", {
+    from: ZERO,
+    to: getAddress(receiver),
+    value: shares,
+  });
+}
+
+function burnTransfer(owner: string, shares: bigint): Change {
+  return eventChange(VAULT, "Transfer", {
+    from: getAddress(owner),
+    to: ZERO,
+    value: shares,
+  });
+}
+
+function depositEvent(sender: string, owner: string, assets: bigint, shares: bigint): Change {
+  return eventChange(VAULT, "Deposit", {
+    sender: getAddress(sender),
+    owner: getAddress(owner),
+    assets,
+    shares,
+  });
+}
+
+function withdrawEvent(
+  sender: string,
+  receiver: string,
+  owner: string,
+  assets: bigint,
+  shares: bigint,
+): Change {
+  return eventChange(VAULT, "Withdraw", {
+    sender: getAddress(sender),
+    owner: getAddress(owner),
+    receiver: getAddress(receiver),
+    assets,
+    shares,
+  });
+}
+
+// ════════════════════════════════════════════════════════════
+// Offline tests
+// ════════════════════════════════════════════════════════════
+
+describe("Shmonad", () => {
+  // ── Metadata ──────────────────────────────────────────────
+
+  it("loads parameter metadata with descriptions", async () => {
+    const { registry } = offlineRegistry();
+    const [loaded] = registry.load([{ protocol: "fastlane-shmonad", method: "stake" }]);
+
+    expect(loaded?.params.amount).toMatchObject({
+      description: expect.stringContaining("MON"),
+      type: expect.objectContaining({
+        description: expect.stringContaining("decimal"),
+      }),
+    });
+  });
+
+  it("discovers the Protocol via category and verb", async () => {
+    const { registry } = offlineRegistry();
+    const discovered = registry.discover({ category: "staking" });
+
+    expect(discovered).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: "fastlane-shmonad",
+          verb: "stake",
+        }),
+      ]),
+    );
+  });
+
+  // ── Capabilities ──────────────────────────────────────────
+
+  it("stake returns exactly one direct TransactionNode", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "stake", ACCOUNT, {
+      amount: "1.5",
+    });
+    const capability = asCapability(result);
+
+    expect(capability).toMatchObject({
+      kind: "capability",
+      protocol: "fastlane-shmonad",
+      method: "stake",
+      receipt: "stakeReceipt",
+    });
+
+    const [tx] = flattenCapabilityTree(capability);
+    if (!tx) throw new Error("missing stake transaction");
+    expect(tx.transaction.to.toLowerCase()).toBe(VAULT.toLowerCase());
+  });
+
+  it("unstake returns exactly one direct TransactionNode", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "unstake", ACCOUNT, {
+      amount: "50",
+    });
+    const capability = asCapability(result);
+
+    const [tx] = flattenCapabilityTree(capability);
+    if (!tx) throw new Error("missing unstake transaction");
+    expect(tx.transaction.to.toLowerCase()).toBe(VAULT.toLowerCase());
+  });
+
+  // ── Queries ───────────────────────────────────────────────
+
+  it("queries shMON balance", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "balanceOf", ACCOUNT, {
+      owner: ACCOUNT,
+    });
+
+    expect(result).toMatchObject({
+      kind: "query",
+      data: {
+        token: VAULT,
+        symbol: "shMON",
+        decimals: 18,
+        balance: expect.stringMatching(/^\d+$/),
+      },
+    });
+  });
+
+  it("queries exchange rate", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "exchangeRate", ACCOUNT, {});
+
+    expect(result).toMatchObject({
+      kind: "query",
+      data: {
+        token: VAULT,
+        symbol: "shMON",
+        decimals: 18,
+        rate: expect.stringMatching(/^\d+\.\d+$/),
+        totalAssets: expect.stringMatching(/^\d+$/),
+        totalShares: expect.stringMatching(/^\d+$/),
+      },
+    });
+  });
+
+  // ── Receipts ──────────────────────────────────────────────
+
+  it("stakeReceipt parses ordered Changes into a typed Outcome", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "stake", ACCOUNT, {
+      amount: "1.5",
+    });
+    const capability = asCapability(result);
+
+    const amount = 1_500_000_000_000_000_000n;
+    const shares = 1_425_000_000_000_000_000n;
+
+    const changes: readonly Change[] = [
+      mintTransfer(ACCOUNT, shares),
+      depositEvent(ACCOUNT, ACCOUNT, amount, shares),
+      nativeTransferChange(ACCOUNT, VAULT, amount),
+    ];
+
+    const receipt = registry.parseReceipt(capability, changes);
+
+    expect(receipt.outcome).toEqual({
+      operation: "stake",
+      account: ACCOUNT,
+      assets: amount.toString(),
+      shares: shares.toString(),
+    });
+
+    expect(receipt.changes).toHaveLength(3);
+    const c0 = asChange(receipt.changes[0]);
+    const c1 = asChange(receipt.changes[1]);
+    const c2 = asChange(receipt.changes[2]);
+    expect(c0.change).toBe(changes[0]);
+    expect(c1.change).toBe(changes[1]);
+    expect(c2.change).toBe(changes[2]);
+  });
+
+  it("unstakeReceipt parses ordered Changes into a typed Outcome", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "unstake", ACCOUNT, {
+      amount: "10",
+    });
+    const capability = asCapability(result);
+
+    const shares = 10_000_000_000_000_000_000n;
+    const assets = 10_526_000_000_000_000_000n;
+
+    const changes: readonly Change[] = [
+      burnTransfer(ACCOUNT, shares),
+      withdrawEvent(ACCOUNT, ACCOUNT, ACCOUNT, assets, shares),
+      nativeTransferChange(VAULT, ACCOUNT, assets),
+    ];
+
+    const receipt = registry.parseReceipt(capability, changes);
+
+    expect(receipt.outcome).toEqual({
+      operation: "unstake",
+      account: ACCOUNT,
+      shares: shares.toString(),
+      assets: assets.toString(),
+    });
+
+    expect(receipt.changes).toHaveLength(3);
+    const u0 = asChange(receipt.changes[0]);
+    const u1 = asChange(receipt.changes[1]);
+    const u2 = asChange(receipt.changes[2]);
+    expect(u0.change).toBe(changes[0]);
+    expect(u1.change).toBe(changes[1]);
+    expect(u2.change).toBe(changes[2]);
+  });
+
+  // ── Error handling ────────────────────────────────────────
+
+  it("rejects missing Deposit event in stakeReceipt", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "stake", ACCOUNT, {
+      amount: "1",
+    });
+    const capability = asCapability(result);
+
+    const changes: readonly Change[] = [
+      mintTransfer(ACCOUNT, 1_000_000_000_000_000_000n),
+      nativeTransferChange(ACCOUNT, VAULT, 1_000_000_000_000_000_000n),
+    ];
+
+    expect(() => registry.parseReceipt(capability, changes)).toThrow("Deposit");
+  });
+
+  it("rejects missing Withdraw event in unstakeReceipt", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "unstake", ACCOUNT, {
+      amount: "1",
+    });
+    const capability = asCapability(result);
+
+    const changes: readonly Change[] = [
+      burnTransfer(ACCOUNT, 1_000_000_000_000_000_000n),
+      nativeTransferChange(VAULT, ACCOUNT, 1_000_000_000_000_000_000n),
+    ];
+
+    expect(() => registry.parseReceipt(capability, changes)).toThrow("Withdraw");
+  });
+
+  it("verifies exact Change object identity and order", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "stake", ACCOUNT, {
+      amount: "1.5",
+    });
+    const capability = asCapability(result);
+
+    const amount = 1_500_000_000_000_000_000n;
+    const shares = 1_425_000_000_000_000_000n;
+
+    const changes: readonly Change[] = [
+      nativeTransferChange(ACCOUNT, VAULT, amount),
+      mintTransfer(ACCOUNT, shares),
+      depositEvent(ACCOUNT, ACCOUNT, amount, shares),
+    ];
+
+    const receipt = registry.parseReceipt(capability, changes);
+
+    // verifyReceiptCoverage checks exact object identity, length, and order
+    expect(() => verifyReceiptCoverage(changes, receipt)).not.toThrow();
+  });
+
+  it("rejects duplicate Deposit events", async () => {
+    const { registry } = offlineRegistry();
+    const result = await registry.action("fastlane-shmonad", "stake", ACCOUNT, {
+      amount: "1",
+    });
+    const capability = asCapability(result);
+
+    const amount = 1_000_000_000_000_000_000n;
+
+    const changes: readonly Change[] = [
+      mintTransfer(ACCOUNT, amount),
+      depositEvent(ACCOUNT, ACCOUNT, amount, amount),
+      depositEvent(ACCOUNT, ACCOUNT, amount, amount),
+      nativeTransferChange(ACCOUNT, VAULT, amount),
+    ];
+
+    expect(() => registry.parseReceipt(capability, changes)).toThrow("multiple Deposit");
+  });
+});
+
+// ════════════════════════════════════════════════════════════
+// Live Monad mainnet tests
+// ════════════════════════════════════════════════════════════
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Shmonad mainnet", () => {
+  it("has deployed bytecode at shMONAD address", { timeout: 30_000 }, async () => {
+    const runtime = await monadRuntime();
+    const code = await runtime.client.getCode({ address: SHMONAD_ADDRESS });
+    expect(code?.length).toBeGreaterThan(2);
+  });
+
+  it("simulates a stake and returns a typed Receipt with zero warnings", {
+    timeout: 180_000,
+  }, async () => {
+    // Dynamic import so the module can resolve even when
+    // @themoss/simulator is not in this package's dependencies.
+    const { createTraceSimulator } = await import("@themoss/simulator");
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(Shmonad);
+
+    const result = await registry.action("fastlane-shmonad", "stake", ACCOUNT, {
+      amount: "0.001",
+    });
+    const capability = asCapability(result);
+
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results[0]?.warnings).toEqual([]);
+    expect(outcome.results[0]?.receipt?.outcome).toMatchObject({
+      operation: "stake",
+      account: ACCOUNT,
+    });
+  });
+});

--- a/packages/protocols/fastlane/test/types.fixture.ts
+++ b/packages/protocols/fastlane/test/types.fixture.ts
@@ -1,0 +1,35 @@
+// Compile-time type tests for FastLane shMONAD Protocol.
+//
+// These are never executed — they verify that TypeScript
+// correctly infers parameter types and rejects invalid usage
+// at compile time.
+
+import type { Shmonad } from "../src/index.js";
+
+declare const shmonad: Shmonad;
+declare const ctx: { account: `0x${string}` };
+
+// ── Valid usage (should compile) ─────────────────────────────
+
+void shmonad.stake({ amount: "1.5" }, ctx);
+void shmonad.unstake({ amount: "100" }, ctx);
+void shmonad.balanceOf({ owner: "0x0000000000000000000000000000000000000001" }, ctx);
+void shmonad.exchangeRate();
+
+// ── Invalid usage (@ts-expect-error) ─────────────────────────
+
+// @ts-expect-error — amount must be a string, not a number
+const wrongAmount: Parameters<typeof shmonad.stake>[0] = { amount: 123 };
+void shmonad.stake(wrongAmount, ctx);
+
+// @ts-expect-error — amount is required, not optional
+const missingAmount: Parameters<typeof shmonad.stake>[0] = {} as { amount?: string };
+void shmonad.stake(missingAmount, ctx);
+
+// @ts-expect-error — owner is required, not optional
+const missingOwner: Parameters<typeof shmonad.balanceOf>[0] = {} as { owner?: string };
+void shmonad.balanceOf(missingOwner, ctx);
+
+// @ts-expect-error — owner must be 0x address, not plain string
+const wrongOwner: Parameters<typeof shmonad.balanceOf>[0] = { owner: "not-an-address" };
+void shmonad.balanceOf(wrongOwner, ctx);

--- a/packages/protocols/fastlane/tsconfig.json
+++ b/packages/protocols/fastlane/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/fastlane/vitest.config.ts
+++ b/packages/protocols/fastlane/vitest.config.ts
@@ -1,0 +1,19 @@
+// Vitest config for @themoss/protocol-fastlane.
+//
+// Stage-3 decorators cannot be parsed natively by V8, so esbuild
+// must lower them (ADR 0001). This is also why the repo pins vitest
+// 3 — vite 8's oxc transform doesn't lower decorators.
+//
+// Tests run against core's source (not dist) so a stale build
+// can never produce phantom failures.
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: { target: "es2022" },
+  resolve: {
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ importers:
         version: 2.5.2
       '@changesets/cli':
         specifier: ^2.31.0
-        version: 2.31.0(@types/node@22.20.0)
+        version: 2.31.0(@types/node@22.20.1)
       '@types/node':
-        specifier: ^22.20.0
-        version: 22.20.0
+        specifier: ^22.20.1
+        version: 22.20.1
       typescript:
-        specifier: ~5.9.0
-        version: 5.9.3
+        specifier: ~5.9.2
+        version: 5.9.2
 
   examples/agent-swap:
     dependencies:
@@ -94,7 +94,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
 
   packages/erc:
     dependencies:
@@ -122,7 +122,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
 
   packages/mcp-server:
     dependencies:
@@ -135,6 +135,9 @@ importers:
       '@themoss/erc':
         specifier: workspace:*
         version: link:../erc
+      '@themoss/protocol-fastlane':
+        specifier: workspace:*
+        version: link:../protocols/fastlane
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
@@ -159,7 +162,7 @@ importers:
         version: 2.54.3(typescript@5.9.3)(zod@3.25.76)
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
 
   packages/protocols/_template:
     dependencies:
@@ -178,7 +181,32 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
+
+  packages/protocols/fastlane:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.2)(zod@4.4.3)
+    devDependencies:
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.2)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.2
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
 
   packages/protocols/kuru:
     dependencies:
@@ -209,7 +237,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
 
   packages/simulator:
     dependencies:
@@ -228,7 +256,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
 
   packages/system:
     dependencies:
@@ -253,7 +281,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+        version: 3.2.6(@types/node@22.20.1)(tsx@4.23.0)
 
 packages:
 
@@ -367,8 +395,8 @@ packages:
   '@changesets/should-skip-package@0.1.2':
     resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
 
-  '@changesets/types@4.1.0':
-    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+  '@changesets/types@4.0.1':
+    resolution: {integrity: sha512-zVfv752D8K2tjyFmxU/vnntQ+dPu+9NupOSguA/2Zuym4tVxRh0ylArgKZ1bOAi2eXfGlZMxJU/kj7uCSI15RQ==}
 
   '@changesets/types@6.1.0':
     resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
@@ -850,8 +878,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@inquirer/external-editor@1.0.3':
-    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+  '@inquirer/external-editor@1.0.2':
+    resolution: {integrity: sha512-yy9cOoBnx58TlsPrIxauKIFQTiyH+0MK4e97y4sV9ERbI+zDxw7i2hxHLCIEGIE/8PPvDxGhgzIOTSOWcs6/MQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1068,11 +1096,11 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+  '@types/node@12.7.1':
+    resolution: {integrity: sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==}
 
-  '@types/node@22.20.0':
-    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
@@ -1154,8 +1182,8 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+  argparse@1.0.7:
+    resolution: {integrity: sha512-svfNOD2ovohwmmIi/Y1NtBuc53G8RhPLeIMBwB0uTK8pXV1yu0+ZVzj+XHFDFWAPYflfOvPLQxjUB8WpnObhjg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1464,8 +1492,8 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+  globby@11.0.0:
+    resolution: {integrity: sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==}
     engines: {node: '>=10'}
 
   gopd@1.2.0:
@@ -1499,8 +1527,8 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
-  ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+  ignore@5.1.4:
+    resolution: {integrity: sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==}
     engines: {node: '>= 4'}
 
   inherits@2.0.4:
@@ -1529,8 +1557,8 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
-  is-subdir@1.2.0:
-    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+  is-subdir@1.1.1:
+    resolution: {integrity: sha512-VYpq0S7gPBVkkmfwkvGnx1EL9UVIo87NQyNcgMiNUdQCws3CJm5wj2nB+XPL7zigvjxhuZgp3bl2yBcKkSIj1w==}
     engines: {node: '>=4'}
 
   is-windows@1.0.2:
@@ -1679,24 +1707,24 @@ packages:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
 
-  p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+  p-limit@2.2.0:
+    resolution: {integrity: sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==}
     engines: {node: '>=6'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
 
-  p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+  p-map@2.0.0:
+    resolution: {integrity: sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==}
     engines: {node: '>=6'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-manager-detector@0.2.11:
-    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+  package-manager-detector@0.2.0:
+    resolution: {integrity: sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1779,8 +1807,8 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+  prettier@2.7.1:
+    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -1796,9 +1824,6 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
-
-  quansync@0.2.11:
-    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2013,6 +2038,11 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2206,7 +2236,7 @@ snapshots:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.8.8
+      prettier: 2.7.1
       resolve-from: 5.0.0
       semver: 7.8.5
 
@@ -2223,7 +2253,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@22.20.0)':
+  '@changesets/cli@2.31.0(@types/node@22.20.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -2239,13 +2269,13 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.20.0)
+      '@inquirer/external-editor': 1.0.2(@types/node@22.20.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
       fs-extra: 7.0.1
       mri: 1.2.0
-      package-manager-detector: 0.2.11
+      package-manager-detector: 0.2.0
       picocolors: 1.1.1
       resolve-from: 5.0.0
       semver: 7.8.5
@@ -2291,7 +2321,7 @@ snapshots:
     dependencies:
       '@changesets/errors': 0.2.0
       '@manypkg/get-packages': 1.1.3
-      is-subdir: 1.2.0
+      is-subdir: 1.1.1
       micromatch: 4.0.8
       spawndamnit: 3.0.1
 
@@ -2326,7 +2356,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
 
-  '@changesets/types@4.1.0': {}
+  '@changesets/types@4.0.1': {}
 
   '@changesets/types@6.1.0': {}
 
@@ -2335,7 +2365,7 @@ snapshots:
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
       human-id: 4.2.0
-      prettier: 2.8.8
+      prettier: 2.7.1
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -2575,12 +2605,12 @@ snapshots:
     dependencies:
       hono: 4.12.27
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.20.0)':
+  '@inquirer/external-editor@1.0.2(@types/node@22.20.1)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
     optionalDependencies:
-      '@types/node': 22.20.0
+      '@types/node': 22.20.1
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2599,17 +2629,17 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@types/node': 12.20.55
+      '@types/node': 12.7.1
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@changesets/types': 4.1.0
+      '@changesets/types': 4.0.1
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
-      globby: 11.1.0
+      globby: 11.0.0
       read-yaml-file: 1.1.0
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
@@ -2751,9 +2781,9 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@12.20.55': {}
+  '@types/node@12.7.1': {}
 
-  '@types/node@22.20.0':
+  '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
 
@@ -2765,13 +2795,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0))':
+  '@vitest/mocker@3.2.6(vite@7.3.6(@types/node@22.20.1)(tsx@4.23.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@22.20.0)(tsx@4.23.0)
+      vite: 7.3.6(@types/node@22.20.1)(tsx@4.23.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -2825,6 +2855,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  abitype@1.2.3(typescript@5.9.2)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 5.9.2
+      zod: 4.4.3
+
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -2859,7 +2894,7 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  argparse@1.0.10:
+  argparse@1.0.7:
     dependencies:
       sprintf-js: 1.0.3
 
@@ -3251,12 +3286,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  globby@11.1.0:
+  globby@11.0.0:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
       fast-glob: 3.3.3
-      ignore: 5.3.2
+      ignore: 5.1.4
       merge2: 1.4.1
       slash: 3.0.0
 
@@ -3286,7 +3321,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ignore@5.3.2: {}
+  ignore@5.1.4: {}
 
   inherits@2.0.4: {}
 
@@ -3304,7 +3339,7 @@ snapshots:
 
   is-promise@4.0.0: {}
 
-  is-subdir@1.2.0:
+  is-subdir@1.1.1:
     dependencies:
       better-path-resolve: 1.0.0
 
@@ -3324,7 +3359,7 @@ snapshots:
 
   js-yaml@3.15.0:
     dependencies:
-      argparse: 1.0.10
+      argparse: 1.0.7
       esprima: 4.0.1
 
   js-yaml@4.3.0:
@@ -3415,6 +3450,21 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  ox@0.14.30(typescript@5.9.2)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.2)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - zod
+
   ox@0.14.30(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -3447,23 +3497,21 @@ snapshots:
 
   p-filter@2.1.0:
     dependencies:
-      p-map: 2.1.0
+      p-map: 2.0.0
 
-  p-limit@2.3.0:
+  p-limit@2.2.0:
     dependencies:
       p-try: 2.2.0
 
   p-locate@4.1.0:
     dependencies:
-      p-limit: 2.3.0
+      p-limit: 2.2.0
 
-  p-map@2.1.0: {}
+  p-map@2.0.0: {}
 
   p-try@2.2.0: {}
 
-  package-manager-detector@0.2.11:
-    dependencies:
-      quansync: 0.2.11
+  package-manager-detector@0.2.0: {}
 
   parseurl@1.3.3: {}
 
@@ -3514,7 +3562,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@2.8.8: {}
+  prettier@2.7.1: {}
 
   prettier@3.9.4: {}
 
@@ -3527,8 +3575,6 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
-
-  quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
 
@@ -3744,6 +3790,34 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tsup@8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.16)(tsx@4.23.0)
+      resolve-from: 5.0.0
+      rollup: 4.62.2
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.16
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsup@8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
@@ -3784,6 +3858,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typescript@5.9.2: {}
+
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
@@ -3795,6 +3871,23 @@ snapshots:
   unpipe@1.0.0: {}
 
   vary@1.1.2: {}
+
+  viem@2.54.3(typescript@5.9.2)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.2)(zod@4.4.3)
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.30(typescript@5.9.2)(zod@4.4.3)
+      ws: 8.21.0
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   viem@2.54.3(typescript@5.9.3)(zod@3.25.76):
     dependencies:
@@ -3830,13 +3923,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@3.2.4(@types/node@22.20.0)(tsx@4.23.0):
+  vite-node@3.2.4(@types/node@22.20.1)(tsx@4.23.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.6(@types/node@22.20.0)(tsx@4.23.0)
+      vite: 7.3.6(@types/node@22.20.1)(tsx@4.23.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3851,7 +3944,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0):
+  vite@7.3.6(@types/node@22.20.1)(tsx@4.23.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -3860,15 +3953,15 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 22.20.0
+      '@types/node': 22.20.1
       fsevents: 2.3.3
       tsx: 4.23.0
 
-  vitest@3.2.6(@types/node@22.20.0)(tsx@4.23.0):
+  vitest@3.2.6(@types/node@22.20.1)(tsx@4.23.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@22.20.0)(tsx@4.23.0))
+      '@vitest/mocker': 3.2.6(vite@7.3.6(@types/node@22.20.1)(tsx@4.23.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -3886,11 +3979,11 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.6(@types/node@22.20.0)(tsx@4.23.0)
-      vite-node: 3.2.4(@types/node@22.20.0)(tsx@4.23.0)
+      vite: 7.3.6(@types/node@22.20.1)(tsx@4.23.0)
+      vite-node: 3.2.4(@types/node@22.20.1)(tsx@4.23.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.20.0
+      '@types/node': 22.20.1
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## What and why

FastLane shMONAD liquid staking adapter for Moss on Monad mainnet. shMONAD is an ERC-4626 vault that accepts native MON deposits and mints shMON (a liquid staking token) in return.
## Type of change

- [ √] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

  New protocol package `@themoss/protocol-fastlane` added to workspace. Registered in MCP composition root (`packages/mcp-server/`).  No core, simulator, or framework changes.

## Verification

- [√ ] `pnpm build`
- [ √] `pnpm typecheck`
- [ √] `pnpm lint`
- [ √] `pnpm test`
- [ ] User-facing package changes include a changeset
- [ ] Docs and examples match the implemented API

### Protocol changes
  - Single-contract adapter (address 0x1b68626dca36c7fe922fd2d55e4f631d962de19c),
    `deposit()` is payable for native MON — no pre-wrapping needed
  - Stake: calls vault.deposit(assets, receiver) with {value: assets},
    returns one TransactionNode (no ERC-20 approve required since MON
    is the native currency)
  - Unstake: calls vault.redeem(shares, receiver, owner), where both
    receiver and owner are the caller — again no approve needed
  - Receipt parsing: uses ERC-4626 Deposit/Withdraw events as the
    canonical evidence chain, cross-validated against nativeTransfer
    and ERC-20 Transfer events. verifyReceiptCoverage ensures every
    Change is accounted for
  - Supports both instant unstaking (with fee) and queued unbonding
    (free, delayed). The Receipt text automatically detects and
    annotates the mode
  - Parameters use reusable PositiveDecimalString type with separate
    field-purpose description for amount
  - Compile-time type fixtures cover valid and invalid parameter usage
    with @ts-expect-error
  - Live Monad mainnet simulation returns zero warnings

- [ √] Parameters separate reusable Zod value types from field-purpose descriptions
- [√ ] Every Capability owns one direct TransactionNode and one typed Receipt
- [ √] Receipt tests preserve every original Change object in exact length and order
- [ √] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [√ ] Fixed addresses and ABIs include sources and verification
- [√ ] A live Monad happy path returns zero Warnings

  ## Changes

  - `packages/protocols/fastlane/` — new Protocol package
    - `@Capability stake`: deposit native MON → receive shMON
    - `@Capability unstake`: redeem shMON → withdraw native MON
    - `@Query balanceOf`: read shMON balance
    - `@Query exchangeRate`: current MON-per-shMON rate
  - `packages/mcp-server/` — register fastlane in composition root

  ## Contract

  - Address: `0x1b68626dca36c7fe922fd2d55e4f631d962de19c`
  - Standard: ERC-4626
  - Verified on-chain via E2E `getCode` check


  ## Closes

  Closes #12
