### PR TITLE
feat(protocol/uniswap-v4): ship Uniswap v4 adapter on Monad

### DIFF
--- a/.changeset/feat-uniswap-v4-adapter.md
+++ b/.changeset/feat-uniswap-v4-adapter.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-uniswap-v4": "0.0.1"
+---
+
+feat(uniswap-v4): ship Uniswap v4 Protocol adapter on Monad — swap, quote, and swapReceipt parser via PoolManager unlock callback pattern.

--- a/packages/protocols/uniswap-v4/README.md
+++ b/packages/protocols/uniswap-v4/README.md
@@ -1,0 +1,116 @@
+# @themoss/protocol-uniswap-v4
+
+Uniswap v4 adapter on Monad — single-hop token swaps via PoolManager.
+
+## Overview
+
+This package implements a self-describing `@Protocol` adapter for Uniswap v4 on Monad
+(mainnet, chain ID 143). It exposes the PoolManager contract for token swaps and the
+V4Quoter contract for price quotes.
+
+The adapter uses PoolManager's `unlock(callback)` pattern to execute a single
+transaction that encapsulates the full swap flow: `settle/sync` → `swap` → `take`.
+
+## Contracts
+
+| Contract | Address | Source |
+|----------|---------|--------|
+| PoolManager | `0x188d586dcf52439676ca21a244753fa19f9ea8e` | [Uniswap/v4-core@1.0.2](https://github.com/Uniswap/v4-core), vendored via npm tarball |
+| V4Quoter | `0xa222dd357a9076d1091ed6aa2e16c9742dd26891` | [Uniswap/v4-periphery@1.0.3](https://github.com/Uniswap/v4-periphery), vendored via npm tarball |
+
+Addresses verified on Monad mainnet (chain 143). Contracts are immutable (no upgrade pattern).
+
+Full address and provenance record: [Uniswap official deployments](https://github.com/Uniswap/docs/blob/main/content/deployments.md).
+
+## Capabilities
+
+### `swap`
+
+Swap a fixed amount of one token for another via a Uniswap v4 pool (exact-in single-hop).
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `tokenIn` | `TokenReference` | Asset offered to the swap (ERC20 address or `"native"` for MON). |
+| `tokenOut` | `TokenReference` | Asset requested from the swap. |
+| `amountIn` | `PositiveDecimalString` | Amount of `tokenIn` to swap, in display units. |
+| `slippageBps` | `BasisPoints` | Maximum adverse price movement allowed (integer basis points; 1 bps = 0.01%). |
+| `hookData` | `TokenReference` (hex) | Arbitrary bytes to pass to pool hooks; defaults to `0x`. |
+
+**Flow:**
+
+1. If `tokenIn` is ERC20: calls `erc20.approve(poolManager, amountIn)` (nested Capability).
+2. If `tokenIn` is native MON: calls `poolManager.sync([])` with `{value: amountIn}` via `settle()` payable function.
+3. Calls `poolManager.unlock(callback)` — single direct TransactionNode.
+   The callback encodes: `settle()`/`sync(tokenOut)` → `swap(poolKey, params, hookData)` → `take(tokenOut, recipient, minAmountOut)`.
+4. Handles native MON output directly via PoolManager's `take()` with the zero address recipient.
+
+**Risk labels:** `fundOut`, `approval`, `priceImpact`
+
+## Queries
+
+### `quote`
+
+Get a quote for an exact-in swap via V4Quoter.
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `tokenIn` | `TokenReference` | Input token address or `"native"`. |
+| `tokenOut` | `TokenReference` | Output token address or `"native"`. |
+| `amountIn` | `PositiveDecimalString` | Amount of `tokenIn` to quote, in display units. |
+
+**Returns `QuoteResult`:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `amountOut` | `string` | Quoted output amount (display units). |
+| `gasEstimate` | `string` | Estimated gas cost. |
+| `amountIn` | `string?` | Input amount (display units). |
+| `estimatedAmountOut` | `string?` | Estimated output amount. |
+| `minimumAmountOut` | `string?` | Minimum output after 2% slippage buffer. |
+
+## Receipt
+
+The `swapReceipt` parser decodes PoolManager events from simulation traces:
+
+- **PoolManager.Swap** — decoded via `decodeAbiParameters` (custom event layout not in 4byte registry). Extracts `amount0`, `amount1`, `fee`, and derives `zeroForOne` direction.
+- **PoolManager.Transfer** — decodes token movements to/from PoolManager to derive `tokenIn` and `tokenOut`.
+- **ERC20 nativeTransfer** — delegated to `erc20.changesReceipt` for value movements.
+- **ERC20 Transfer/Approval** — delegated to `erc20.changesReceipt` for non-PoolManager events.
+
+Returns `SwapOutcome` with operation, protocol, token refs, amounts, fee tier, and direction.
+
+## ABI Provenance
+
+All ABIs follow ADR 0007 vendored provenance:
+
+| ABI | Source | Tarball SHA256 |
+|-----|--------|----------------|
+| PoolManagerAbi | `@uniswap/v4-core@1.0.2` foundry artifacts | `033d148fac5995874b83621afe35be94a28eb00bfd59bd0a8c9c030bea6a1aef` |
+| V4QuoterAbi | `@uniswap/v4-periphery@1.0.3` foundry artifacts | `3abeef0bd9e6d895727e0bec457db5d600fbb5debd4d413a95577cca938adff0` |
+| UniversalRouterAbi | `@uniswap/universal-router@2.1.0` | `9cdf0ead2bc8993604a4e6e2e8a1fd6f6f8621a5026cb63ef14888c952b42aa5` |
+
+Generated from npm tarballs via `pnpm gen:abis`. See `abis-src/*.json` for committed upstream metadata.
+
+## Risks
+
+- **priceImpact**: Slippage can cause significant loss on low-liquidity pools. Use `slippageBps` to limit adverse movement.
+- **slippage**: The adapter computes `minAmountOut` from on-chain quotes; ensure slippage tolerance matches your risk appetite.
+- **hook uncertainty**: Pool hooks may modify swap behavior unpredictably. Hook address should be verified before use.
+- **quote advisory**: The `quote` query is advisory — actual swap execution repeats discovery against current state.
+
+## Fee Tiers
+
+Standard pool fee tiers (in hundredths of a bip, i.e., 1/10,000,000):
+
+| Fee value | Percentage |
+|-----------|------------|
+| 100 | 0.01% |
+| 500 | 0.05% |
+| 3000 | 0.3% (default) |
+| 10000 | 1% |
+
+Dynamic-fee pools use fee value `0x800000` (highest bit set).

--- a/packages/protocols/uniswap-v4/README.zh-CN.md
+++ b/packages/protocols/uniswap-v4/README.zh-CN.md
@@ -1,0 +1,115 @@
+# @themoss/protocol-uniswap-v4
+
+Monad 上的 Uniswap v4 适配器 — 通过 PoolManager 进行单跳代币兑换。
+
+## 概述
+
+本包实现了 Uniswap v4 在 Monad 主网（链 ID 143）上的自描述 `@Protocol` 适配器。
+它通过 PoolManager 合约提供代币兑换功能，并通过 V4Quoter 合约提供价格报价。
+
+适配器使用 PoolManager 的 `unlock(callback)` 模式来执行单个交易，封装完整的兑换流程：
+`settle/sync` → `swap` → `take`。
+
+## 合约
+
+| 合约 | 地址 | 来源 |
+|------|------|------|
+| PoolManager | `0x188d586dcf52439676ca21a244753fa19f9ea8e` | [Uniswap/v4-core@1.0.2](https://github.com/Uniswap/v4-core)，通过 npm tarball 引入 |
+| V4Quoter | `0xa222dd357a9076d1091ed6aa2e16c9742dd26891` | [Uniswap/v4-periphery@1.0.3](https://github.com/Uniswap/v4-periphery)，通过 npm tarball 引入 |
+
+地址已在 Monad 主网（链 ID 143）验证。合约不可升级。
+
+完整地址和来源记录：[Uniswap 官方部署](https://github.com/Uniswap/docs/blob/main/content/deployments.md)。
+
+## 能力（Capabilities）
+
+### `swap`
+
+通过 Uniswap v4 池将固定数量的代币兑换为另一种代币（精确输入单跳兑换）。
+
+**参数：**
+
+| 名称 | 类型 | 描述 |
+|------|------|------|
+| `tokenIn` | `TokenReference` | 提供的代币（ERC20 地址或 `"native"` 表示 MON）。 |
+| `tokenOut` | `TokenReference` | 请求的代币。 |
+| `amountIn` | `PositiveDecimalString` | 要兑换的 `tokenIn` 数量（显示单位）。 |
+| `slippageBps` | `BasisPoints` | 允许的最大不利价格变动（整数基点；1 基点 = 0.01%）。 |
+| `hookData` | `TokenReference`（hex） | 传递给池钩子的任意字节；默认为 `0x`。 |
+
+**流程：**
+
+1. 如果 `tokenIn` 是 ERC20：调用 `erc20.approve(poolManager, amountIn)`（嵌套能力）。
+2. 如果 `tokenIn` 是原生 MON：通过 `settle()` 可支付函数调用 `poolManager.sync([])` 并附带 `{value: amountIn}`。
+3. 调用 `poolManager.unlock(callback)` — 单个直接 TransactionNode。
+   回调编码：`settle()`/`sync(tokenOut)` → `swap(poolKey, params, hookData)` → `take(tokenOut, recipient, minAmountOut)`。
+4. 通过 PoolManager 的 `take()` 函数，使用零地址接收者直接处理原生 MON 输出。
+
+**风险标签：** `fundOut`、`approval`、`priceImpact`
+
+## 查询（Queries）
+
+### `quote`
+
+通过 V4Quoter 获取精确输入兑换的报价。
+
+**参数：**
+
+| 名称 | 类型 | 描述 |
+|------|------|------|
+| `tokenIn` | `TokenReference` | 输入代币地址或 `"native"`。 |
+| `tokenOut` | `TokenReference` | 输出代币地址或 `"native"`。 |
+| `amountIn` | `PositiveDecimalString` | 要兑换的 `tokenIn` 数量（显示单位）。 |
+
+**返回 `QuoteResult`：**
+
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| `amountOut` | `string` | 报价输出数量（显示单位）。 |
+| `gasEstimate` | `string` | 预估 gas 成本。 |
+| `amountIn` | `string?` | 输入数量（显示单位）。 |
+| `estimatedAmountOut` | `string?` | 预估输出数量。 |
+| `minimumAmountOut` | `string?` | 2% 滑点缓冲后的最低输出。 |
+
+## 收据（Receipt）
+
+`swapReceipt` 解析器从模拟跟踪中解码 PoolManager 事件：
+
+- **PoolManager.Swap** — 通过 `decodeAbiParameters` 解码（自定义事件布局不在 4byte 注册表中）。提取 `amount0`、`amount1`、`fee`，并推导 `zeroForOne` 方向。
+- **PoolManager.Transfer** — 解码到/从 PoolManager 的代币流动，以推导 `tokenIn` 和 `tokenOut`。
+- **ERC20 nativeTransfer** — 委托给 `erc20.changesReceipt` 处理价值流动。
+- **ERC20 Transfer/Approval** — 委托给 `erc20.changesReceipt` 处理非 PoolManager 事件。
+
+返回包含操作、协议、代币引用、数量、费用等级和方向的 `SwapOutcome`。
+
+## ABI 来源证明
+
+所有 ABI 遵循 ADR 0007 引入的来源规范：
+
+| ABI | 来源 | Tarball SHA256 |
+|-----|------|----------------|
+| PoolManagerAbi | `@uniswap/v4-core@1.0.2` foundry 产物 | `033d148fac5995874b83621afe35be94a28eb00bfd59bd0a8c9c030bea6a1aef` |
+| V4QuoterAbi | `@uniswap/v4-periphery@1.0.3` foundry 产物 | `3abeef0bd9e6d895727e0bec457db5d600fbb5debd4d413a95577cca938adff0` |
+| UniversalRouterAbi | `@uniswap/universal-router@2.1.0` | `9cdf0ead2bc8993604a4e6e2e8a1fd6f6f8621a5026cb63ef14888c952b42aa5` |
+
+通过 `pnpm gen:abis` 从 npm tarball 生成。提交的上游元数据见 `abis-src/*.json`。
+
+## 风险
+
+- **价格影响（priceImpact）**：在低流动性池上滑点可能导致重大损失。使用 `slippageBps` 限制不利变动。
+- **滑点（slippage）**：适配器从链上报价计算 `minAmountOut`；请确保滑点容忍度符合您的风险偏好。
+- **钩子不确定性（hook uncertainty）**：池钩子可能不可预测地修改兑换行为。使用前应验证钩子地址。
+- **报价参考性**：`quote` 查询仅为参考 — 实际兑换执行会针对当前状态重新发现。
+
+## 费用等级
+
+标准池费用等级（以十万分之一基点为单位，即 1/10,000,000）：
+
+| 费用值 | 百分比 |
+|--------|--------|
+| 100 | 0.01% |
+| 500 | 0.05% |
+| 3000 | 0.3%（默认） |
+| 10000 | 1% |
+
+动态费用池使用费用值 `0x800000`（最高位设置）。

--- a/packages/protocols/uniswap-v4/abis-src/PoolManager.json
+++ b/packages/protocols/uniswap-v4/abis-src/PoolManager.json
@@ -1,0 +1,1341 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "initialOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "burn",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "clear",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "collectProtocolFees",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountCollected",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "donate",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "amount0",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "hookData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "delta",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "extsload",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "extsload",
+    "inputs": [
+      {
+        "name": "startSlot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nSlots",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "extsload",
+    "inputs": [
+      {
+        "name": "slots",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "exttload",
+    "inputs": [
+      {
+        "name": "slots",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "exttload",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "sqrtPriceX96",
+        "type": "uint160",
+        "internalType": "uint160"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "tick",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isOperator",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isOperator",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "modifyLiquidity",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct ModifyLiquidityParams",
+        "components": [
+          {
+            "name": "tickLower",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "tickUpper",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "liquidityDelta",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "salt",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "hookData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "callerDelta",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      },
+      {
+        "name": "feesAccrued",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeController",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeesAccrued",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setProtocolFee",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "newProtocolFee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setProtocolFeeController",
+    "inputs": [
+      {
+        "name": "controller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settle",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paid",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "settleFor",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "paid",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "swap",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct SwapParams",
+        "components": [
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "amountSpecified",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "sqrtPriceLimitX96",
+            "type": "uint160",
+            "internalType": "uint160"
+          }
+        ]
+      },
+      {
+        "name": "hookData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "swapDelta",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sync",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "take",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unlock",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateDynamicLPFee",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "newDynamicLPFee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Donate",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount0",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "amount1",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialize",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "currency0",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "indexed": true,
+        "name": "currency1",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "indexed": false,
+        "name": "fee",
+        "type": "uint24",
+        "internalType": "uint24"
+      },
+      {
+        "indexed": false,
+        "name": "tickSpacing",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "hooks",
+        "type": "address",
+        "internalType": "contract IHooks"
+      },
+      {
+        "indexed": false,
+        "name": "sqrtPriceX96",
+        "type": "uint160",
+        "internalType": "uint160"
+      },
+      {
+        "indexed": false,
+        "name": "tick",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ModifyLiquidity",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "tickLower",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "tickUpper",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "liquidityDelta",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "indexed": false,
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorSet",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeeControllerUpdated",
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "protocolFeeController",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeeUpdated",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": false,
+        "name": "protocolFee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Swap",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount0",
+        "type": "int128",
+        "internalType": "int128"
+      },
+      {
+        "indexed": false,
+        "name": "amount1",
+        "type": "int128",
+        "internalType": "int128"
+      },
+      {
+        "indexed": false,
+        "name": "sqrtPriceX96",
+        "type": "uint160",
+        "internalType": "uint160"
+      },
+      {
+        "indexed": false,
+        "name": "liquidity",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "indexed": false,
+        "name": "tick",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "fee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "currency0",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "currency1",
+        "type": "address",
+        "internalType": "Currency"
+      }
+    ],
+    "name": "CurrenciesOutOfOrderOrEqual"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "CurrencyNotSettled"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "ManagerLocked"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "NonzeroNativeValue"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "MustClearExactPositiveDelta"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "PoolNotInitialized"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "SwapAmountCannotBeZero"
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "tickSpacing",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "name": "TickSpacingTooLarge"
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "tickSpacing",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "name": "TickSpacingTooSmall"
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "fee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "name": "UnorderedCurrencyFeeCollision"
+  }
+]

--- a/packages/protocols/uniswap-v4/abis-src/UniversalRouter.json
+++ b/packages/protocols/uniswap-v4/abis-src/UniversalRouter.json
@@ -1,0 +1,738 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "permit2",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "weth9",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v2Factory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v3Factory",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "pairInitCodeHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "poolInitCodeHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "v4PoolManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v3NFTPositionManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v4PositionManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "spokePool",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct RouterParameters",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "AddressInsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BalanceTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ContractLocked",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Currency",
+        "name": "currency",
+        "type": "address"
+      }
+    ],
+    "name": "DeltaNotNegative",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Currency",
+        "name": "currency",
+        "type": "address"
+      }
+    ],
+    "name": "DeltaNotPositive",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ECDSAInvalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureLength",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureS",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ETHNotAccepted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "commandIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "message",
+        "type": "bytes"
+      }
+    ],
+    "name": "ExecutionFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedInnerCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FromAddressIsNotOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InputLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientETH",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientToken",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "action",
+        "type": "bytes4"
+      }
+    ],
+    "name": "InvalidAction",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBips",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "commandType",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidCommandType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidEthSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidHopSlippageLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPath",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidReserves",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidShortString",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NonceAlreadyUsed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotAuthorizedForToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotPoolManager",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyMintAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SliceOutOfBounds",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "str",
+        "type": "string"
+      }
+    ],
+    "name": "StringTooLong",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TransactionDeadlinePassed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsafeCast",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "action",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnsupportedAction",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V2InvalidPath",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V2TooLittleReceived",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V2TooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3InvalidAmountOut",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3InvalidCaller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3InvalidSwap",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3TooLittleReceived",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3TooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "minAmountOutReceived",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountReceived",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooLittleReceived",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "hopIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooLittleReceivedPerHop",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxAmountInRequested",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountRequested",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "hopIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooMuchRequestedPerHop",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "SPOKE_POOL",
+    "outputs": [
+      {
+        "internalType": "contract IV3SpokePool",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "V3_POSITION_MANAGER",
+    "outputs": [
+      {
+        "internalType": "contract INonfungiblePositionManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "V4_POSITION_MANAGER",
+    "outputs": [
+      {
+        "internalType": "contract IPositionManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "commands",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "inputs",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "commands",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "inputs",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "commands",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "inputs",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "intent",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "data",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "verifySender",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "nonce",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "executeSigned",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "msgSender",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "nonce",
+        "type": "bytes32"
+      }
+    ],
+    "name": "noncesUsed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "used",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolManager",
+    "outputs": [
+      {
+        "internalType": "contract IPoolManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "signedRouteContext",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "intent",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "data",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "amount0Delta",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "amount1Delta",
+        "type": "int256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "uniswapV3SwapCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "unlockCallback",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/packages/protocols/uniswap-v4/abis-src/V4CoreVendor.json
+++ b/packages/protocols/uniswap-v4/abis-src/V4CoreVendor.json
@@ -1,0 +1,7 @@
+{
+  "name": "@uniswap/v4-core",
+  "version": "1.0.2",
+  "tarballSha256": "033d148fac5995874b83621afe35be94a28eb00bfd59bd0a8c9c030bea6a1aef",
+  "vendoredAt": "2026-07-18",
+  "releaseAgeGuardDays": 7
+}

--- a/packages/protocols/uniswap-v4/abis-src/V4PeripheryVendor.json
+++ b/packages/protocols/uniswap-v4/abis-src/V4PeripheryVendor.json
@@ -1,0 +1,7 @@
+{
+  "name": "@uniswap/v4-periphery",
+  "version": "1.0.3",
+  "tarballSha256": "3abeef0bd9e6d895727e0bec457db5d600fbb5debd4d413a95577cca938adff0",
+  "vendoredAt": "2026-07-18",
+  "releaseAgeGuardDays": 7
+}

--- a/packages/protocols/uniswap-v4/abis-src/V4Quoter.json
+++ b/packages/protocols/uniswap-v4/abis-src/V4Quoter.json
@@ -1,0 +1,650 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_poolManager",
+        "type": "address",
+        "internalType": "contract IPoolManager"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactInput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactInputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactOutput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactOutputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "msgSender",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "poolManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IPoolManager"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactInput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactInputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactOutput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactOutputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unlockCallback",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "error",
+    "name": "NotEnoughLiquidity",
+    "inputs": [
+      {
+        "name": "poolId",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotPoolManager",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotSelf",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "QuoteSwap",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnexpectedCallSuccess",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UnexpectedRevertBytes",
+    "inputs": [
+      {
+        "name": "revertData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  }
+]

--- a/packages/protocols/uniswap-v4/abis-src/Vendor.json
+++ b/packages/protocols/uniswap-v4/abis-src/Vendor.json
@@ -1,0 +1,7 @@
+{
+  "name": "@uniswap/universal-router",
+  "version": "2.1.0",
+  "tarballSha256": "9cdf0ead2bc8993604a4e6e2e8a1fd6f6f8621a5026cb63ef14888c952b42aa5",
+  "vendoredAt": "2026-07-17",
+  "releaseAgeGuardDays": 7
+}

--- a/packages/protocols/uniswap-v4/package.json
+++ b/packages/protocols/uniswap-v4/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@themoss/protocol-uniswap-v4",
+  "version": "0.0.0",
+  "description": "Uniswap v4 adapter on Monad — DEX swaps via PoolManager",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "gen:abis": "tsx scripts/gen-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/simulator": "workspace:*",
+    "@themoss/system": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/uniswap-v4/scripts/abis.ts
+++ b/packages/protocols/uniswap-v4/scripts/abis.ts
@@ -1,0 +1,158 @@
+/**
+ * The DETERMINISTIC half of the ABI pipeline: derive src/abis/*.ts purely
+ * from the committed abis-src/ files. No network, no clock — same inputs, same
+ * bytes. This is what makes the provenance chain enforceable: test/abis.test.ts
+ * asserts each generated file === the committed file, so hand-edits to the
+ * generated TS, generator edits without regeneration, and abis-src edits
+ * without regeneration all fail the suite.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const packageRoot = join(__dirname, "..");
+
+interface SourceSpec {
+  srcFile: string;
+  exportName: string;
+  metadataFile: string;
+}
+
+/**
+ * Full upstream ABIs are exported (ADR 0007) — the adapter's callable surface
+ * is reviewed where Capabilities and Receipt parsers live, and simulation is
+ * the enforcement layer.
+ */
+export const SOURCES: SourceSpec[] = [
+  {
+    srcFile: "PoolManager.json",
+    exportName: "PoolManagerAbi",
+    metadataFile: "V4CoreVendor.json",
+  },
+  {
+    srcFile: "V4Quoter.json",
+    exportName: "V4QuoterAbi",
+    metadataFile: "V4PeripheryVendor.json",
+  },
+  {
+    srcFile: "UniversalRouter.json",
+    exportName: "UniversalRouterAbi",
+    metadataFile: "Vendor.json",
+  },
+];
+
+interface VendorInfo {
+  name: string;
+  version: string;
+  tarballSha256: string;
+  vendoredAt: string;
+  releaseAgeGuardDays: number;
+}
+
+interface AbiEntry {
+  type: string;
+  name?: string;
+}
+
+/**
+ * Read a source file (JSON) and extract the ABI array.
+ * Tolerates both bare arrays and { abi: [...] } wrapper objects.
+ */
+function extractAbi(abiPath: string): AbiEntry[] {
+  const raw = readFileSync(abiPath, "utf8");
+  const artifact = JSON.parse(raw);
+  if (Array.isArray(artifact)) return artifact;
+  if (artifact.abi && Array.isArray(artifact.abi)) return artifact.abi;
+  throw new Error(`Cannot find ABI array in ${abiPath}`);
+}
+
+/** The Swap event signature hash for receipt parsing. */
+const SWAP_EVENT_TOPIC = "0x7a107ae252ae577c7e90822f0aa2558a54b37b19a49f1b832616f2c18991635d";
+
+/**
+ * Generate the header comment for a generated ABI file.
+ * The header is the only variable part — everything after it is
+ * deterministic from the source ABI JSON.
+ */
+function generateHeader(vendor: VendorInfo): string {
+  return [
+    "// GENERATED FILE — do not edit by hand.",
+    `//   compile from npm tarball:  pnpm gen:abis`,
+    "// ABI origin: vendored (ADR 0007)",
+    `//   source:   ${vendor.name}@${vendor.version} (npm), foundry artifacts`,
+    `//   tarball:  sha256 ${vendor.tarballSha256}`,
+    `//   verification: contracts verified on Monad mainnet via rpc.monad.xyz;`,
+    `//   the adapter's e2e tests pin observable behavior.`,
+    `//   caveat:   V4 contracts are immutable once deployed (no upgrade pattern).`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Generate the full TypeScript ABI file content from a source ABI JSON.
+ * The output is byte-for-byte deterministic given the same input.
+ */
+function generateFile(
+  exportName: string,
+  vendor: VendorInfo,
+  abi: AbiEntry[],
+  isPoolManager: boolean,
+): string {
+  let output = `${generateHeader(vendor)}export const ${exportName} = ${JSON.stringify(abi, null, 2)} as const;\n`;
+  // Append the Swap event topic constant for PoolManager ABI
+  if (isPoolManager) {
+    output += `\n/** Swap event signature hash for receipt parsing */\nexport const SWAP_EVENT_TOPIC = "${SWAP_EVENT_TOPIC}" as const;\n`;
+  }
+  return output;
+}
+
+/**
+ * Generate all ABI files from their source JSON files.
+ * This is called by scripts/gen-abis.ts after editing the generator logic.
+ */
+export function generateAll(packageRoot: string): void {
+  // Mapping from export names to source file names
+  const exportToSource: Record<string, { srcFile: string; metadataFile: string }> = {};
+  for (const source of SOURCES) {
+    exportToSource[source.exportName] = {
+      srcFile: source.srcFile,
+      metadataFile: source.metadataFile,
+    };
+  }
+
+  for (const [exportName, { srcFile, metadataFile }] of Object.entries(exportToSource)) {
+    const vendorPath = join(packageRoot, "abis-src", metadataFile);
+    const vendor = JSON.parse(readFileSync(vendorPath, "utf8")) as VendorInfo;
+    const abiPath = join(packageRoot, "abis-src", srcFile);
+    const abi = extractAbi(abiPath);
+
+    // Map export names to file names:
+    // PoolManagerAbi → uniswap-v4.ts
+    // V4QuoterAbi → v4quoter.ts
+    // UniversalRouterAbi → universal-router.ts
+    let fileName: string;
+    const isPoolManager = exportName === "PoolManagerAbi";
+    switch (exportName) {
+      case "PoolManagerAbi":
+        fileName = "uniswap-v4";
+        break;
+      case "V4QuoterAbi":
+        fileName = "v4quoter";
+        break;
+      case "UniversalRouterAbi":
+        fileName = "universal-router";
+        break;
+      default:
+        fileName = exportName.toLowerCase().replace("abi", "");
+    }
+    const output = generateFile(exportName, vendor, abi, isPoolManager);
+    writeFileSync(join(packageRoot, "src", "abis", `${fileName}.ts`), output);
+    console.log(`generated src/abis/${fileName}.ts from ${srcFile}`);
+  }
+}
+
+// Allow running this script directly
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  generateAll(packageRoot);
+}

--- a/packages/protocols/uniswap-v4/scripts/gen-abis.ts
+++ b/packages/protocols/uniswap-v4/scripts/gen-abis.ts
@@ -1,0 +1,14 @@
+/**
+ * Offline regeneration: derive src/abis/*.ts from the COMMITTED abis-src/
+ * files. Use after changing the deterministic generator in ./abis.ts — no
+ * network involved. test/abis.test.ts enforces that the committed output
+ * matches this exactly.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateAll } from "./abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+generateAll(packageRoot);
+console.log("regenerated all src/abis/*.ts from abis-src/ (offline)");

--- a/packages/protocols/uniswap-v4/src/abis/uniswap-v4.ts
+++ b/packages/protocols/uniswap-v4/src/abis/uniswap-v4.ts
@@ -1,0 +1,1352 @@
+// GENERATED FILE — do not edit by hand.
+//   compile from npm tarball:  pnpm gen:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   @uniswap/v4-core@1.0.2 (npm), foundry artifacts
+//   tarball:  sha256 033d148fac5995874b83621afe35be94a28eb00bfd59bd0a8c9c030bea6a1aef
+//   verification: contracts verified on Monad mainnet via rpc.monad.xyz;
+//   the adapter's e2e tests pin observable behavior.
+//   caveat:   V4 contracts are immutable once deployed (no upgrade pattern).
+export const PoolManagerAbi = [
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "initialOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "burn",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "clear",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "collectProtocolFees",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountCollected",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "donate",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "amount0",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount1",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "hookData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "delta",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "extsload",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "extsload",
+    "inputs": [
+      {
+        "name": "startSlot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nSlots",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "extsload",
+    "inputs": [
+      {
+        "name": "slots",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "exttload",
+    "inputs": [
+      {
+        "name": "slots",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "exttload",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "sqrtPriceX96",
+        "type": "uint160",
+        "internalType": "uint160"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "tick",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isOperator",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isOperator",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "modifyLiquidity",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct ModifyLiquidityParams",
+        "components": [
+          {
+            "name": "tickLower",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "tickUpper",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "liquidityDelta",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "salt",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "hookData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "callerDelta",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      },
+      {
+        "name": "feesAccrued",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeController",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeesAccrued",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setProtocolFee",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "newProtocolFee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setProtocolFeeController",
+    "inputs": [
+      {
+        "name": "controller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settle",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paid",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "settleFor",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "paid",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "swap",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct SwapParams",
+        "components": [
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "amountSpecified",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "sqrtPriceLimitX96",
+            "type": "uint160",
+            "internalType": "uint160"
+          }
+        ]
+      },
+      {
+        "name": "hookData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "swapDelta",
+        "type": "int256",
+        "internalType": "BalanceDelta"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sync",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "take",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unlock",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateDynamicLPFee",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "tuple",
+        "internalType": "struct PoolKey",
+        "components": [
+          {
+            "name": "currency0",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "currency1",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "fee",
+            "type": "uint24",
+            "internalType": "uint24"
+          },
+          {
+            "name": "tickSpacing",
+            "type": "int24",
+            "internalType": "int24"
+          },
+          {
+            "name": "hooks",
+            "type": "address",
+            "internalType": "contract IHooks"
+          }
+        ]
+      },
+      {
+        "name": "newDynamicLPFee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Donate",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount0",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "amount1",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialize",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "currency0",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "indexed": true,
+        "name": "currency1",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "indexed": false,
+        "name": "fee",
+        "type": "uint24",
+        "internalType": "uint24"
+      },
+      {
+        "indexed": false,
+        "name": "tickSpacing",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "hooks",
+        "type": "address",
+        "internalType": "contract IHooks"
+      },
+      {
+        "indexed": false,
+        "name": "sqrtPriceX96",
+        "type": "uint160",
+        "internalType": "uint160"
+      },
+      {
+        "indexed": false,
+        "name": "tick",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ModifyLiquidity",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "tickLower",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "tickUpper",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "liquidityDelta",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "indexed": false,
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OperatorSet",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeeControllerUpdated",
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "protocolFeeController",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeeUpdated",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": false,
+        "name": "protocolFee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Swap",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "id",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      },
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount0",
+        "type": "int128",
+        "internalType": "int128"
+      },
+      {
+        "indexed": false,
+        "name": "amount1",
+        "type": "int128",
+        "internalType": "int128"
+      },
+      {
+        "indexed": false,
+        "name": "sqrtPriceX96",
+        "type": "uint160",
+        "internalType": "uint160"
+      },
+      {
+        "indexed": false,
+        "name": "liquidity",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "indexed": false,
+        "name": "tick",
+        "type": "int24",
+        "internalType": "int24"
+      },
+      {
+        "indexed": false,
+        "name": "fee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "indexed": false,
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "currency0",
+        "type": "address",
+        "internalType": "Currency"
+      },
+      {
+        "name": "currency1",
+        "type": "address",
+        "internalType": "Currency"
+      }
+    ],
+    "name": "CurrenciesOutOfOrderOrEqual"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "CurrencyNotSettled"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "ManagerLocked"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "NonzeroNativeValue"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "MustClearExactPositiveDelta"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "PoolNotInitialized"
+  },
+  {
+    "type": "error",
+    "inputs": [],
+    "name": "SwapAmountCannotBeZero"
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "tickSpacing",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "name": "TickSpacingTooLarge"
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "tickSpacing",
+        "type": "int24",
+        "internalType": "int24"
+      }
+    ],
+    "name": "TickSpacingTooSmall"
+  },
+  {
+    "type": "error",
+    "inputs": [
+      {
+        "name": "fee",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "name": "UnorderedCurrencyFeeCollision"
+  }
+] as const;
+
+/** Swap event signature hash for receipt parsing */
+export const SWAP_EVENT_TOPIC = "0x7a107ae252ae577c7e90822f0aa2558a54b37b19a49f1b832616f2c18991635d" as const;

--- a/packages/protocols/uniswap-v4/src/abis/universal-router.ts
+++ b/packages/protocols/uniswap-v4/src/abis/universal-router.ts
@@ -1,0 +1,746 @@
+// GENERATED FILE — do not edit by hand.
+//   compile from npm tarball:  pnpm gen:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   @uniswap/universal-router@2.1.0 (npm), foundry artifacts
+//   tarball:  sha256 9cdf0ead2bc8993604a4e6e2e8a1fd6f6f8621a5026cb63ef14888c952b42aa5
+//   verification: contracts verified on Monad mainnet via rpc.monad.xyz;
+//   the adapter's e2e tests pin observable behavior.
+//   caveat:   V4 contracts are immutable once deployed (no upgrade pattern).
+export const UniversalRouterAbi = [
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "permit2",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "weth9",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v2Factory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v3Factory",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "pairInitCodeHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "poolInitCodeHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "v4PoolManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v3NFTPositionManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "v4PositionManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "spokePool",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct RouterParameters",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "AddressInsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BalanceTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ContractLocked",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Currency",
+        "name": "currency",
+        "type": "address"
+      }
+    ],
+    "name": "DeltaNotNegative",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "Currency",
+        "name": "currency",
+        "type": "address"
+      }
+    ],
+    "name": "DeltaNotPositive",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ECDSAInvalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureLength",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureS",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ETHNotAccepted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "commandIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "message",
+        "type": "bytes"
+      }
+    ],
+    "name": "ExecutionFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedInnerCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FromAddressIsNotOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InputLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientETH",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientToken",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "action",
+        "type": "bytes4"
+      }
+    ],
+    "name": "InvalidAction",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBips",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "commandType",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidCommandType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidEthSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidHopSlippageLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPath",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidReserves",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidShortString",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NonceAlreadyUsed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotAuthorizedForToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotPoolManager",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyMintAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SliceOutOfBounds",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "str",
+        "type": "string"
+      }
+    ],
+    "name": "StringTooLong",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TransactionDeadlinePassed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsafeCast",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "action",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnsupportedAction",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V2InvalidPath",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V2TooLittleReceived",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V2TooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3InvalidAmountOut",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3InvalidCaller",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3InvalidSwap",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3TooLittleReceived",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "V3TooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "minAmountOutReceived",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountReceived",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooLittleReceived",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "hopIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooLittleReceivedPerHop",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxAmountInRequested",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountRequested",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "hopIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "V4TooMuchRequestedPerHop",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "SPOKE_POOL",
+    "outputs": [
+      {
+        "internalType": "contract IV3SpokePool",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "V3_POSITION_MANAGER",
+    "outputs": [
+      {
+        "internalType": "contract INonfungiblePositionManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "V4_POSITION_MANAGER",
+    "outputs": [
+      {
+        "internalType": "contract IPositionManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "commands",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "inputs",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "commands",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "inputs",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "commands",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "inputs",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "intent",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "data",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "verifySender",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "nonce",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "executeSigned",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "msgSender",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "nonce",
+        "type": "bytes32"
+      }
+    ],
+    "name": "noncesUsed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "used",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolManager",
+    "outputs": [
+      {
+        "internalType": "contract IPoolManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "signedRouteContext",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "intent",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "data",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "amount0Delta",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "amount1Delta",
+        "type": "int256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "uniswapV3SwapCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "unlockCallback",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+] as const;

--- a/packages/protocols/uniswap-v4/src/abis/v4quoter.ts
+++ b/packages/protocols/uniswap-v4/src/abis/v4quoter.ts
@@ -1,0 +1,658 @@
+// GENERATED FILE — do not edit by hand.
+//   compile from npm tarball:  pnpm gen:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   @uniswap/v4-periphery@1.0.3 (npm), foundry artifacts
+//   tarball:  sha256 3abeef0bd9e6d895727e0bec457db5d600fbb5debd4d413a95577cca938adff0
+//   verification: contracts verified on Monad mainnet via rpc.monad.xyz;
+//   the adapter's e2e tests pin observable behavior.
+//   caveat:   V4 contracts are immutable once deployed (no upgrade pattern).
+export const V4QuoterAbi = [
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "_poolManager",
+        "type": "address",
+        "internalType": "contract IPoolManager"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactInput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactInputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactOutput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "_quoteExactOutputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "msgSender",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "poolManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IPoolManager"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactInput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactInputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactOutput",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactParams",
+        "components": [
+          {
+            "name": "exactCurrency",
+            "type": "address",
+            "internalType": "Currency"
+          },
+          {
+            "name": "path",
+            "type": "tuple[]",
+            "internalType": "struct PathKey[]",
+            "components": [
+              {
+                "name": "intermediateCurrency",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              },
+              {
+                "name": "hookData",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "quoteExactOutputSingle",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IV4Quoter.QuoteExactSingleParams",
+        "components": [
+          {
+            "name": "poolKey",
+            "type": "tuple",
+            "internalType": "struct PoolKey",
+            "components": [
+              {
+                "name": "currency0",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "currency1",
+                "type": "address",
+                "internalType": "Currency"
+              },
+              {
+                "name": "fee",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "tickSpacing",
+                "type": "int24",
+                "internalType": "int24"
+              },
+              {
+                "name": "hooks",
+                "type": "address",
+                "internalType": "contract IHooks"
+              }
+            ]
+          },
+          {
+            "name": "zeroForOne",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "exactAmount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "hookData",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasEstimate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unlockCallback",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "error",
+    "name": "NotEnoughLiquidity",
+    "inputs": [
+      {
+        "name": "poolId",
+        "type": "bytes32",
+        "internalType": "PoolId"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotPoolManager",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotSelf",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "QuoteSwap",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnexpectedCallSuccess",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UnexpectedRevertBytes",
+    "inputs": [
+      {
+        "name": "revertData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  }
+] as const;

--- a/packages/protocols/uniswap-v4/src/adapter.ts
+++ b/packages/protocols/uniswap-v4/src/adapter.ts
@@ -1,0 +1,580 @@
+/**
+ * Uniswap v4 Protocol adapter on Monad.
+ *
+ * Single-hop exact-in swaps via PoolManager using the unlock() callback
+ * pattern — this keeps exactly one direct TransactionNode per ADR 0011.
+ *
+ * Flow:
+ *   1. ERC20.approve(poolManager, amountIn)    — nested Capability (conditional)
+ *   2. poolManager.unlock(callback)             — single direct TransactionNode
+ *      callback: settle/sync → swap → take(recipient)
+ *
+ * The unlock callback is a single bytes blob containing concatenated
+ * ABI-encoded function calls. PoolManager.unlock(bytes) forwards the
+ * calldata to an internal unlockCallback which executes the sequence.
+ */
+import {
+  type ActionCtx,
+  type AddressValue,
+  BasisPoints,
+  Capability,
+  type CapabilityNode,
+  type CapabilityResult,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type MossRuntime,
+  NATIVE,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  type TokenRef,
+  TokenReference,
+  type TransactionNode,
+} from "@themoss/core";
+import { ERC20, ERC20Abi } from "@themoss/erc";
+import {
+  decodeAbiParameters,
+  decodeEventLog,
+  encodeFunctionData,
+  formatUnits,
+  parseUnits,
+} from "viem";
+import { PoolManagerAbi, SWAP_EVENT_TOPIC } from "./abis/uniswap-v4.js";
+import { V4QuoterAbi } from "./abis/v4quoter.js";
+import {
+  buildPoolKey,
+  getSwapDirection,
+  isNativeCurrency,
+  type PoolFee,
+  type PoolKey,
+  type PoolTickSpacing,
+  type QuoteResult,
+  type SwapOutcome,
+  toCurrencyAddress,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Addresses — verified against Uniswap's official deployments (chain 143 = Monad).
+// Source: https://github.com/Uniswap/docs/blob/main/content/deployments.md
+// ---------------------------------------------------------------------------
+export const UNISWAP_V4_POOL_MANAGER_ADDRESS =
+  "0x188d586ddcf52439676ca21a244753fa19f9ea8e" as const;
+
+export const UNISWAP_V4_QUOTER_ADDRESS = "0xa222dd357a9076d1091ed6aa2e16c9742dd26891" as const;
+
+// Default tick spacing for standard pools (0.3% fee)
+const DEFAULT_TICK_SPACING: PoolTickSpacing = 1;
+// Standard fee tiers: 100 = 0.01%, 500 = 0.05%, 3000 = 0.3%, 10000 = 1%
+const DEFAULT_FEE: PoolFee = 3000;
+
+// ---------------------------------------------------------------------------
+// Parameter specs
+// ---------------------------------------------------------------------------
+
+const swapParams = {
+  tokenIn: { type: TokenReference, description: "Asset offered to the swap." },
+  tokenOut: { type: TokenReference, description: "Asset requested from the swap." },
+  amountIn: { type: PositiveDecimalString, description: "Amount of tokenIn to swap." },
+  slippageBps: {
+    type: BasisPoints,
+    description: "Maximum adverse price movement allowed during execution.",
+  },
+  hookData: {
+    type: TokenReference.describe(
+      "Arbitrary hex-encoded bytes to pass to the pool hooks; defaults to empty bytes.",
+    ),
+    description: "Arbitrary bytes to pass to the pool hooks; defaults to empty.",
+  },
+} satisfies ParamsSpec;
+
+const quoteParams = {
+  tokenIn: { type: TokenReference, description: "Input token address or 'native'." },
+  tokenOut: { type: TokenReference, description: "Output token address or 'native'." },
+  amountIn: { type: PositiveDecimalString, description: "Amount of tokenIn to quote." },
+} satisfies ParamsSpec;
+
+// ---------------------------------------------------------------------------
+// Calldata helpers — build the unlock() callback payload
+// ---------------------------------------------------------------------------
+
+/** Encode a single function call as raw calldata (selector + args). */
+function encodeCall(abi: readonly unknown[], fn: string, args: readonly unknown[]): Hex {
+  return encodeFunctionData({ abi, functionName: fn, args }) as Hex;
+}
+
+/**
+ * Replace an address at a specific byte offset in a hex calldata blob.
+ * Each EVM address occupies 32 bytes (64 hex chars), left-padded with zeros.
+ */
+function replaceAtHex(hex: string | Hex, byteOffset: number, address: `0x${string}`): Hex {
+  const clean = (hex as Hex).replace("0x", "");
+  const hexOffset = byteOffset * 2;
+  const before = clean.slice(0, hexOffset);
+  const after = clean.slice(hexOffset + 64);
+  return `0x${before}${address.slice(2).padStart(64, "0")}${after}` as Hex;
+}
+
+/**
+ * Build the calldata payload for poolManager.unlock(callback).
+ *
+ * The callback is concatenated ABI-encoded function calls:
+ *   settle() or sync(tokenOut) + swap(poolKey, params, hookData) + take(currency, recipient, minAmountOut)
+ */
+function buildUnlockCallback(
+  useSettle: boolean,
+  syncTokenAddr: AddressValue,
+  poolKey: PoolKey,
+  zeroForOne: boolean,
+  amountSpecified: bigint,
+  hookDataBytes: Hex,
+  tokenOutAddr: AddressValue,
+  recipientAddr: AddressValue,
+  minAmountOut: bigint,
+): Hex {
+  const parts: Hex[] = [];
+
+  // Step 1: settle() (payable, for native MON input) or sync(tokenOut) (for ERC20 input)
+  if (useSettle) {
+    parts.push(encodeCall(PoolManagerAbi, "settle", []));
+  } else {
+    parts.push(encodeCall(PoolManagerAbi, "sync", [syncTokenAddr]));
+  }
+
+  // Step 2: swap(key, {zeroForOne, amountSpecified, sqrtPriceLimitX96}, hookData)
+  parts.push(
+    encodeCall(PoolManagerAbi, "swap", [
+      poolKey,
+      { zeroForOne, amountSpecified, sqrtPriceLimitX96: 0n },
+      hookDataBytes,
+    ]),
+  );
+
+  // Step 3: take(currency, recipient, minAmountOut)
+  parts.push(encodeCall(PoolManagerAbi, "take", [tokenOutAddr, recipientAddr, minAmountOut]));
+
+  // Compute exact byte offset of recipient inside the full callback blob
+  const allHex = parts.map((p) => p.replace("0x", "")).join("");
+  let takeStart = 0;
+  for (let i = 0; i < parts.length - 1; i++) {
+    takeStart += (parts[i] || "").replace("0x", "").length / 2;
+  }
+  const recipientOffset = takeStart + 36;
+  return replaceAtHex(allHex as Hex, recipientOffset, recipientAddr as `0x${string}`);
+}
+
+// ---------------------------------------------------------------------------
+// UniswapV4 Protocol
+// ---------------------------------------------------------------------------
+
+@Protocol({
+  name: "uniswap-v4",
+  category: "dex",
+  description: "Uniswap v4 on Monad: single-hop token swaps via PoolManager.",
+  contracts: {
+    poolManager: { abi: PoolManagerAbi, addr: UNISWAP_V4_POOL_MANAGER_ADDRESS },
+    v4Quoter: { abi: V4QuoterAbi, addr: UNISWAP_V4_QUOTER_ADDRESS },
+  },
+  protocols: {
+    erc20: ERC20,
+  },
+})
+export class UniswapV4 {
+  declare runtime: MossRuntime;
+  declare poolManager: Handle<typeof PoolManagerAbi>;
+  declare v4Quoter: Handle<typeof V4QuoterAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  // --- swap Capability ---
+
+  @Capability<UniswapV4, typeof swapParams>({
+    intent: "Swap {amountIn} of {tokenIn} into {tokenOut} via Uniswap v4",
+    verb: "swap",
+    params: swapParams,
+    receipt: "swapReceipt",
+    risk: ["fundOut", "approval", "priceImpact"],
+    tags: ["dex", "swap"],
+  })
+  async swap(params: InferParams<typeof swapParams>, ctx: ActionCtx): Promise<CapabilityResult> {
+    const { tokenIn, tokenOut, amountIn, slippageBps, hookData } = params;
+    const isInputNative = isNativeCurrency(tokenIn);
+    const isOutputNative = isNativeCurrency(tokenOut);
+
+    // 1. Query on-chain token decimals for correct parseUnits
+    const [inDecimals, _outDecimals] = await this.#getTokenDecimals(tokenIn, tokenOut);
+    const amountInBase = parseUnits(amountIn as string, inDecimals);
+    const amountInSmallest = amountInBase.toString();
+
+    // 2. Get on-chain quote to compute real minAmountOut
+    const quote = await this.#quoteExactInputSingle(
+      tokenIn,
+      tokenOut,
+      amountInBase,
+      hookData as Hex,
+    );
+    const bps = slippageBps as number;
+    const minAmountOut =
+      quote.amountOut > 0n
+        ? (quote.amountOut * BigInt(10_000 - bps)) / 10_000n
+        : (amountInBase * BigInt(10_000 - bps)) / 10_000n;
+
+    const poolKey = buildPoolKey(tokenIn, tokenOut, DEFAULT_FEE, DEFAULT_TICK_SPACING);
+    const { zeroForOne } = getSwapDirection(tokenIn, poolKey);
+
+    // 3. Approval (if ERC20 input) — nested Capability, not a direct transaction
+    const children: (CapabilityNode | TransactionNode)[] = [];
+    if (!isInputNative) {
+      children.push(
+        await this.erc20.approve({
+          token: toCurrencyAddress(tokenIn) as AddressValue,
+          spender: UNISWAP_V4_POOL_MANAGER_ADDRESS as AddressValue,
+          amount: amountInSmallest,
+        }),
+      );
+    }
+
+    // 4. Single direct TransactionNode: poolManager.unlock(callback)
+    //    Callback encodes: settle/sync → swap → take
+    const tokenOutAddr = toCurrencyAddress(tokenOut) as AddressValue;
+    const recipientAddr = isOutputNative
+      ? ("0x0000000000000000000000000000000000000000" as AddressValue)
+      : (ctx.account as AddressValue);
+
+    const callback = buildUnlockCallback(
+      isInputNative, // useSettle
+      tokenOutAddr, // sync token (tokenOut for ERC20 input path)
+      poolKey,
+      zeroForOne,
+      -amountInBase, // negative = exactIn
+      hookData as Hex,
+      tokenOutAddr,
+      recipientAddr,
+      minAmountOut,
+    );
+
+    children.push(
+      this.poolManager.unlock([callback], {
+        value: isInputNative ? amountInBase : undefined,
+      }),
+    );
+
+    return children;
+  }
+
+  // --- quote Query ---
+
+  @Query({ intent: "Quote a Uniswap v4 exact-in swap", params: quoteParams })
+  async quote(params: InferParams<typeof quoteParams>): Promise<QuoteResult> {
+    const { tokenIn, tokenOut, amountIn } = params;
+
+    const [inDecimals, outDecimals] = await this.#getTokenDecimals(tokenIn, tokenOut);
+    const amountInBase = parseUnits(amountIn as string, inDecimals);
+
+    const quote = await this.#quoteExactInputSingle(tokenIn, tokenOut, amountInBase, "0x" as Hex);
+
+    return {
+      amountOut: formatUnits(quote.amountOut, outDecimals),
+      gasEstimate: quote.gasEstimate.toString(),
+      amountSide: "amountIn" as const,
+      amountIn: formatUnits(amountInBase, inDecimals),
+      estimatedAmountOut: formatUnits(quote.amountOut, outDecimals),
+      minimumAmountOut: formatUnits((quote.amountOut * 98n) / 100n, outDecimals),
+    };
+  }
+
+  // --- swap Receipt Parser ---
+
+  @Receipt()
+  swapReceipt(changes: readonly Change[]): ReceiptResult<SwapOutcome> {
+    let tokenIn: TokenRef | undefined;
+    let tokenOut: TokenRef | undefined;
+    let poolManagerNativeSent = false;
+
+    // Pass 1: collect Transfer context to derive tokenIn/tokenOut
+    for (const change of changes) {
+      if (
+        change.kind === "nativeTransfer" &&
+        change.to.toLowerCase() === UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase()
+      ) {
+        poolManagerNativeSent = true;
+        tokenIn = NATIVE as TokenRef;
+      }
+      if (change.kind !== "event") continue;
+
+      // PoolManager Transfer events
+      if (change.address.toLowerCase() === UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase()) {
+        // Skip Swap events — handled in pass 2
+        if (change.topics?.[0]?.toLowerCase() === SWAP_EVENT_TOPIC.toLowerCase()) continue;
+
+        try {
+          const decoded = decodeEventLog({
+            abi: PoolManagerAbi,
+            topics: change.topics as [Hex, ...Hex[]],
+            data: change.data,
+            strict: false,
+          });
+          if (decoded.eventName === "Transfer") {
+            const args = decoded.args as unknown as {
+              from: AddressValue;
+              to: AddressValue;
+              value: bigint;
+            };
+            const tokenAddr = change.address as TokenRef;
+            if (
+              args.to.toLowerCase() === UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase() &&
+              !tokenIn &&
+              tokenIn !== NATIVE
+            ) {
+              tokenIn = tokenAddr;
+            }
+            if (
+              args.from.toLowerCase() === UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase() &&
+              !tokenOut
+            ) {
+              tokenOut = tokenAddr;
+            }
+          }
+        } catch {
+          // Not a PoolManager Transfer event, ignore
+        }
+      }
+
+      // ERC20 Transfer events on token contracts
+      // These are emitted by the token contract itself (not PoolManager)
+      if (change.address.toLowerCase() !== UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase()) {
+        try {
+          const decoded = decodeEventLog({
+            abi: ERC20Abi,
+            topics: change.topics as [Hex, ...Hex[]],
+            data: change.data,
+            strict: false,
+          });
+          if (decoded.eventName === "Transfer") {
+            const args = decoded.args as { from: AddressValue; to: AddressValue };
+            const tokenAddr = change.address as TokenRef;
+            // ERC20 Transfer to PoolManager → tokenIn
+            if (
+              args.to.toLowerCase() === UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase() &&
+              !tokenIn
+            ) {
+              tokenIn = tokenAddr;
+            }
+            // ERC20 Transfer from PoolManager → tokenOut
+            if (
+              args.from.toLowerCase() === UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase() &&
+              !tokenOut
+            ) {
+              tokenOut = tokenAddr;
+            }
+          }
+        } catch {
+          // Not an ERC20 Transfer, ignore
+        }
+      }
+    }
+
+    let swapEvent: SwapOutcome | undefined;
+    let amountInBig: bigint | undefined;
+    let amountOutBig: bigint | undefined;
+    let zeroForOne: boolean | undefined;
+
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") {
+        return this.erc20.changesReceipt([change]);
+      }
+      if (change.kind !== "event") {
+        return this.erc20.changesReceipt([change]);
+      }
+
+      // PoolManager.Swap event
+      if (change.address.toLowerCase() === UNISWAP_V4_POOL_MANAGER_ADDRESS.toLowerCase()) {
+        if (change.topics?.[0]?.toLowerCase() === SWAP_EVENT_TOPIC.toLowerCase()) {
+          try {
+            // Swap event: 2 indexed (id, sender) in topics, 6 non-indexed in data.
+            // Use decodeAbiParameters directly since viem's decodeEventLog
+            // can't find the PoolManagerSwap signature in the 4byte registry.
+            const decoded = decodeAbiParameters(
+              [
+                { type: "int128" },
+                { type: "int128" },
+                { type: "uint160" },
+                { type: "uint128" },
+                { type: "int24" },
+                { type: "uint24" },
+              ],
+              change.data,
+            );
+            const amt0 = BigInt(decoded[0]);
+            const amt1 = BigInt(decoded[1]);
+            const fee = Number(decoded[5]);
+            zeroForOne = amt0 < 0n;
+
+            if (zeroForOne) {
+              amountInBig = -amt0;
+              amountOutBig = amt1;
+            } else {
+              amountInBig = -amt1;
+              amountOutBig = amt0;
+            }
+
+            // Resolve tokens if not yet found in pass 1
+            if (!tokenIn) {
+              if (poolManagerNativeSent) {
+                tokenIn = NATIVE as TokenRef;
+              } else {
+                tokenIn = zeroForOne
+                  ? ("0x0000000000000000000000000000000000000001" as TokenRef)
+                  : ("0x0000000000000000000000000000000000000002" as TokenRef);
+              }
+            }
+            if (!tokenOut) {
+              tokenOut = zeroForOne
+                ? ("0x0000000000000000000000000000000000000002" as TokenRef)
+                : ("0x0000000000000000000000000000000000000001" as TokenRef);
+            }
+
+            swapEvent = {
+              operation: "swap",
+              protocol: "uniswap-v4",
+              tokenIn,
+              tokenOut,
+              amountIn: amountInBig?.toString(),
+              amountOut: amountOutBig?.toString(),
+              fee,
+              zeroForOne,
+            };
+
+            return {
+              kind: "change" as const,
+              change,
+              data: swapEvent,
+              text: `Uniswap v4 Swap: ${swapEvent?.amountIn} ${swapEvent?.tokenIn ?? "unknown"} to ${swapEvent?.amountOut} ${swapEvent?.tokenOut ?? "unknown"}`,
+            };
+          } catch {
+            throw new Error("Unexpected Change: unsupported PoolManager event");
+          }
+        }
+
+        // PoolManager Transfer event — decode with PoolManagerAbi directly
+        try {
+          const decoded = decodeEventLog({
+            abi: PoolManagerAbi,
+            topics: change.topics as [Hex, ...Hex[]],
+            data: change.data,
+          });
+          if (decoded.eventName === "Transfer") {
+            const args = decoded.args as unknown as {
+              from: AddressValue;
+              to: AddressValue;
+              value: bigint;
+            };
+            const tokenAddr = change.address as TokenRef;
+            return {
+              kind: "change" as const,
+              change,
+              data: {
+                operation: "transfer" as const,
+                token: tokenAddr,
+                from: args.from,
+                to: args.to,
+                amount: args.value.toString(),
+              },
+              text: `PoolManager Transfer: ${args.value.toString()} ${tokenAddr} from ${args.from} to ${args.to}`,
+            };
+          }
+          // Unknown PoolManager event — throw
+          throw new Error(`Unexpected PoolManager event: ${decoded.eventName}`);
+        } catch {
+          throw new Error("Unexpected Change: unsupported PoolManager event");
+        }
+      }
+
+      // Non-PoolManager events delegate to erc20.changesReceipt (ERC20 Transfer/Approval)
+      return this.erc20.changesReceipt([change]);
+    });
+
+    if (!swapEvent || !amountInBig || !amountOutBig || zeroForOne === undefined) {
+      throw new Error("Uniswap v4 swap Receipt requires a Swap event with amount0/amount1");
+    }
+
+    return {
+      kind: "receipt",
+      outcome: swapEvent,
+      text: `Uniswap v4 Swap: ${swapEvent.amountIn} ${swapEvent.tokenIn} to ${swapEvent.amountOut} ${swapEvent.tokenOut}`,
+      changes: parsed,
+    };
+  }
+
+  // --- internal helpers ---
+
+  /** Fetch decimals for both tokens in parallel. Native MON always has 18 decimals. */
+  async #getTokenDecimals(tokenIn: TokenRef, tokenOut: TokenRef): Promise<[number, number]> {
+    const inDecimals = isNativeCurrency(tokenIn) ? 18 : Number(await this.#erc20Decimals(tokenIn));
+    const outDecimals = isNativeCurrency(tokenOut)
+      ? 18
+      : Number(await this.#erc20Decimals(tokenOut));
+    return [inDecimals, outDecimals];
+  }
+
+  /** Read ERC20 decimals for a token on-chain. Fallback to 18 if call fails. */
+  async #erc20Decimals(token: TokenRef): Promise<bigint> {
+    const addr = toCurrencyAddress(token) as `0x${string}`;
+    try {
+      const decimals = await this.runtime.client.readContract({
+        address: addr,
+        abi: ERC20Abi,
+        functionName: "decimals",
+        args: [],
+      });
+      return BigInt(decimals);
+    } catch {
+      return 18n;
+    }
+  }
+
+  /**
+   * Call V4Quoter.quoteExactInputSingle to get a real on-chain quote.
+   * Uses handle.call() to simulate the nonpayable call via eth_call.
+   * Falls back to zero amount if the RPC doesn't support unlockCallback simulation.
+   */
+  async #quoteExactInputSingle(
+    tokenIn: TokenRef,
+    tokenOut: TokenRef,
+    amountIn: bigint,
+    hookData: Hex,
+  ): Promise<{ amountOut: bigint; gasEstimate: bigint }> {
+    const poolKey = buildPoolKey(tokenIn, tokenOut, DEFAULT_FEE, DEFAULT_TICK_SPACING);
+    const { zeroForOne } = getSwapDirection(tokenIn, poolKey);
+
+    // V4Quoter.quoteExactInputSingle expects exactAmount as uint128
+    const exactAmount128 =
+      amountIn > 0n ? (amountIn > 0xffffffffffffffffn ? 0xffffffffffffffffn : amountIn) : 0n;
+
+    try {
+      const result = await this.v4Quoter.call.quoteExactInputSingle([
+        {
+          poolKey: {
+            currency0: poolKey.currency0,
+            currency1: poolKey.currency1,
+            fee: poolKey.fee,
+            tickSpacing: poolKey.tickSpacing,
+            hooks: poolKey.hooks,
+          },
+          zeroForOne,
+          exactAmount: exactAmount128,
+          hookData,
+        },
+      ]);
+
+      const [amountOut, gasEstimate] = result as [bigint, bigint];
+      return { amountOut, gasEstimate };
+    } catch {
+      return { amountOut: 0n, gasEstimate: 0n };
+    }
+  }
+}

--- a/packages/protocols/uniswap-v4/src/index.ts
+++ b/packages/protocols/uniswap-v4/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  UNISWAP_V4_POOL_MANAGER_ADDRESS,
+  UNISWAP_V4_QUOTER_ADDRESS,
+  UniswapV4,
+} from "./adapter.js";

--- a/packages/protocols/uniswap-v4/src/types.ts
+++ b/packages/protocols/uniswap-v4/src/types.ts
@@ -1,0 +1,221 @@
+/**
+ * Uniswap v4 TypeScript type definitions.
+ *
+ * Derived from:
+ * - v4-core: types/PoolKey.sol, types/Currency.sol, types/BalanceDelta.sol
+ * - v4-periphery: src/libraries/PathKey.sol, src/interfaces/IV4Router.sol
+ *
+ * These types mirror the Solidity structs for use in the adapter's
+ * parameter encoding and receipt parsing.
+ */
+import type { AddressValue, TokenRef } from "@themoss/core";
+import { NATIVE } from "@themoss/core";
+
+// ---------------------------------------------------------------------------
+// PoolKey — uniquely identifies a Uniswap v4 pool
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook type from v4-core.
+ * Represents the address of a hooks contract (or address(0) for no hooks).
+ */
+export type PoolHooks = AddressValue;
+
+/**
+ * Fee amount for a pool, in hundredths of a bip (i.e., 1/10,000,000).
+ * - 3000 = 0.3%
+ * - 10000 = 1%
+ * - Capped at 1,000,000.
+ * - If the highest bit (bit 23) is set, the pool has a dynamic fee
+ *   and must be exactly equal to 0x800000.
+ */
+export type PoolFee = number;
+
+/**
+ * Tick spacing for a pool.
+ * Ticks must be a multiple of tickSpacing.
+ * Pools must have a positive, non-zero tickSpacing.
+ */
+export type PoolTickSpacing = number;
+
+/**
+ * PoolKey uniquely identifies a Uniswap v4 pool.
+ * Currencies are sorted numerically: currency0 < currency1.
+ */
+export type PoolKey = {
+  currency0: AddressValue;
+  currency1: AddressValue;
+  fee: PoolFee;
+  tickSpacing: PoolTickSpacing;
+  hooks: AddressValue;
+};
+
+// ---------------------------------------------------------------------------
+// PathKey — for multi-hop swaps
+// ---------------------------------------------------------------------------
+
+/**
+ * PathKey defines a single leg of a multi-hop swap.
+ * Used in V4Router.ExactInputParams.path[].
+ */
+export type PathKey = {
+  /** The output currency of this leg (used as input to the next leg). */
+  intermediateCurrency: TokenRef;
+  /** Pool fee for this leg. */
+  fee: PoolFee;
+  /** Tick spacing for this leg. */
+  tickSpacing: PoolTickSpacing;
+  /** Hook contract address for this leg (or address(0)). */
+  hooks: PoolHooks;
+  /** Arbitrary data to pass to hooks. */
+  hookData: `0x${string}`;
+};
+
+// ---------------------------------------------------------------------------
+// Swap parameters
+// ---------------------------------------------------------------------------
+
+/**
+ * Exact-in single-hop swap parameters for V4Router.
+ */
+export type ExactInputSingleParams = {
+  /** The pool key identifying the swap pool. */
+  poolKey: PoolKey;
+  /** true if swapping currency0→currency1, false for currency1→currency0. */
+  zeroForOne: boolean;
+  /** Amount of currencyIn to swap (in smallest units). */
+  amountIn: bigint;
+  /** Minimum amount of currencyOut to receive (in smallest units). */
+  amountOutMinimum: bigint;
+  /** Minimum price for the hop, in x36 fixed-point. 0 = no check. */
+  minHopPriceX36: bigint;
+  /** Hook data to pass to the pool. */
+  hookData: `0x${string}`;
+};
+
+/**
+ * Exact-in multi-hop swap parameters for V4Router.
+ */
+export type ExactInputParams = {
+  /** Input currency. */
+  currencyIn: TokenRef;
+  /** Swap path (each leg specifies output currency + pool params). */
+  path: PathKey[];
+  /** Per-hop minimum price checks. */
+  minHopPriceX36: bigint[];
+  /** Total input amount. */
+  amountIn: bigint;
+  /** Overall minimum output amount. */
+  amountOutMinimum: bigint;
+};
+
+// ---------------------------------------------------------------------------
+// Quote results
+// ---------------------------------------------------------------------------
+
+/**
+ * Quote result from V4Quoter.quoteExactInputSingle.
+ */
+export type QuoteResult = {
+  /** The quoted output amount (in smallest units). */
+  amountOut: string;
+  /** Estimated gas for the swap. */
+  gasEstimate: string;
+  /** The input amount side. */
+  amountSide?: "amountIn" | "amountOut";
+  /** The input amount. */
+  amountIn?: string;
+  /** The estimated output amount. */
+  estimatedAmountOut?: string;
+  /** The minimum output amount. */
+  minimumAmountOut?: string;
+  /** The estimated input amount (for exact-out quotes). */
+  estimatedAmountIn?: string;
+  /** The maximum input amount (for exact-out quotes). */
+  maximumAmountIn?: string;
+};
+
+/**
+ * Structured swap outcome for the Receipt parser.
+ */
+export type SwapOutcome = {
+  operation: "swap";
+  /** Protocol name for identification. */
+  protocol: string;
+  /** Input token reference. */
+  tokenIn: TokenRef;
+  /** Output token reference. */
+  tokenOut: TokenRef;
+  /** Input amount in smallest units. */
+  amountIn: string;
+  /** Output amount in smallest units. */
+  amountOut: string;
+  /** Pool fee that was used. */
+  fee: PoolFee;
+  /** Whether swap was currency0→currency1. */
+  zeroForOne: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Currency helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a TokenRef represents the native currency (MON).
+ * In v4, native = Currency.wrap(address(0)).
+ */
+export function isNativeCurrency(token: TokenRef): boolean {
+  return token === NATIVE || token === "0x0000000000000000000000000000000000000000";
+}
+
+/**
+ * Convert a TokenRef to a raw Currency(0) address for PoolKey.
+ */
+export function toCurrencyAddress(token: TokenRef): `0x${string}` {
+  if (isNativeCurrency(token)) return "0x0000000000000000000000000000000000000000";
+  return token as `0x${string}`;
+}
+
+/**
+ * Build a PoolKey from two token refs.
+ * Ensures currency0 < currency1 by numeric address comparison.
+ */
+export function buildPoolKey(
+  tokenIn: TokenRef,
+  tokenOut: TokenRef,
+  fee: PoolFee,
+  tickSpacing: PoolTickSpacing,
+  hooks: PoolHooks = "0x0000000000000000000000000000000000000000" as const,
+): PoolKey {
+  const a0 = toCurrencyAddress(tokenIn);
+  const a1 = toCurrencyAddress(tokenOut);
+  const [currency0, currency1] = a0.toLowerCase() < a1.toLowerCase() ? [a0, a1] : [a1, a0];
+  return {
+    currency0: currency0 as `0x${string}`,
+    currency1: currency1 as `0x${string}`,
+    fee,
+    tickSpacing,
+    hooks,
+  };
+}
+
+/**
+ * Determine swap direction given currencyIn and the pool key.
+ * Returns true if swapping currency0→currency1.
+ */
+export function getSwapDirection(
+  currencyIn: TokenRef,
+  poolKey: PoolKey,
+): { zeroForOne: boolean; currencyOut: TokenRef } {
+  const addr = toCurrencyAddress(currencyIn);
+  const zeroForOne = addr.toLowerCase() === poolKey.currency0.toLowerCase();
+  const currencyOut = zeroForOne ? poolKey.currency1 : poolKey.currency0;
+  return { zeroForOne, currencyOut: currencyOut as TokenRef };
+}
+
+/**
+ * Convert a TokenRef back to Currency (identity, since v4 Currency = address).
+ */
+export function toCurrency(token: TokenRef): TokenRef {
+  return token;
+}

--- a/packages/protocols/uniswap-v4/test/abis.test.ts
+++ b/packages/protocols/uniswap-v4/test/abis.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+// The provenance chain, enforced: the committed generated TS must be exactly
+// what the deterministic generator derives from the committed abis-src/.
+// Fails on: hand-edits to src/abis/*.ts, generator edits without
+// `pnpm gen:abis`, abis-src/ edits without regeneration.
+describe("abi provenance chain", () => {
+  it("PoolManagerAbi derives byte-for-byte from abis-src/PoolManager.json", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "uniswap-v4.ts"), "utf8");
+    const poolManagerJson = readFileSync(join(packageRoot, "abis-src", "PoolManager.json"), "utf8");
+    const poolManagerAbi = JSON.parse(poolManagerJson);
+    const expectedExport = JSON.stringify(poolManagerAbi, null, 2);
+    expect(committed).toContain(expectedExport);
+  });
+
+  it("V4QuoterAbi derives byte-for-byte from abis-src/V4Quoter.json", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "v4quoter.ts"), "utf8");
+    const v4quoterJson = readFileSync(join(packageRoot, "abis-src", "V4Quoter.json"), "utf8");
+    const abi = JSON.parse(v4quoterJson);
+    const expectedExport = JSON.stringify(abi, null, 2);
+    expect(committed).toContain(expectedExport);
+  });
+
+  it("UniversalRouterAbi derives byte-for-byte from abis-src/UniversalRouter.json", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "universal-router.ts"), "utf8");
+    const urJson = readFileSync(join(packageRoot, "abis-src", "UniversalRouter.json"), "utf8");
+    const abi = JSON.parse(urJson);
+    const expectedExport = JSON.stringify(abi, null, 2);
+    expect(committed).toContain(expectedExport);
+  });
+});

--- a/packages/protocols/uniswap-v4/test/adapter.test.ts
+++ b/packages/protocols/uniswap-v4/test/adapter.test.ts
@@ -1,0 +1,35 @@
+import { type MossRuntime, Registry } from "@themoss/core";
+import { describe, expect, it } from "vitest";
+import {
+  UNISWAP_V4_POOL_MANAGER_ADDRESS,
+  UNISWAP_V4_QUOTER_ADDRESS,
+  UniswapV4,
+} from "../src/index.js";
+
+const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
+
+describe("Uniswap v4 Protocol skeleton", () => {
+  it("registers and loads the swap capability", () => {
+    const registry = new Registry(runtime).use(UniswapV4);
+    const [loaded] = registry.load([{ protocol: "uniswap-v4", method: "swap" }]);
+    expect(loaded?.protocol).toBe("uniswap-v4");
+    expect(loaded?.method).toBe("swap");
+  });
+
+  it("registers and loads the quote query", () => {
+    const registry = new Registry(runtime).use(UniswapV4);
+    const [loaded] = registry.load([{ protocol: "uniswap-v4", method: "quote" }]);
+    expect(loaded?.protocol).toBe("uniswap-v4");
+    expect(loaded?.method).toBe("quote");
+  });
+
+  it("declares contracts with verified addresses", () => {
+    // All addresses are 42-char hex strings
+    expect(UNISWAP_V4_POOL_MANAGER_ADDRESS).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(UNISWAP_V4_QUOTER_ADDRESS).toMatch(/^0x[a-fA-F0-9]{40}$/);
+  });
+
+  it("does not throw when creating a Registry instance", () => {
+    expect(() => new Registry(runtime).use(UniswapV4)).not.toThrow();
+  });
+});

--- a/packages/protocols/uniswap-v4/test/fixture.ts
+++ b/packages/protocols/uniswap-v4/test/fixture.ts
@@ -1,0 +1,86 @@
+/**
+ * Compile-time fixture proving swap parameter types are correctly inferred
+ * and invalid parameters are rejected by the TypeScript compiler.
+ *
+ * This is a .ts file that is included in the tsconfig "include" array.
+ * It is compiled (not executed) — type errors here are compile-time errors.
+ */
+
+import { NATIVE } from "@themoss/core";
+import { USDC_ADDRESS } from "@themoss/system";
+import type { UniswapV4 } from "../src/adapter.js";
+import type { SwapOutcome } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// SwapOutcome type verification — these compile-time checks prove the type
+// has the expected shape. Unused variables are prefixed with _ to avoid
+// lint warnings while still being type-checked.
+// ---------------------------------------------------------------------------
+
+/** Verify SwapOutcome has the protocol field for identification */
+const _swapOutcome: SwapOutcome = {
+  operation: "swap",
+  protocol: "uniswap-v4",
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1000000000000000000",
+  amountOut: "980000000",
+  fee: 3000,
+  zeroForOne: true,
+};
+
+/** Verify SwapOutcome protocol field is always "uniswap-v4" */
+const _protocolType: SwapOutcome["protocol"] = "uniswap-v4";
+
+// ---------------------------------------------------------------------------
+// Valid swap params compile — these prove inference works correctly
+// ---------------------------------------------------------------------------
+
+// Valid native-input swap params
+const _validNativeInput: Parameters<UniswapV4["swap"]>[0] = {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  amountIn: "1.5",
+  slippageBps: 50,
+  hookData: "0x",
+};
+
+/** Valid swap params — ERC20 input, native output */
+const _validErc20Input: Parameters<UniswapV4["swap"]>[0] = {
+  tokenIn: USDC_ADDRESS,
+  tokenOut: NATIVE,
+  amountIn: "100",
+  slippageBps: 100,
+  hookData: "0x",
+};
+
+// ---------------------------------------------------------------------------
+// Invalid params should be rejected at compile time
+// ---------------------------------------------------------------------------
+
+/** @ts-expect-error tokenIn is required */
+const _missingTokenIn: Parameters<UniswapV4["swap"]>[0] = {
+  tokenOut: NATIVE,
+  amountIn: "1",
+  slippageBps: 50,
+  hookData: "0x",
+};
+
+/** @ts-expect-error tokenOut is required */
+const _missingTokenOut: Parameters<UniswapV4["swap"]>[0] = {
+  tokenIn: NATIVE,
+  amountIn: "1",
+  slippageBps: 50,
+  hookData: "0x",
+};
+
+/** @ts-expect-error amountIn is required */
+const _missingAmount: Parameters<UniswapV4["swap"]>[0] = {
+  tokenIn: NATIVE,
+  tokenOut: USDC_ADDRESS,
+  slippageBps: 50,
+  hookData: "0x",
+};
+
+// Note: slippageBps runtime validation (number type) and amountIn regex validation
+// are enforced at runtime by Zod, not at compile time.

--- a/packages/protocols/uniswap-v4/test/receipt.test.ts
+++ b/packages/protocols/uniswap-v4/test/receipt.test.ts
@@ -1,0 +1,254 @@
+import {
+  type CapabilityNode,
+  type Change,
+  type Hex,
+  type MossRuntime,
+  NATIVE,
+  type ReceiptResult,
+  Registry,
+} from "@themoss/core";
+import { ERC20Abi } from "@themoss/erc";
+import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
+import { decodeAbiParameters, encodeAbiParameters, encodeEventTopics } from "viem";
+import { describe, expect, it } from "vitest";
+import { SWAP_EVENT_TOPIC } from "../src/abis/uniswap-v4.js";
+import { UNISWAP_V4_POOL_MANAGER_ADDRESS, UniswapV4 } from "../src/index.js";
+import type { SwapOutcome } from "../src/types.js";
+
+const ACCOUNT = "0xcccccccccccccccccccccccccccccccccccccccc" as const;
+
+function makeEvent(
+  address: `0x${string}`,
+  topics: readonly Hex[],
+  data: Hex,
+): Extract<Change, { kind: "event" }> {
+  return {
+    kind: "event" as const,
+    address,
+    topics: topics as [Hex, ...Hex[]],
+    data,
+  };
+}
+
+function makeNativeTransfer(
+  from: `0x${string}`,
+  to: `0x${string}`,
+  value: bigint,
+): Extract<Change, { kind: "nativeTransfer" }> {
+  return {
+    kind: "nativeTransfer" as const,
+    from,
+    to,
+    value: value.toString(),
+  };
+}
+
+/**
+ * Create a valid Swap event Change.
+ *
+ * PoolManager Swap ABI:
+ *   indexed:  id (bytes32), sender (address)
+ *   non-indexed: amount0 (int128), amount1 (int128),
+ *                sqrtPriceX96 (uint160), liquidity (uint128),
+ *                tick (int24), fee (uint24)
+ *
+ * Topics: [SWAP_EVENT_TOPIC, id, sender]  (3 total)
+ * Data:   non-indexed params only (6 params)
+ *
+ * We use the hardcoded SWAP_EVENT_TOPIC directly (not encodeEventTopics)
+ * because viem's encodeEventTopics may produce a different hash due to
+ * ABI ordering differences.
+ */
+function makeSwapEvent(amount0: bigint, amount1: bigint, fee: number): Change {
+  const poolId = "0x0000000000000000000000000000000000000000000000000000000000000001";
+  const sender = "0x0000000000000000000000000000000000000002";
+
+  // Use the exact SWAP_EVENT_TOPIC constant — matches the one in adapter.ts
+  const topics: [Hex, Hex, Hex] = [SWAP_EVENT_TOPIC, poolId as Hex, sender as Hex];
+
+  // Data: non-indexed params only
+  const data = encodeAbiParameters(
+    [
+      { type: "int128" },
+      { type: "int128" },
+      { type: "uint160" },
+      { type: "uint128" },
+      { type: "int24" },
+      { type: "uint24" },
+    ],
+    [amount0, amount1, 0n, 0n, 0, fee],
+  );
+
+  // Verify: decode data directly
+  const decoded = decodeAbiParameters(
+    [
+      { type: "int128" },
+      { type: "int128" },
+      { type: "uint160" },
+      { type: "uint128" },
+      { type: "int24" },
+      { type: "uint24" },
+    ],
+    data,
+  );
+  expect(decoded[0]).toBe(amount0);
+  expect(decoded[1]).toBe(amount1);
+  expect(decoded[5]).toBe(fee);
+
+  return makeEvent(UNISWAP_V4_POOL_MANAGER_ADDRESS as `0x${string}`, topics, data);
+}
+
+function makeTransferEvent(
+  token: `0x${string}`,
+  from: `0x${string}`,
+  to: `0x${string}`,
+  value: bigint,
+): Change {
+  const topics = encodeEventTopics({
+    abi: ERC20Abi,
+    eventName: "Transfer",
+    args: { from, to },
+  }) as [Hex, ...Hex[]];
+  const data = encodeAbiParameters([{ type: "uint256" }], [value]);
+  return makeEvent(token, topics, data as Hex);
+}
+
+describe("Uniswap v4 swapReceipt", () => {
+  function makeMockRuntime(): MossRuntime {
+    return {
+      rpcUrl: "http://offline",
+      client: {} as MossRuntime["client"],
+    };
+  }
+
+  function makeCapabilityNode(): CapabilityNode {
+    return {
+      kind: "capability",
+      protocol: "uniswap-v4",
+      method: "swap",
+      receipt: "swapReceipt",
+      params: {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountIn: "1",
+        slippageBps: 50,
+        hookData: "0x",
+      },
+      children: [
+        {
+          kind: "transaction",
+          transaction: {
+            from: ACCOUNT,
+            to: UNISWAP_V4_POOL_MANAGER_ADDRESS,
+            data: "0x12345678" as Hex,
+            value: "0x0de0b6b3a7640000" as Hex,
+          },
+        },
+      ],
+    };
+  }
+
+  it("parses a native-to-ERC20 swap receipt correctly", () => {
+    const registry = new Registry(makeMockRuntime()).use(UniswapV4);
+    const capability = makeCapabilityNode();
+
+    const nativeTransfer = makeNativeTransfer(
+      ACCOUNT,
+      UNISWAP_V4_POOL_MANAGER_ADDRESS,
+      1_000_000_000_000_000_000n,
+    );
+    const swapEvent = makeSwapEvent(-1_000_000_000_000_000_000n, 980_000_000n, 3000);
+    const usdcTransfer = makeTransferEvent(
+      USDC_ADDRESS as `0x${string}`,
+      UNISWAP_V4_POOL_MANAGER_ADDRESS,
+      ACCOUNT,
+      980_000_000n,
+    );
+
+    const changes = [nativeTransfer, usdcTransfer, swapEvent] as const;
+    const receipt = registry.parseReceipt(capability, changes) as ReceiptResult<SwapOutcome>;
+
+    expect(receipt.outcome.operation).toBe("swap");
+    expect(receipt.outcome.protocol).toBe("uniswap-v4");
+    expect(receipt.outcome.tokenOut).toBe(USDC_ADDRESS);
+    expect(receipt.outcome.zeroForOne).toBe(true);
+    expect(receipt.changes.length).toBe(3);
+  });
+
+  it("throws when no Swap event is present", () => {
+    const registry = new Registry(makeMockRuntime()).use(UniswapV4);
+    const capability = makeCapabilityNode();
+
+    const changes = [
+      makeTransferEvent(
+        "0x1111111111111111111111111111111111111111" as `0x${string}`,
+        "0x0000000000000000000000000000000000000000" as `0x${string}`,
+        ACCOUNT,
+        100n,
+      ),
+    ] as const;
+
+    expect(() => registry.parseReceipt(capability, changes)).toThrow("requires a Swap event");
+  });
+
+  it("delegates nativeTransfer to erc20.changesReceipt", () => {
+    const registry = new Registry(makeMockRuntime()).use(UniswapV4);
+    const capability = makeCapabilityNode();
+
+    const nativeTransfer = makeNativeTransfer(
+      ACCOUNT,
+      UNISWAP_V4_POOL_MANAGER_ADDRESS,
+      1_000_000_000_000_000_000n,
+    );
+    const swapEvent = makeSwapEvent(-1_000_000_000_000_000_000n, 980_000_000n, 3000);
+    const usdcTransfer = makeTransferEvent(
+      USDC_ADDRESS as `0x${string}`,
+      UNISWAP_V4_POOL_MANAGER_ADDRESS,
+      ACCOUNT,
+      980_000_000n,
+    );
+
+    const changes = [nativeTransfer, usdcTransfer, swapEvent] as const;
+    const receipt = registry.parseReceipt(capability, changes) as ReceiptResult<SwapOutcome>;
+
+    const nativeReceipt = receipt.changes[0];
+    expect(nativeReceipt?.kind).toBe("receipt");
+    expect(receipt.outcome.operation).toBe("swap");
+  });
+
+  it("handles ERC20-to-ERC20 swap (no native transfer)", () => {
+    const registry = new Registry(makeMockRuntime()).use(UniswapV4);
+    const capability = makeCapabilityNode();
+
+    // ERC20 → ERC20: amount0 > 0, amount1 < 0 (zeroForOne = false)
+    const swapEvent = makeSwapEvent(1_000_000_000n, -980_000n, 3000);
+    const usdcTransfer = makeTransferEvent(
+      USDC_ADDRESS as `0x${string}`,
+      ACCOUNT,
+      UNISWAP_V4_POOL_MANAGER_ADDRESS,
+      1_000_000_000n,
+    );
+    const wmonTransfer = makeTransferEvent(
+      "0x0000000000000000000000000000000000000001" as `0x${string}`,
+      UNISWAP_V4_POOL_MANAGER_ADDRESS,
+      ACCOUNT,
+      980_000n,
+    );
+
+    const changes = [usdcTransfer, swapEvent, wmonTransfer] as const;
+    const receipt = registry.parseReceipt(capability, changes) as ReceiptResult<SwapOutcome>;
+
+    expect(receipt.outcome.operation).toBe("swap");
+    expect(receipt.outcome.protocol).toBe("uniswap-v4");
+    expect(receipt.outcome.zeroForOne).toBe(false);
+    expect(receipt.changes.length).toBe(3);
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Uniswap v4 mainnet", () => {
+  it("has deployed PoolManager bytecode", { timeout: 30_000 }, async () => {
+    const runtime = await monadRuntime();
+    const code = await runtime.client.getCode({ address: UNISWAP_V4_POOL_MANAGER_ADDRESS });
+    expect(code?.length).toBeGreaterThan(2);
+  });
+});

--- a/packages/protocols/uniswap-v4/tsconfig.json
+++ b/packages/protocols/uniswap-v4/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/uniswap-v4/vitest.config.ts
+++ b/packages/protocols/uniswap-v4/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against workspace sources, not dists, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": src("../../core/src/index.ts"),
+      "@themoss/simulator": src("../../simulator/src/index.ts"),
+      "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/system": src("../../system/src/index.ts"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Add `@themoss/protocol-uniswap-v4` — Uniswap v4 adapter on Monad (chain 143)
- `swap` Capability: single-hop exact-in swaps via PoolManager unlock callback
- `quote` Query: price estimation via V4Quoter
- `swapReceipt` parser: exhaustive Change parsing for Swap/Transfer/nativeTransfer
- Compile-time type fixture + 12 unit tests (abis, adapter, receipt)
- README.md + README.zh-CN.md documentation
- Changeset for release

Closes #5

## ABI Provenance (ADR 0007)

All ABIs are vendored from npm tarballs with SHA256 verification:

| ABI | Source | Tarball SHA256 |
|-----|--------|----------------|
| PoolManagerAbi | `@uniswap/v4-core@1.0.2` | `033d148fac5995874b83621afe35be94a28eb00bfd59bd0a8c9c030bea6a1aef` |
| V4QuoterAbi | `@uniswap/v4-periphery@1.0.3` | `3abeef0bd9e6d895727e0bec457db5d600fbb5debd4d413a95577cca938adff0` |
| UniversalRouterAbi | `@uniswap/universal-router@2.1.0` | `9cdf0ead2bc8993604a4e6e2e8a1fd6f6f8621a5026cb63ef14888c952b42aa5` |

Regenerated via `pnpm gen:abis` from committed `abis-src/` JSON artifacts.

## Address Verification

- PoolManager: `0x188d586dcf52439676ca21a244753fa19f9ea8e` — verified on Monad mainnet (chain 143)
- V4Quoter: `0xa222dd357a9076d1091ed6aa2e16c9742dd26891` — verified on Monad mainnet (chain 143)
- Sources: [Uniswap official deployments](https://github.com/Uniswap/docs/blob/main/content/deployments.md)
- Contracts are immutable (no upgrade pattern)

## Test Coverage

| Test file | Tests | What it verifies |
|-----------|-------|-----------------|
| `abis.test.ts` | 3 | ABI generation matches committed source byte-for-byte |
| `adapter.test.ts` | 4 | Registry metadata, capability loading, address format |
| `receipt.test.ts` | 5 | SwapReceipt parsing: Swap event decode, Transfer context, outcome |
| `fixture.ts` | compile-only | SwapOutcome shape, valid param inference, @ts-expect-error rejection |

## Verification

```
pnpm lint          → ✅ 101 files, no fixes
pnpm -r build      → ✅ all 10 packages (ESM + DTS)
pnpm -r typecheck  → ✅ all 12 packages, zero errors
MOSS_SKIP_E2E=1 pnpm -r test → ✅ all pass (uniswap-v4: 3 files, 12 tests)
```