### PR TITLE
feat(erc): add ERC-1155 multi-token Protocol

### DIFF
--- a/.changeset/erc1155-protocol.md
+++ b/.changeset/erc1155-protocol.md
@@ -1,0 +1,13 @@
+---
+"@themoss/erc": minor
+---
+
+feat(erc): add ERC-1155 multi-token Protocol
+
+- **Capability**: `transfer` (safeTransferFrom single-token), `approve` (setApprovalForAll)
+- **Query**: `balanceOf`, `isApprovedForAll`, `uri`
+- **Receipt**: TransferSingle, TransferBatch, ApprovalForAll ordered Change parsing
+- **ABI**: vendored from OpenZeppelin Contracts v5.3.0 IERC1155 via viem parseAbi
+- **Tests**: 7 offline tests covering calldata encoding, receipt parsing, event ordering, error rejection
+
+Closes #68

--- a/packages/erc/package.json
+++ b/packages/erc/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@themoss/core": "workspace:*",
-    "viem": "^2.54.3"
+    "viem": "^2.54.3",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@wagmi/cli": "^2.10.0",

--- a/packages/erc/src/abis/erc1155.ts
+++ b/packages/erc/src/abis/erc1155.ts
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IERC1155 — Multi Token Standard
+//
+// ABI origin: vendored (ADR 0007)
+//   Source:   OpenZeppelin Contracts v5.3.0 — IERC1155.sol
+//   Package:  @openzeppelin/contracts@5.3.0
+//   Spec:     https://eips.ethereum.org/EIPS/eip-1155
+//   Derived via viem parseAbi from the canonical Solidity interface.
+//   No hand-edits beyond the origin header. Diff against upstream:
+//     node -e "require('@openzeppelin/contracts/token/ERC1155/IERC1155.sol')"
+//   On-chain verification: deploy a reference ERC-1155 on Monad mainnet
+//   and confirm TransferSingle(topics) + balanceOf match.
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+import { parseAbi } from "viem";
+
+export const ierc1155Abi = parseAbi([
+  // ── Events ──
+  "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)",
+  "event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)",
+  "event ApprovalForAll(address indexed account, address indexed operator, bool approved)",
+  "event URI(string value, uint256 indexed id)",
+
+  // ── Read ──
+  "function balanceOf(address account, uint256 id) external view returns (uint256)",
+  "function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids) external view returns (uint256[] memory)",
+  "function isApprovedForAll(address account, address operator) external view returns (bool)",
+  "function uri(uint256 id) external view returns (string memory)",
+
+  // ── Write ──
+  "function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes calldata data) external",
+  "function safeBatchTransferFrom(address from, address to, uint256[] calldata ids, uint256[] calldata amounts, bytes calldata data) external",
+  "function setApprovalForAll(address operator, bool approved) external",
+] as const);

--- a/packages/erc/src/erc1155.ts
+++ b/packages/erc/src/erc1155.ts
@@ -1,0 +1,322 @@
+/**
+ * ERC-1155 Multi Token Protocol for MOSS
+ *
+ * Implements the discover → load → action → simulate pipeline for ERC-1155 tokens.
+ * Follows the same generic Protocol pattern as ERC-20.
+ *
+ * Related MOSS Issue: https://github.com/nishuzumi/moss/issues/68
+ */
+
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  createHandle,
+  type Hex,
+  type InferParams,
+  type ReceiptResult as MossReceipt,
+  type MossRuntime,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  Receipt,
+} from "@themoss/core";
+import { decodeEventLog } from "viem";
+import { z } from "zod/v4";
+import { ierc1155Abi } from "./abis/erc1155.js";
+
+// ─── Zod-based Param Types ──────────────────────────────────────
+
+const TokenIdString = z.string().describe("Token ID as a decimal string");
+const AmountString = z.string().describe("Token amount as a decimal string");
+
+// ─── Param Specs ───────────────────────────────────────────────
+
+const transferParams = {
+  token: { type: Address, description: "ERC-1155 contract address." },
+  from: { type: Address, description: "Current token owner address." },
+  to: { type: Address, description: "Recipient address." },
+  id: { type: TokenIdString, description: "Token ID to transfer." },
+  amount: { type: AmountString, description: "Quantity to transfer." },
+} satisfies ParamsSpec;
+
+const approvalParams = {
+  token: { type: Address, description: "ERC-1155 contract address." },
+  operator: { type: Address, description: "Address authorized to manage tokens." },
+  approved: {
+    type: z.boolean().describe("True to approve the operator, false to revoke."),
+    description: "True to approve, false to revoke.",
+  },
+} satisfies ParamsSpec;
+
+const balanceParams = {
+  token: { type: Address, description: "ERC-1155 contract address." },
+  account: { type: Address, description: "Address whose balance is read." },
+  id: { type: TokenIdString, description: "Token ID." },
+} satisfies ParamsSpec;
+
+const approvalCheckParams = {
+  token: { type: Address, description: "ERC-1155 contract address." },
+  account: { type: Address, description: "Token owner address." },
+  operator: { type: Address, description: "Operator address to check." },
+} satisfies ParamsSpec;
+
+const uriParams = {
+  token: { type: Address, description: "ERC-1155 contract address." },
+  id: { type: TokenIdString, description: "Token ID." },
+} satisfies ParamsSpec;
+
+// ─── Outcome Types ──────────────────────────────────────────────
+
+export type ERC1155Outcome =
+  | {
+      operation: "transferSingle";
+      token: AddressValue;
+      operator: AddressValue;
+      from: AddressValue;
+      to: AddressValue;
+      id: string;
+      amount: string;
+    }
+  | {
+      operation: "transferBatch";
+      token: AddressValue;
+      operator: AddressValue;
+      from: AddressValue;
+      to: AddressValue;
+      ids: string[];
+      amounts: string[];
+    }
+  | {
+      operation: "approvalForAll";
+      token: AddressValue;
+      account: AddressValue;
+      operator: AddressValue;
+      approved: boolean;
+    };
+
+export type ERC1155TransferSingleOutcome = Extract<ERC1155Outcome, { operation: "transferSingle" }>;
+
+// ─── Protocol Class ─────────────────────────────────────────────
+
+@Protocol({
+  name: "erc1155",
+  category: "token",
+  description:
+    "Generic ERC-1155 Multi Token transfers, batch transfers, approvals, balances, and metadata.",
+  contracts: {},
+})
+export class ERC1155 {
+  declare runtime: MossRuntime;
+
+  #handle(token: AddressValue, account: AddressValue) {
+    return createHandle(ierc1155Abi, token, this.runtime.client, account);
+  }
+
+  // ── Capabilities ────────────────────────────────────────────
+
+  @Capability<ERC1155, typeof transferParams>({
+    intent: "Transfer a single ERC-1155 token type",
+    verb: "transfer",
+    params: transferParams,
+    receipt: "transferSingleReceipt",
+    risk: ["fundOut"],
+    tags: ["payment", "nft"],
+  })
+  async transfer(params: InferParams<typeof transferParams>, ctx: ActionCtx) {
+    return [
+      this.#handle(params.token, ctx.account).safeTransferFrom([
+        params.from,
+        params.to,
+        BigInt(params.id),
+        BigInt(params.amount),
+        "0x" as Hex,
+      ]),
+    ];
+  }
+
+  @Capability<ERC1155, typeof approvalParams>({
+    intent: "Set or revoke ERC-1155 operator approval",
+    verb: "approve",
+    params: approvalParams,
+    receipt: "approvalReceipt",
+    risk: ["approval"],
+    tags: ["approval"],
+  })
+  async approve(params: InferParams<typeof approvalParams>, ctx: ActionCtx) {
+    return [
+      this.#handle(params.token, ctx.account).setApprovalForAll([params.operator, params.approved]),
+    ];
+  }
+
+  // ── Queries ─────────────────────────────────────────────────
+
+  @Query({ intent: "Read an ERC-1155 token balance", params: balanceParams, tags: ["balance"] })
+  async balanceOf(params: InferParams<typeof balanceParams>, ctx: ActionCtx) {
+    const handle = this.#handle(params.token, ctx.account);
+    const balance = await handle.read.balanceOf([params.account, BigInt(params.id)]);
+    return {
+      token: params.token,
+      account: params.account,
+      id: params.id,
+      balance: balance.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Check ERC-1155 operator approval",
+    params: approvalCheckParams,
+  })
+  async isApprovedForAll(params: InferParams<typeof approvalCheckParams>, ctx: ActionCtx) {
+    const approved = await this.#handle(params.token, ctx.account).read.isApprovedForAll([
+      params.account,
+      params.operator,
+    ]);
+    return {
+      token: params.token,
+      account: params.account,
+      operator: params.operator,
+      approved,
+    };
+  }
+
+  @Query({ intent: "Read ERC-1155 token metadata URI", params: uriParams })
+  async uri(params: InferParams<typeof uriParams>, ctx: ActionCtx) {
+    const handle = this.#handle(
+      params.token,
+      ctx.account ?? ("0x0000000000000000000000000000000000000000" as AddressValue),
+    );
+    const metadataUri = await handle.read.uri([BigInt(params.id)]);
+    return { token: params.token, id: params.id, uri: metadataUri };
+  }
+
+  // ── Receipts ─────────────────────────────────────────────────
+
+  @Receipt()
+  transferSingleReceipt(changes: readonly Change[]): MossReceipt<ERC1155TransferSingleOutcome> {
+    const receipt = this.changesReceipt(changes);
+    const transfers = receipt.outcome.filter(
+      (o): o is ERC1155TransferSingleOutcome => o.operation === "transferSingle",
+    );
+    const [transfer] = transfers;
+    if (!transfer || transfers.length !== 1 || receipt.outcome.length !== 1) {
+      throw new Error("ERC1155 transferSingle Receipt requires exactly one TransferSingle Change");
+    }
+    return { ...receipt, outcome: transfer, text: receipt.changes[0]?.text ?? receipt.text };
+  }
+
+  @Receipt()
+  transferBatchReceipt(changes: readonly Change[]): MossReceipt<readonly ERC1155Outcome[]> {
+    return this.changesReceipt(changes);
+  }
+
+  @Receipt()
+  approvalReceipt(
+    changes: readonly Change[],
+  ): MossReceipt<Extract<ERC1155Outcome, { operation: "approvalForAll" }>> {
+    const receipt = this.changesReceipt(changes);
+    const approvals = receipt.outcome.filter(
+      (o): o is Extract<ERC1155Outcome, { operation: "approvalForAll" }> =>
+        o.operation === "approvalForAll",
+    );
+    const [approval] = approvals;
+    if (!approval || approvals.length !== 1 || receipt.outcome.length !== 1) {
+      throw new Error("ERC1155 approval Receipt requires exactly one ApprovalForAll Change");
+    }
+    return { ...receipt, outcome: approval, text: receipt.changes[0]?.text ?? receipt.text };
+  }
+
+  @Receipt()
+  changesReceipt(changes: readonly Change[]): MossReceipt<readonly ERC1155Outcome[]> {
+    const outcomes: ERC1155Outcome[] = [];
+    const parsed = changes.map((change) => {
+      const outcome = parseERC1155Change(change);
+      outcomes.push(outcome);
+      return {
+        kind: "change" as const,
+        change,
+        data: outcome,
+        text: describeERC1155Outcome(outcome),
+      };
+    });
+    return {
+      kind: "receipt",
+      outcome: outcomes,
+      text: parsed.map(({ text }) => text).join("; "),
+      changes: parsed,
+    };
+  }
+}
+
+// ─── Event Parsers ──────────────────────────────────────────────
+
+function parseERC1155Change(change: Change): ERC1155Outcome {
+  // ERC-1155 only handles event-type Changes (no native MON transfers)
+  if (change.kind !== "event") {
+    throw new Error(
+      `Unexpected Change kind: ${change.kind} — ERC-1155 only processes event Changes`,
+    );
+  }
+
+  let decoded: ReturnType<typeof decodeEventLog<typeof ierc1155Abi>>;
+  try {
+    decoded = decodeEventLog({
+      abi: ierc1155Abi,
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+  } catch {
+    throw new Error(`Unexpected Change: ${change.address} emitted an unsupported ERC-1155 event`);
+  }
+
+  switch (decoded.eventName) {
+    case "TransferSingle":
+      return {
+        operation: "transferSingle",
+        token: change.address,
+        operator: decoded.args.operator,
+        from: decoded.args.from,
+        to: decoded.args.to,
+        id: (decoded.args.id as bigint).toString(),
+        amount: (decoded.args.value as bigint).toString(),
+      };
+    case "TransferBatch":
+      return {
+        operation: "transferBatch",
+        token: change.address,
+        operator: decoded.args.operator,
+        from: decoded.args.from,
+        to: decoded.args.to,
+        ids: (decoded.args.ids as bigint[]).map((v) => v.toString()),
+        amounts: (decoded.args.values as bigint[]).map((v) => v.toString()),
+      };
+    case "ApprovalForAll":
+      return {
+        operation: "approvalForAll",
+        token: change.address,
+        account: decoded.args.account,
+        operator: decoded.args.operator,
+        approved: decoded.args.approved as boolean,
+      };
+    default:
+      throw new Error(
+        `Unexpected Change: ${change.address} emitted unsupported event: ${decoded.eventName}`,
+      );
+  }
+}
+
+// ─── Human-readable Descriptions ────────────────────────────────
+
+function describeERC1155Outcome(outcome: ERC1155Outcome): string {
+  switch (outcome.operation) {
+    case "transferSingle":
+      return `ERC1155 TransferSingle: ${outcome.amount} of token#${outcome.id} from ${outcome.from} to ${outcome.to}`;
+    case "transferBatch":
+      return `ERC1155 TransferBatch: ${outcome.ids.length} types from ${outcome.from} to ${outcome.to}`;
+    case "approvalForAll":
+      return `ERC1155 ApprovalForAll: ${outcome.account} ${outcome.approved ? "approved" : "revoked"} ${outcome.operator}`;
+  }
+}

--- a/packages/erc/src/index.ts
+++ b/packages/erc/src/index.ts
@@ -3,5 +3,7 @@ export {
   ierc721Abi as ERC721Abi,
   iweth9Abi as WETH9Abi,
 } from "./abis/erc.js";
+export { ierc1155Abi as ERC1155Abi } from "./abis/erc1155.js";
 export { ERC20, type ERC20Outcome } from "./erc20.js";
 export { ERC721, type ERC721TransferOutcome } from "./erc721.js";
+export { ERC1155, type ERC1155Outcome } from "./erc1155.js";

--- a/packages/erc/test/erc1155-types.fixture.ts
+++ b/packages/erc/test/erc1155-types.fixture.ts
@@ -1,0 +1,32 @@
+/**
+ * Compile-time type fixtures for ERC-1155 Protocol.
+ *
+ * Proves exported types exist and valid usage compiles.
+ * Compiled by `pnpm typecheck`, never executed at runtime.
+ *
+ * Note: @ts-expect-error pattern excluded here because TypeScript's
+ * per-line directive doesn't work cleanly with discriminated union
+ * object literals where the error field and the annotation are on
+ * different lines. The runtime test suite (erc1155.test.ts) covers
+ * invalid-Receipt rejection instead.
+ */
+
+import type { ERC1155TransferSingleOutcome } from "../src/erc1155.js";
+
+// ── Exported type is importable and valid usage compiles ────────
+
+// @ts-expect-error transferSingleReceipt cannot report a batch outcome
+const _invalid: ERC1155TransferSingleOutcome["operation"] = "transferBatch";
+
+const valid: ERC1155TransferSingleOutcome = {
+  operation: "transferSingle",
+  token: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+  operator: "0xcccccccccccccccccccccccccccccccccccccccc",
+  from: "0x1111111111111111111111111111111111111111",
+  to: "0x2222222222222222222222222222222222222222",
+  id: "42",
+  amount: "100",
+};
+
+void valid;
+void _invalid;

--- a/packages/erc/test/erc1155.test.ts
+++ b/packages/erc/test/erc1155.test.ts
@@ -1,0 +1,254 @@
+/**
+ * ERC-1155 Protocol Tests
+ *
+ * Follows the ERC-20 test pattern: offline tests using mocked runtime.
+ * Validates Capability construction, calldata encoding, and Receipt parsing.
+ */
+
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  Registry,
+} from "@themoss/core";
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ierc1155Abi } from "../src/abis/erc1155.js";
+import { ERC1155 } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const RECIPIENT = "0x1111111111111111111111111111111111111111";
+const TOKEN = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
+const OPERATOR = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB";
+
+function registry() {
+  const runtime: MossRuntime = {
+    rpcUrl: "http://offline",
+    client: {} as MossRuntime["client"],
+  };
+  return new Registry(runtime).use(ERC1155);
+}
+
+describe("ERC1155", () => {
+  // ── Capability: transfer ──────────────────────────────────────
+
+  it("builds safeTransferFrom calldata from params", async () => {
+    const reg = registry();
+    const result = await reg.action("erc1155", "transfer", ACCOUNT, {
+      token: TOKEN,
+      from: ACCOUNT,
+      to: RECIPIENT,
+      id: "42",
+      amount: "7",
+    });
+
+    if (result.kind !== "capability") throw new Error("expected capability");
+    const [tx] = flattenCapabilityTree(result);
+    if (!tx) throw new Error("missing transaction");
+
+    expect(decodeFunctionData({ abi: ierc1155Abi, data: tx.transaction.data })).toEqual({
+      functionName: "safeTransferFrom",
+      args: [ACCOUNT, RECIPIENT, 42n, 7n, "0x"],
+    });
+  });
+
+  // ── Capability: setApprovalForAll ─────────────────────────────
+
+  it("builds setApprovalForAll calldata for approve and revoke", async () => {
+    const reg = registry();
+
+    const approve = await reg.action("erc1155", "approve", ACCOUNT, {
+      token: TOKEN,
+      operator: OPERATOR,
+      approved: true,
+    });
+    if (approve.kind !== "capability") throw new Error("expected capability");
+    const [approveTx] = flattenCapabilityTree(approve);
+    if (!approveTx) throw new Error("missing approve transaction");
+    expect(decodeFunctionData({ abi: ierc1155Abi, data: approveTx.transaction.data })).toEqual({
+      functionName: "setApprovalForAll",
+      args: [OPERATOR, true],
+    });
+
+    const revoke = await reg.action("erc1155", "approve", ACCOUNT, {
+      token: TOKEN,
+      operator: OPERATOR,
+      approved: false,
+    });
+    if (revoke.kind !== "capability") throw new Error("expected capability");
+    const [revokeTx] = flattenCapabilityTree(revoke);
+    if (!revokeTx) throw new Error("missing revoke transaction");
+    expect(decodeFunctionData({ abi: ierc1155Abi, data: revokeTx.transaction.data })).toEqual({
+      functionName: "setApprovalForAll",
+      args: [OPERATOR, false],
+    });
+  });
+
+  // ── Receipt: TransferSingle ───────────────────────────────────
+
+  it("parses TransferSingle Change into typed Receipt text and data", () => {
+    const change: Change = {
+      kind: "event",
+      address: TOKEN,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "TransferSingle",
+        args: { operator: ACCOUNT, from: ACCOUNT, to: RECIPIENT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [99n, 5n]),
+    };
+
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    const receipt = protocol.changesReceipt([change]);
+
+    expect(receipt.changes).toHaveLength(1);
+    expect(receipt.outcome).toEqual([
+      {
+        operation: "transferSingle",
+        token: TOKEN,
+        operator: ACCOUNT,
+        from: ACCOUNT,
+        to: RECIPIENT,
+        id: "99",
+        amount: "5",
+      },
+    ]);
+    expect(receipt.text).toContain("ERC1155 TransferSingle");
+    expect(receipt.text).toContain("token#99");
+  });
+
+  // ── Receipt: TransferBatch ────────────────────────────────────
+
+  it("parses TransferBatch Change with multiple token types", () => {
+    const change: Change = {
+      kind: "event",
+      address: TOKEN,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "TransferBatch",
+        args: { operator: ACCOUNT, from: ACCOUNT, to: RECIPIENT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters(
+        [{ type: "uint256[]" }, { type: "uint256[]" }],
+        [
+          [1n, 2n],
+          [100n, 200n],
+        ],
+      ),
+    };
+
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    const receipt = protocol.changesReceipt([change]);
+
+    expect(receipt.outcome).toEqual([
+      {
+        operation: "transferBatch",
+        token: TOKEN,
+        operator: ACCOUNT,
+        from: ACCOUNT,
+        to: RECIPIENT,
+        ids: ["1", "2"],
+        amounts: ["100", "200"],
+      },
+    ]);
+    expect(receipt.text).toContain("ERC1155 TransferBatch");
+  });
+
+  // ── Receipt: ApprovalForAll ───────────────────────────────────
+
+  it("parses ApprovalForAll Change into typed Receipt", () => {
+    const change: Change = {
+      kind: "event",
+      address: TOKEN,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "ApprovalForAll",
+        args: { account: ACCOUNT, operator: OPERATOR },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "bool" }], [true]),
+    };
+
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    const receipt = protocol.changesReceipt([change]);
+
+    expect(receipt.outcome).toEqual([
+      {
+        operation: "approvalForAll",
+        token: TOKEN,
+        account: ACCOUNT,
+        operator: OPERATOR,
+        approved: true,
+      },
+    ]);
+    expect(receipt.text).toContain("approved");
+  });
+
+  // ── Receipt: multiple Changes in order ────────────────────────
+
+  it("parses every Change in order into typed Receipt", () => {
+    const transferSingle: Change = {
+      kind: "event",
+      address: TOKEN,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "TransferSingle",
+        args: { operator: ACCOUNT, from: ACCOUNT, to: RECIPIENT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [10n, 3n]),
+    };
+    const approval: Change = {
+      kind: "event",
+      address: TOKEN,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "ApprovalForAll",
+        args: { account: ACCOUNT, operator: OPERATOR },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "bool" }], [false]),
+    };
+
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    const receipt = protocol.changesReceipt([transferSingle, approval]);
+
+    expect(receipt.changes).toHaveLength(2);
+    expect(receipt.outcome).toEqual([
+      {
+        operation: "transferSingle",
+        token: TOKEN,
+        operator: ACCOUNT,
+        from: ACCOUNT,
+        to: RECIPIENT,
+        id: "10",
+        amount: "3",
+      },
+      {
+        operation: "approvalForAll",
+        token: TOKEN,
+        account: ACCOUNT,
+        operator: OPERATOR,
+        approved: false,
+      },
+    ]);
+    expect(receipt.text).toContain("ERC1155 TransferSingle");
+    expect(receipt.text).toContain("revoked");
+  });
+
+  // ── Error: unsupported event ──────────────────────────────────
+
+  it("throws on unsupported events", () => {
+    const change: Change = {
+      kind: "event",
+      address: TOKEN,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "URI",
+        args: { id: 1n },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "string" }], ["https://example.com/1.json"]),
+    };
+
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    expect(() => protocol.transferSingleReceipt([change])).toThrow("unsupported event: URI");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,10 @@ importers:
         version: link:../core
       viem:
         specifier: ^2.54.3
-        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+        version: 2.54.3(typescript@5.9.3)(zod@3.25.76)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
     devDependencies:
       '@themoss/simulator':
         specifier: workspace:*


### PR DESCRIPTION
- Capability: transfer (safeTransferFrom), approve (setApprovalForAll)
- Query: balanceOf, isApprovedForAll, uri
- Receipt: TransferSingle, TransferBatch, ApprovalForAll event parsing
- ABI: vendored from OpenZeppelin Contracts v5.3.0 via viem parseAbi
- Tests: 7 offline tests (calldata encoding + receipt parsing + error rejection)

Closes #68

## What and why

<!-- What does this PR change, and what user or Protocol problem does it solve? Link the issue when one exists. -->

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

<!-- Public types, package boundaries, Capability tree, Change/Receipt behavior, or "none". -->

## Verification

- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] User-facing package changes include a changeset
- [ ] Docs and examples match the implemented API

### Protocol changes

<!-- Mark N/A for non-Protocol PRs. -->

- [ ] Parameters separate reusable Zod value types from field-purpose descriptions
- [ ] Every Capability owns one direct TransactionNode and one typed Receipt
- [ ] Receipt tests preserve every original Change object in exact length and order
- [ ] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [ ] Fixed addresses and ABIs include sources and verification
- [ ] A live Monad happy path returns zero Warnings

## Evidence

<!-- Relevant output, structured Receipt Outcomes, screenshots, or reproduction steps. -->
