### PR TITLE
feat(erc): add compiled IERC4626 ABI

### DIFF
--- a/.changeset/erc4626-compiled-abi.md
+++ b/.changeset/erc4626-compiled-abi.md
@@ -1,0 +1,5 @@
+---
+"@themoss/erc": patch
+---
+
+Add the compiled IERC4626 tokenized vault ABI to the ERC interface layer.

--- a/packages/erc/contracts/IERC4626.sol
+++ b/packages/erc/contracts/IERC4626.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "./IERC20.sol";
+
+/// @notice The ERC-4626 tokenized vault interface Moss consumes. This file is
+/// the source of truth for the generated `src/abis/erc.ts`; regenerate with
+/// `pnpm gen:abis` (requires foundry).
+interface IERC4626 is IERC20 {
+    event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
+    event Withdraw(
+        address indexed sender,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
+    function asset() external view returns (address assetTokenAddress);
+    function totalAssets() external view returns (uint256 totalManagedAssets);
+    function convertToShares(uint256 assets) external view returns (uint256 shares);
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
+    function maxDeposit(address receiver) external view returns (uint256 maxAssets);
+    function previewDeposit(uint256 assets) external view returns (uint256 shares);
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+    function maxMint(address receiver) external view returns (uint256 maxShares);
+    function previewMint(uint256 shares) external view returns (uint256 assets);
+    function mint(uint256 shares, address receiver) external returns (uint256 assets);
+    function maxWithdraw(address owner) external view returns (uint256 maxAssets);
+    function previewWithdraw(uint256 assets) external view returns (uint256 shares);
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+    function maxRedeem(address owner) external view returns (uint256 maxShares);
+    function previewRedeem(uint256 shares) external view returns (uint256 assets);
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+}

--- a/packages/erc/src/abis/erc.ts
+++ b/packages/erc/src/abis/erc.ts
@@ -122,6 +122,327 @@ export const ierc20Abi = [
 ] as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IERC4626
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const ierc4626Abi = [
+  {
+    type: 'function',
+    inputs: [
+      { name: 'owner', internalType: 'address', type: 'address' },
+      { name: 'spender', internalType: 'address', type: 'address' },
+    ],
+    name: 'allowance',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'spender', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'approve',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'asset',
+    outputs: [
+      { name: 'assetTokenAddress', internalType: 'address', type: 'address' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'account', internalType: 'address', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    name: 'convertToAssets',
+    outputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    name: 'convertToShares',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ name: '', internalType: 'uint8', type: 'uint8' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'assets', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+    ],
+    name: 'deposit',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'receiver', internalType: 'address', type: 'address' }],
+    name: 'maxDeposit',
+    outputs: [{ name: 'maxAssets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'receiver', internalType: 'address', type: 'address' }],
+    name: 'maxMint',
+    outputs: [{ name: 'maxShares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'owner', internalType: 'address', type: 'address' }],
+    name: 'maxRedeem',
+    outputs: [{ name: 'maxShares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'owner', internalType: 'address', type: 'address' }],
+    name: 'maxWithdraw',
+    outputs: [{ name: 'maxAssets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'shares', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+    ],
+    name: 'mint',
+    outputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'name',
+    outputs: [{ name: '', internalType: 'string', type: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    name: 'previewDeposit',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    name: 'previewMint',
+    outputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    name: 'previewRedeem',
+    outputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    name: 'previewWithdraw',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'shares', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+      { name: 'owner', internalType: 'address', type: 'address' },
+    ],
+    name: 'redeem',
+    outputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'symbol',
+    outputs: [{ name: '', internalType: 'string', type: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'totalAssets',
+    outputs: [
+      { name: 'totalManagedAssets', internalType: 'uint256', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'transfer',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address' },
+      { name: 'to', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'transferFrom',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'assets', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+      { name: 'owner', internalType: 'address', type: 'address' },
+    ],
+    name: 'withdraw',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'owner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'spender',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'value',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Approval',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'sender',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'owner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'assets',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'shares',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Deposit',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'from', internalType: 'address', type: 'address', indexed: true },
+      { name: 'to', internalType: 'address', type: 'address', indexed: true },
+      {
+        name: 'value',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Transfer',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'sender',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'receiver',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'owner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'assets',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'shares',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Withdraw',
+  },
+] as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // IERC721
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/erc/src/index.ts
+++ b/packages/erc/src/index.ts
@@ -1,6 +1,7 @@
 export {
   ierc20Abi as ERC20Abi,
   ierc721Abi as ERC721Abi,
+  ierc4626Abi as ERC4626Abi,
   iweth9Abi as WETH9Abi,
 } from "./abis/erc.js";
 export { ERC20, type ERC20Outcome } from "./erc20.js";

--- a/packages/erc/test/erc4626-abi.test.ts
+++ b/packages/erc/test/erc4626-abi.test.ts
@@ -1,0 +1,112 @@
+import {
+  decodeEventLog,
+  encodeAbiParameters,
+  encodeEventTopics,
+  encodeFunctionData,
+  getAddress,
+  type Hex,
+} from "viem";
+import { describe, expect, it } from "vitest";
+import { ERC4626Abi } from "../src/index.js";
+
+const VAULT = getAddress("0x1111111111111111111111111111111111111111");
+const OWNER = getAddress("0x2222222222222222222222222222222222222222");
+const RECEIVER = getAddress("0x3333333333333333333333333333333333333333");
+
+describe("ERC4626 ABI", () => {
+  it("exports the complete ERC-4626 vault surface", () => {
+    const functionNames = new Set(
+      ERC4626Abi.flatMap((entry) => (entry.type === "function" ? [entry.name] : [])),
+    );
+    expect([...functionNames].sort()).toEqual([
+      "allowance",
+      "approve",
+      "asset",
+      "balanceOf",
+      "convertToAssets",
+      "convertToShares",
+      "decimals",
+      "deposit",
+      "maxDeposit",
+      "maxMint",
+      "maxRedeem",
+      "maxWithdraw",
+      "mint",
+      "name",
+      "previewDeposit",
+      "previewMint",
+      "previewRedeem",
+      "previewWithdraw",
+      "redeem",
+      "symbol",
+      "totalAssets",
+      "totalSupply",
+      "transfer",
+      "transferFrom",
+      "withdraw",
+    ]);
+
+    const eventNames = new Set(
+      ERC4626Abi.flatMap((entry) => (entry.type === "event" ? [entry.name] : [])),
+    );
+    expect([...eventNames].sort()).toEqual(["Approval", "Deposit", "Transfer", "Withdraw"]);
+  });
+
+  it("keeps ERC-4626 read and write signatures ABI-typed", () => {
+    expect(
+      encodeFunctionData({
+        abi: ERC4626Abi,
+        functionName: "deposit",
+        args: [123n, RECEIVER],
+      }),
+    ).toMatch(/^0x/);
+    expect(
+      encodeFunctionData({
+        abi: ERC4626Abi,
+        functionName: "withdraw",
+        args: [123n, RECEIVER, OWNER],
+      }),
+    ).toMatch(/^0x/);
+    expect(
+      encodeFunctionData({
+        abi: ERC4626Abi,
+        functionName: "previewRedeem",
+        args: [456n],
+      }),
+    ).toMatch(/^0x/);
+  });
+
+  it("decodes ERC-4626 Deposit and Withdraw events", () => {
+    expect(
+      decodeEventLog({
+        abi: ERC4626Abi,
+        eventName: "Deposit",
+        topics: encodeEventTopics({
+          abi: ERC4626Abi,
+          eventName: "Deposit",
+          args: { sender: OWNER, owner: RECEIVER },
+        }) as [Hex, ...Hex[]],
+        data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [123n, 456n]),
+      }),
+    ).toMatchObject({
+      eventName: "Deposit",
+      args: { sender: OWNER, owner: RECEIVER, assets: 123n, shares: 456n },
+    });
+
+    expect(
+      decodeEventLog({
+        abi: ERC4626Abi,
+        eventName: "Withdraw",
+        topics: encodeEventTopics({
+          abi: ERC4626Abi,
+          eventName: "Withdraw",
+          args: { sender: OWNER, receiver: RECEIVER, owner: VAULT },
+        }) as [Hex, ...Hex[]],
+        data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [123n, 456n]),
+      }),
+    ).toMatchObject({
+      eventName: "Withdraw",
+      args: { sender: OWNER, receiver: RECEIVER, owner: VAULT, assets: 123n, shares: 456n },
+    });
+  });
+});

--- a/packages/erc/test/types.fixture.ts
+++ b/packages/erc/test/types.fixture.ts
@@ -1,4 +1,7 @@
+import { type AddressValue, createHandle, type Handle } from "@themoss/core";
+import type { PublicClient } from "viem";
 import type { ERC20 } from "../src/erc20.js";
+import { ERC4626Abi } from "../src/index.js";
 
 type TransferOperation = ReturnType<ERC20["transferReceipt"]>["outcome"]["operation"];
 type ApprovalOperation = ReturnType<ERC20["approveReceipt"]>["outcome"]["operation"];
@@ -14,3 +17,24 @@ void transfer;
 void invalidTransfer;
 void approval;
 void invalidApproval;
+
+declare const account: AddressValue;
+declare const receiver: AddressValue;
+declare const owner: AddressValue;
+declare const client: PublicClient;
+const erc4626Handle: Handle<typeof ERC4626Abi> = createHandle(ERC4626Abi, owner, client, account);
+
+erc4626Handle.deposit([1n, receiver]);
+erc4626Handle.withdraw([1n, receiver, owner]);
+erc4626Handle.redeem([1n, receiver, owner]);
+erc4626Handle.read.asset();
+erc4626Handle.read.previewDeposit([1n]);
+erc4626Handle.read.previewMint([1n]);
+erc4626Handle.read.previewRedeem([1n]);
+erc4626Handle.read.maxWithdraw([owner]);
+// @ts-expect-error deposit requires assets and receiver.
+erc4626Handle.deposit([1n]);
+// @ts-expect-error redeem expects shares, receiver, and owner.
+erc4626Handle.redeem([receiver]);
+// @ts-expect-error ERC-4626 does not define a strategy function.
+erc4626Handle.read.strategy();

--- a/packages/erc/wagmi.config.ts
+++ b/packages/erc/wagmi.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   plugins: [
     foundry({
       project: ".",
-      include: ["IERC20.sol/**", "IERC721.sol/**", "IWETH9.sol/**"],
+      include: ["IERC20.sol/**", "IERC721.sol/**", "IERC4626.sol/**", "IWETH9.sol/**"],
       // wagmi's default excludes assume IERC20 is someone else's vendored
       // interface; here it IS our compiled source of truth — override them.
       exclude: ["build-info/**"],


### PR DESCRIPTION
## Problem

Issue #13 needs a reusable ERC-4626 interface layer, but the architecture for concrete vault identity and composition is still being designed. In particular, #74 and the related architecture work may affect whether a vault is represented as a bound Protocol, a curated protocol deployment, or another verified identity model.

The standard ABI itself does not depend on that decision. Keeping this PR to the compiled ABI surface makes useful progress without prematurely fixing the vault address, discovery, Capability, or Receipt model.

## Changes

- rebase the ABI slice onto current `main` at `95dc4ef`;
- add `IERC4626.sol` as the compiled source of truth in `@themoss/erc`;
- regenerate the complete inherited ERC-20 + ERC-4626 ABI through the existing Foundry/Wagmi pipeline;
- export it as `ERC4626Abi`;
- test the complete function/event surface, typed calldata encoding, and `Deposit`/`Withdraw` event decoding;
- add compile-time `Handle<typeof ERC4626Abi>` fixtures covering valid inference and rejected invalid usage;
- add a patch changeset for `@themoss/erc`.

## Why This Slice Only

#13 is marked `needs-design`. Query Protocols and write Capabilities would force decisions that this ABI does not need to make:

- whether callers may provide arbitrary vault addresses or only curated/verified vaults;
- whether each concrete vault should use the bound Protocol model under discussion in #74;
- how vault identity and labels are exposed through the interface layer;
- how ERC-20 approval composition and ERC-4626 Receipts fit the final Capability tree contract.

This PR therefore adds only the address-free standard artifact owned by `@themoss/erc`. It does not introduce a temporary adapter shape or compatibility layer that later architecture work would need to preserve.

## Deferred Follow-Up

This PR intentionally does **not** add a Protocol, Query, vault catalog, arbitrary-address entry point, write Capability, Receipt parser, or MCP exposure.

The remaining work for #13 should continue after the relevant architecture settles, especially:

- #74 / the concrete bound Protocol and vault identity direction;
- the label/identity work around #62 and #63;
- #64 / bound ERC-20 composition for approval-dependent vault writes.

Once those contracts are accepted, follow-up PRs can add query-only vault behavior first, then deposit/withdraw/redeem Capabilities and evidence-based Receipts without rewriting this ABI layer.

## Effect

Future ERC-4626 implementations can reuse one complete, ABI-typed, address-free standard interface. This provides typed reads, previews, writes, and event decoding while leaving deployment trust, protocol semantics, simulation, and Receipt ownership in their proper packages.

## Verification

Run after rebasing onto `95dc4ef`:

- `pnpm --filter @themoss/erc gen:abis` passed and reproduced the committed artifact with zero diff;
- `pnpm lint` passed;
- `pnpm build` passed;
- `pnpm typecheck` passed, including positive and negative compile-time fixtures;
- `NODE_USE_ENV_PROXY=1 pnpm test` passed — 125\/125, including live Monad mainnet WMON and Kuru checks;
- `git diff --check origin/main...HEAD` passed;
- focused secret and dangerous-API scans found no additions.

## Security Review

- No transaction execution, signing, RPC target, address constant, dependency, or lockfile behavior changes in this PR.
- `pnpm audit --prod --audit-level low` reports no known production vulnerabilities.
- The full development dependency audit reports one existing low-severity tooling advisory, not introduced by this PR.
- ABI generation still emits Node's existing `DEP0190` warning from the Wagmi CLI child-process path. Generation inputs are fixed repository files, and the generated output reproduced byte-for-byte. This PR does not alter that toolchain.

Partial work toward #13.