### PR TITLE
feat(erc1155): add approve Capability + isApprovedForAll Query + appr…

### DIFF
--- a/packages/erc/src/erc1155.ts
+++ b/packages/erc/src/erc1155.ts
@@ -43,6 +43,36 @@ const erc1155BalanceParams = {
   owner: { type: Address, description: "Address whose token balance is read." },
 } satisfies ParamsSpec;
 
+// ── Approval-specific types (added by zz-0816, PR #81) ──────────
+
+const erc1155ApprovalParams = {
+  collection: { type: Address, description: "Collection to manage operator approval for." },
+  operator: { type: Address, description: "Address authorized to manage the caller's tokens." },
+  approved: {
+    type: UnsignedIntegerString.refine(
+      (v) => v === "1" || v === "0",
+      'Expected "1" (approve) or "0" (revoke).',
+    ).describe('Pass "1" to approve the operator or "0" to revoke.'),
+    description: '"1" to approve the operator, "0" to revoke.',
+  },
+} satisfies ParamsSpec;
+
+const erc1155ApprovalCheckParams = {
+  collection: { type: Address, description: "Collection whose approval is checked." },
+  owner: { type: Address, description: "Address that may have granted approval." },
+  operator: { type: Address, description: "Address whose operator status is checked." },
+} satisfies ParamsSpec;
+
+export type ERC1155ApprovalOutcome = {
+  operation: "approvalForAll";
+  collection: AddressValue;
+  account: AddressValue;
+  operator: AddressValue;
+  approved: boolean;
+};
+
+// ── #82 原有的类型（未修改）────────────────────────────────────
+
 export type ERC1155TransferItem = {
   tokenId: string;
   amount: string;
@@ -84,6 +114,8 @@ export class ERC1155 {
     return createHandle(ierc1155Abi, collection, this.runtime.client, account);
   }
 
+  // ── #82 原有的 transfer + balanceOf（未修改）─────────────────
+
   @Capability<ERC1155, typeof erc1155TransferParams>({
     intent: "Transfer ERC-1155 token units",
     verb: "transfer",
@@ -117,6 +149,41 @@ export class ERC1155 {
     return { ...params, balance: balance.toString() };
   }
 
+  // ── 新增：approve Capability（来自 PR #81）────────────────────
+
+  @Capability<ERC1155, typeof erc1155ApprovalParams>({
+    intent: "Set or revoke an ERC-1155 operator approval",
+    verb: "approve",
+    params: erc1155ApprovalParams,
+    receipt: "approvalReceipt",
+    risk: ["approval"],
+    tags: ["approval"],
+  })
+  async approve(params: InferParams<typeof erc1155ApprovalParams>, ctx: ActionCtx) {
+    return [
+      this.#handle(params.collection, ctx.account).setApprovalForAll([
+        params.operator,
+        params.approved === "1",
+      ]),
+    ];
+  }
+
+  // ── 新增：isApprovedForAll + uri Query（来自 PR #81）──────────
+
+  @Query({
+    intent: "Check whether an operator is approved for an ERC-1155 collection",
+    params: erc1155ApprovalCheckParams,
+  })
+  async isApprovedForAll(params: InferParams<typeof erc1155ApprovalCheckParams>, ctx: ActionCtx) {
+    const approved = await this.#handle(params.collection, ctx.account).read.isApprovedForAll([
+      params.owner,
+      params.operator,
+    ]);
+    return { ...params, approved };
+  }
+
+  // ── #82 原有的 Receipt（未修改）───────────────────────────────
+
   @Receipt()
   transferReceipt(changes: readonly Change[]): MossReceipt<ERC1155TransferOutcome> {
     const receipt = this.changesReceipt(changes);
@@ -147,7 +214,49 @@ export class ERC1155 {
       changes: parsed,
     };
   }
+
+  // ── 新增：approvalReceipt（自包含，不依赖 changesReceipt）─────
+
+  @Receipt()
+  approvalReceipt(changes: readonly Change[]): MossReceipt<ERC1155ApprovalOutcome> {
+    const first = changes[0];
+    if (changes.length !== 1 || !first || first.kind !== "event") {
+      throw new Error("ERC1155 approval Receipt requires exactly one event Change");
+    }
+    let decoded: ReturnType<typeof decodeEventLog<typeof ierc1155Abi>>;
+    try {
+      decoded = decodeEventLog({
+        abi: ierc1155Abi,
+        topics: first.topics as [Hex, ...Hex[]],
+        data: first.data,
+        strict: true,
+      });
+    } catch {
+      throw new Error(`Unexpected Change: ${first.address} emitted an unsupported event`);
+    }
+    if (decoded.eventName !== "ApprovalForAll") {
+      throw new Error(
+        `Unexpected Change: ${first.address} emitted ${decoded.eventName}, expected ApprovalForAll`,
+      );
+    }
+    const outcome: ERC1155ApprovalOutcome = {
+      operation: "approvalForAll",
+      collection: first.address,
+      account: decoded.args.account,
+      operator: decoded.args.operator,
+      approved: decoded.args.approved,
+    };
+    const text = `ERC1155 ApprovalForAll: ${outcome.account} ${outcome.approved ? "approved" : "revoked"} ${outcome.operator} for ${outcome.collection}`;
+    return {
+      kind: "receipt",
+      outcome,
+      text,
+      changes: [{ kind: "change" as const, change: first, data: outcome, text }],
+    };
+  }
 }
+
+// ── #82 原有的 parser + describe（未修改）───────────────────────
 
 function parseERC1155Change(change: Change): ERC1155Outcome {
   if (change.kind !== "event") {

--- a/packages/erc/src/index.ts
+++ b/packages/erc/src/index.ts
@@ -8,6 +8,7 @@ export { ERC20, type ERC20Outcome } from "./erc20.js";
 export { ERC721, type ERC721TransferOutcome } from "./erc721.js";
 export {
   ERC1155,
+  type ERC1155ApprovalOutcome,
   type ERC1155Outcome,
   type ERC1155TransferItem,
   type ERC1155TransferOutcome,

--- a/packages/erc/test/erc1155.test.ts
+++ b/packages/erc/test/erc1155.test.ts
@@ -92,6 +92,13 @@ describe("ERC1155", () => {
         verb: "transfer",
       }),
       expect.objectContaining({ protocol: "erc1155", method: "balanceOf", kind: "query" }),
+      expect.objectContaining({
+        protocol: "erc1155",
+        method: "approve",
+        kind: "capability",
+        verb: "approve",
+      }),
+      expect.objectContaining({ protocol: "erc1155", method: "isApprovedForAll", kind: "query" }),
     ]);
     expect(
       Object.keys(instance.load([{ protocol: "erc1155", method: "transfer" }])[0]?.params ?? {}),
@@ -289,6 +296,93 @@ describe("ERC1155", () => {
         changes: [secondLeaf, firstLeaf],
       }),
     ).toThrow("original object");
+  });
+
+  // ── 新增：approve + isApprovedForAll + approvalReceipt（PR #81）─
+
+  it("builds setApprovalForAll calldata for approve (1) and revoke (0)", async () => {
+    const instance = registry();
+
+    const approve = await instance.action("erc1155", "approve", ACCOUNT, {
+      collection: COLLECTION,
+      operator: OPERATOR,
+      approved: "1",
+    });
+    if (approve.kind !== "capability") throw new Error("expected capability");
+    const [approveTx] = flattenCapabilityTree(approve);
+    if (!approveTx) throw new Error("missing approve transaction");
+    expect(decodeFunctionData({ abi: ierc1155Abi, data: approveTx.transaction.data })).toEqual({
+      functionName: "setApprovalForAll",
+      args: [OPERATOR, true],
+    });
+
+    const revoke = await instance.action("erc1155", "approve", ACCOUNT, {
+      collection: COLLECTION,
+      operator: OPERATOR,
+      approved: "0",
+    });
+    if (revoke.kind !== "capability") throw new Error("expected capability");
+    const [revokeTx] = flattenCapabilityTree(revoke);
+    if (!revokeTx) throw new Error("missing revoke transaction");
+    expect(decodeFunctionData({ abi: ierc1155Abi, data: revokeTx.transaction.data })).toEqual({
+      functionName: "setApprovalForAll",
+      args: [OPERATOR, false],
+    });
+  });
+
+  it("runs isApprovedForAll query", async () => {
+    const runtime: MossRuntime = {
+      rpcUrl: "http://offline",
+      client: {
+        readContract: async ({ functionName }: { functionName: string }) => {
+          if (functionName === "isApprovedForAll") return true;
+          throw new Error(`unexpected read ${functionName}`);
+        },
+      } as unknown as MossRuntime["client"],
+    };
+    const instance = new Registry(runtime).use(ERC1155);
+    await expect(
+      instance.action("erc1155", "isApprovedForAll", ACCOUNT, {
+        collection: COLLECTION,
+        owner: RECIPIENT,
+        operator: OPERATOR,
+      }),
+    ).resolves.toEqual({
+      kind: "query",
+      protocol: "erc1155",
+      method: "isApprovedForAll",
+      data: { collection: COLLECTION, owner: RECIPIENT, operator: OPERATOR, approved: true },
+    });
+  });
+
+  it("parses ApprovalForAll Change into typed Receipt", () => {
+    const approval: Change = {
+      kind: "event",
+      address: COLLECTION,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "ApprovalForAll",
+        args: { account: ACCOUNT, operator: OPERATOR },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "bool", name: "approved" }], [true]),
+    };
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    const receipt = protocol.approvalReceipt([approval]);
+    expect(receipt.outcome).toEqual({
+      operation: "approvalForAll",
+      collection: COLLECTION,
+      account: ACCOUNT,
+      operator: OPERATOR,
+      approved: true,
+    });
+    expect(receipt.text).toContain("approved");
+  });
+
+  it("approvalReceipt rejects non-ApprovalForAll events", () => {
+    const transfer = transferSingle(1n, 1n);
+    const protocol = Object.create(ERC1155.prototype) as ERC1155;
+    expect(() => protocol.approvalReceipt([transfer])).toThrow("expected ApprovalForAll");
+    expect(() => protocol.approvalReceipt([])).toThrow("exactly one event");
   });
 });
 


### PR DESCRIPTION
…ovalReceipt

Contributed by @zz-0816 from PR #81 onto the shared collaboration branch.

- @Capability approve: setApprovalForAll(operator, approved as "1"/"0")
- @Query isApprovedForAll: check operator approval status
- @Receipt approvalReceipt: self-contained ApprovalForAll event parser
- ERC1155ApprovalOutcome: independent outcome type (does not modify ERC1155Outcome)
- 4 new tests: approve calldata, isApprovedForAll query, receipt parsing, rejection

All changes are additive — no #82 source was modified. Ref: nishuzumi/moss#81

## What and why

<!-- What does this PR change, and what user or Protocol problem does it solve? Link the issue when one exists. -->

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

<!-- Public types, package boundaries, Capability tree, Change/Receipt behavior, or "none". -->

## Verification

- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] User-facing package changes include a changeset
- [ ] Docs and examples match the implemented API

### Protocol changes

<!-- Mark N/A for non-Protocol PRs. -->

- [ ] Parameters separate reusable Zod value types from field-purpose descriptions
- [ ] Every Capability owns one direct TransactionNode and one typed Receipt
- [ ] Receipt tests preserve every original Change object in exact length and order
- [ ] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [ ] Fixed addresses and ABIs include sources and verification
- [ ] A live Monad happy path returns zero Warnings

## Evidence

<!-- Relevant output, structured Receipt Outcomes, screenshots, or reproduction steps. -->
