### PR TITLE
feat(protocols): add Morpho Vaults V2 adapter

### DIFF
--- a/.changeset/morpho-vaults-v2-adapter.md
+++ b/.changeset/morpho-vaults-v2-adapter.md
@@ -1,0 +1,6 @@
+---
+"@themoss/protocol-morpho": minor
+"@themoss/mcp-server": patch
+---
+
+Add the Morpho Vaults V2 Protocol adapter for Monad: `vaults` discovery through the official Morpho GraphQL API with mandatory on-chain factory attestation and asset cross-checks (ADR 0012), on-chain `position` and `previewDeposit` Queries, `deposit` (nested ERC-20 approve + one direct transaction) and `withdraw` Capabilities pinned to the acting account, and exhaustive ordered Receipts that decode `Deposit` / `Withdraw` / `AccrueInterest` and delegate ERC-20 Changes. Registers the Protocol in the MCP composition root.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | ERC-20 and native MON | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `allowance`, `metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| Morpho Vaults V2 | `@themoss/protocol-morpho` | `deposit`, `withdraw` | `vaults`, `position`, `previewDeposit` |
 
 ## Quickstart
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | ERC-20 与 native MON | `@themoss/erc` | `transfer`、`approve` | `balanceOf`、`allowance`、`metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| Morpho Vaults V2 | `@themoss/protocol-morpho` | `deposit`、`withdraw` | `vaults`、`position`、`previewDeposit` |
 
 ## 快速开始
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,6 +25,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
+    "@themoss/protocol-morpho": "workspace:*",
     "zod": "^3.25.0",
     "@themoss/erc": "workspace:*",
     "@themoss/system": "workspace:*",

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -2,6 +2,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as erc from "@themoss/erc";
 import * as kuru from "@themoss/protocol-kuru";
+import * as morpho from "@themoss/protocol-morpho";
 import * as system from "@themoss/system";
 import { monadRuntime } from "@themoss/system";
 import { createMossServer } from "./server.js";
@@ -10,7 +11,7 @@ const rpcUrl = process.env.MOSS_RPC_URL;
 const runtime = await monadRuntime({ ...(rpcUrl ? { rpcUrl } : {}) });
 const { server, registry } = createMossServer({
   runtime,
-  protocols: [system, erc, kuru],
+  protocols: [system, erc, kuru, morpho],
 });
 const catalog = registry.discover();
 console.error(

--- a/packages/protocols/morpho/README.md
+++ b/packages/protocols/morpho/README.md
@@ -1,0 +1,69 @@
+# @themoss/protocol-morpho
+
+Moss protocol adapter for [Morpho Vaults V2](https://docs.morpho.org/) on Monad
+mainnet: deposit into and withdraw from curated ERC-4626 yield vaults.
+
+## What it does
+
+- `vaults` (Query) — lists curated (`listed: true`) Morpho V2 vaults on Monad
+  via the official keyless GraphQL API (`https://api.morpho.org/graphql`).
+  API rows are **candidates only** (ADR 0012): every vault must pass the fixed
+  factory's on-chain `isVaultV2` attestation, and its underlying asset address,
+  symbol, decimals, and `totalAssets` are read from chain state. `name`,
+  `symbol`, `netApy`, `netApyExcludingRewards`, and `totalAssetsUsd` are
+  advisory API display data and never become transaction inputs.
+- `position` (Query) — on-chain only: `balanceOf` + `convertToAssets`.
+- `previewDeposit` (Query) — on-chain `previewDeposit` for a display-unit
+  amount.
+- `deposit` (Capability, verb `supply`) — ERC-20 `approve` nested Capability +
+  one direct `deposit(assets, onBehalf)` transaction. `onBehalf` is pinned to
+  the acting account.
+- `withdraw` (Capability, verb `withdraw`) — one direct
+  `withdraw(assets, receiver, onBehalf)` transaction with both `receiver` and
+  `onBehalf` pinned to the acting account; no approval is needed.
+
+Receipts decode the vault's `Deposit` / `Withdraw` events, keep
+`AccrueInterest` as an informational leaf, and delegate every ERC-20 `Transfer`
+/ `Approval` Change to the injected `erc20` Protocol so ordered coverage stays
+exhaustive (ADR 0011).
+
+## Fixed address provenance
+
+`MORPHO_VAULT_V2_FACTORY_ADDRESS = 0x8B2F922162FBb60A6a072cC784A2E4168fB0bb0c`
+comes from the vendored `@morpho-org/morpho-ts` SDK
+(`addresses[143].vaultV2Factory`; version and tarball sha256 in
+`abis-src/VENDOR.json`) and is cross-checked against `api.morpho.org`, which
+reports the same `factory.address` for every listed Monad vault. The live test
+verifies deployed bytecode; every vault interaction re-verifies `isVaultV2`
+on-chain. Vault addresses themselves are dynamic chain state and never become
+constants.
+
+## ABI provenance
+
+`src/abis/morpho.ts` is generated (ADR 0007, vendored origin) from the
+committed verbatim upstream module `abis-src/abis.js.txt`
+(`@morpho-org/morpho-ts` `lib/esm/abis.js`). Regenerate offline with
+`pnpm gen:abis`; re-vendor from npm (dist-tags.latest with a 7-day release-age
+guard) with `pnpm update:abis`. `test/abis.test.ts` enforces byte-for-byte
+derivation.
+
+## Units
+
+- `amount` parameters are display units of the vault's underlying asset
+  (e.g. `"1.5"` USDC); decimals are read from the asset contract on-chain.
+- Query outputs return base-unit strings (`shares`, `assets`, `totalAssets`)
+  plus display-formatted fields where meaningful. Share amounts stay in base
+  units; VaultV2 share decimals mirror the underlying asset's decimals plus a
+  virtual-share offset — consult the vault contract before displaying them.
+
+## Limitations
+
+- Exact-assets withdraw only (`withdraw`); a max-style `redeem` Capability is
+  future work.
+- VaultV2's `maxDeposit` / `maxMint` / `maxWithdraw` / `maxRedeem` always
+  return 0 by design and are never used.
+- Vaults with a configured `liquidityAdapter` may route deposits/withdrawals
+  through allocation adapters and emit `Allocate` / `Deallocate` plus adapter
+  events. The v1 Receipts fail loudly on such Changes (simulation surfaces a
+  Warning instead of unverifiable evidence). The discovery Query surfaces each
+  vault's `liquidityAdapter` so callers can prefer idle-liquidity vaults.

--- a/packages/protocols/morpho/abis-src/VENDOR.json
+++ b/packages/protocols/morpho/abis-src/VENDOR.json
@@ -1,0 +1,7 @@
+{
+  "name": "@morpho-org/morpho-ts",
+  "version": "2.8.0",
+  "tarballSha256": "be0bb0e608b73d44983f20735503f9352ef52d289b11b40ef8a0479cab6eb1b1",
+  "vendoredAt": "2026-07-18",
+  "releaseAgeGuardDays": 7
+}

--- a/packages/protocols/morpho/abis-src/abis.js.txt
+++ b/packages/protocols/morpho/abis-src/abis.js.txt
@@ -1,0 +1,10481 @@
+/** ERC-2612 permit ABI fragment used for nonce reads and permit calldata. */
+export const erc2612Abi = [
+    {
+        inputs: [],
+        name: "DOMAIN_SEPARATOR",
+        outputs: [
+            {
+                internalType: "bytes32",
+                name: "",
+                type: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+        ],
+        name: "nonces",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "deadline",
+                type: "uint256",
+            },
+            {
+                internalType: "uint8",
+                name: "v",
+                type: "uint8",
+            },
+            {
+                internalType: "bytes32",
+                name: "r",
+                type: "bytes32",
+            },
+            {
+                internalType: "bytes32",
+                name: "s",
+                type: "bytes32",
+            },
+        ],
+        name: "permit",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+];
+/** Uniswap Permit2 ABI used for allowance reads and Permit2 signature helpers. */
+export const permit2Abi = [
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "deadline",
+                type: "uint256",
+            },
+        ],
+        name: "AllowanceExpired",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "ExcessiveInvalidation",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "InsufficientAllowance",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "maxAmount",
+                type: "uint256",
+            },
+        ],
+        name: "InvalidAmount",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "InvalidContractSignature",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "InvalidNonce",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "InvalidSignature",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "InvalidSignatureLength",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "InvalidSigner",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "LengthMismatch",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "signatureDeadline",
+                type: "uint256",
+            },
+        ],
+        name: "SignatureExpired",
+        type: "error",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint160",
+                name: "amount",
+                type: "uint160",
+            },
+            {
+                indexed: false,
+                internalType: "uint48",
+                name: "expiration",
+                type: "uint48",
+            },
+        ],
+        name: "Approval",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+        ],
+        name: "Lockdown",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint48",
+                name: "newNonce",
+                type: "uint48",
+            },
+            {
+                indexed: false,
+                internalType: "uint48",
+                name: "oldNonce",
+                type: "uint48",
+            },
+        ],
+        name: "NonceInvalidation",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint160",
+                name: "amount",
+                type: "uint160",
+            },
+            {
+                indexed: false,
+                internalType: "uint48",
+                name: "expiration",
+                type: "uint48",
+            },
+            {
+                indexed: false,
+                internalType: "uint48",
+                name: "nonce",
+                type: "uint48",
+            },
+        ],
+        name: "Permit",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "word",
+                type: "uint256",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "mask",
+                type: "uint256",
+            },
+        ],
+        name: "UnorderedNonceInvalidation",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "DOMAIN_SEPARATOR",
+        outputs: [
+            {
+                internalType: "bytes32",
+                name: "",
+                type: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        name: "allowance",
+        outputs: [
+            {
+                internalType: "uint160",
+                name: "amount",
+                type: "uint160",
+            },
+            {
+                internalType: "uint48",
+                name: "expiration",
+                type: "uint48",
+            },
+            {
+                internalType: "uint48",
+                name: "nonce",
+                type: "uint48",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint160",
+                name: "amount",
+                type: "uint160",
+            },
+            {
+                internalType: "uint48",
+                name: "expiration",
+                type: "uint48",
+            },
+        ],
+        name: "approve",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint48",
+                name: "newNonce",
+                type: "uint48",
+            },
+        ],
+        name: "invalidateNonces",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "wordPos",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "mask",
+                type: "uint256",
+            },
+        ],
+        name: "invalidateUnorderedNonces",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: "address",
+                        name: "token",
+                        type: "address",
+                    },
+                    {
+                        internalType: "address",
+                        name: "spender",
+                        type: "address",
+                    },
+                ],
+                internalType: "struct IAllowanceTransfer.TokenSpenderPair[]",
+                name: "approvals",
+                type: "tuple[]",
+            },
+        ],
+        name: "lockdown",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        name: "nonceBitmap",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: "address",
+                                name: "token",
+                                type: "address",
+                            },
+                            {
+                                internalType: "uint160",
+                                name: "amount",
+                                type: "uint160",
+                            },
+                            {
+                                internalType: "uint48",
+                                name: "expiration",
+                                type: "uint48",
+                            },
+                            {
+                                internalType: "uint48",
+                                name: "nonce",
+                                type: "uint48",
+                            },
+                        ],
+                        internalType: "struct IAllowanceTransfer.PermitDetails",
+                        name: "details",
+                        type: "tuple",
+                    },
+                    {
+                        internalType: "address",
+                        name: "spender",
+                        type: "address",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "sigDeadline",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct IAllowanceTransfer.PermitSingle",
+                name: "permitSingle",
+                type: "tuple",
+            },
+            {
+                internalType: "bytes",
+                name: "signature",
+                type: "bytes",
+            },
+        ],
+        name: "permit",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: "address",
+                                name: "token",
+                                type: "address",
+                            },
+                            {
+                                internalType: "uint256",
+                                name: "amount",
+                                type: "uint256",
+                            },
+                        ],
+                        internalType: "struct ISignatureTransfer.TokenPermissions",
+                        name: "permitted",
+                        type: "tuple",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "nonce",
+                        type: "uint256",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "deadline",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.PermitTransferFrom",
+                name: "permit",
+                type: "tuple",
+            },
+            {
+                components: [
+                    {
+                        internalType: "address",
+                        name: "to",
+                        type: "address",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "requestedAmount",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.SignatureTransferDetails",
+                name: "transferDetails",
+                type: "tuple",
+            },
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "bytes",
+                name: "signature",
+                type: "bytes",
+            },
+        ],
+        name: "permitTransferFrom",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: "address",
+                                name: "token",
+                                type: "address",
+                            },
+                            {
+                                internalType: "uint256",
+                                name: "amount",
+                                type: "uint256",
+                            },
+                        ],
+                        internalType: "struct ISignatureTransfer.TokenPermissions[]",
+                        name: "permitted",
+                        type: "tuple[]",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "nonce",
+                        type: "uint256",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "deadline",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.PermitBatchTransferFrom",
+                name: "permit",
+                type: "tuple",
+            },
+            {
+                components: [
+                    {
+                        internalType: "address",
+                        name: "to",
+                        type: "address",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "requestedAmount",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.SignatureTransferDetails[]",
+                name: "transferDetails",
+                type: "tuple[]",
+            },
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "bytes",
+                name: "signature",
+                type: "bytes",
+            },
+        ],
+        name: "permitTransferFrom",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: "address",
+                                name: "token",
+                                type: "address",
+                            },
+                            {
+                                internalType: "uint256",
+                                name: "amount",
+                                type: "uint256",
+                            },
+                        ],
+                        internalType: "struct ISignatureTransfer.TokenPermissions",
+                        name: "permitted",
+                        type: "tuple",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "nonce",
+                        type: "uint256",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "deadline",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.PermitTransferFrom",
+                name: "permit",
+                type: "tuple",
+            },
+            {
+                components: [
+                    {
+                        internalType: "address",
+                        name: "to",
+                        type: "address",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "requestedAmount",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.SignatureTransferDetails",
+                name: "transferDetails",
+                type: "tuple",
+            },
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "bytes32",
+                name: "witness",
+                type: "bytes32",
+            },
+            {
+                internalType: "string",
+                name: "witnessTypeString",
+                type: "string",
+            },
+            {
+                internalType: "bytes",
+                name: "signature",
+                type: "bytes",
+            },
+        ],
+        name: "permitWitnessTransferFrom",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: "address",
+                                name: "token",
+                                type: "address",
+                            },
+                            {
+                                internalType: "uint256",
+                                name: "amount",
+                                type: "uint256",
+                            },
+                        ],
+                        internalType: "struct ISignatureTransfer.TokenPermissions[]",
+                        name: "permitted",
+                        type: "tuple[]",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "nonce",
+                        type: "uint256",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "deadline",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.PermitBatchTransferFrom",
+                name: "permit",
+                type: "tuple",
+            },
+            {
+                components: [
+                    {
+                        internalType: "address",
+                        name: "to",
+                        type: "address",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "requestedAmount",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct ISignatureTransfer.SignatureTransferDetails[]",
+                name: "transferDetails",
+                type: "tuple[]",
+            },
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "bytes32",
+                name: "witness",
+                type: "bytes32",
+            },
+            {
+                internalType: "string",
+                name: "witnessTypeString",
+                type: "string",
+            },
+            {
+                internalType: "bytes",
+                name: "signature",
+                type: "bytes",
+            },
+        ],
+        name: "permitWitnessTransferFrom",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: "address",
+                        name: "from",
+                        type: "address",
+                    },
+                    {
+                        internalType: "address",
+                        name: "to",
+                        type: "address",
+                    },
+                    {
+                        internalType: "uint160",
+                        name: "amount",
+                        type: "uint160",
+                    },
+                    {
+                        internalType: "address",
+                        name: "token",
+                        type: "address",
+                    },
+                ],
+                internalType: "struct IAllowanceTransfer.AllowanceTransferDetails[]",
+                name: "transferDetails",
+                type: "tuple[]",
+            },
+        ],
+        name: "transferFrom",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                internalType: "uint160",
+                name: "amount",
+                type: "uint160",
+            },
+            {
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+        ],
+        name: "transferFrom",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+];
+/** wstETH ABI fragment used to read the stETH exchange rate. */
+export const wstEthAbi = [
+    {
+        inputs: [
+            {
+                internalType: "contract IStETH",
+                name: "_stETH",
+                type: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Approval",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Transfer",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "DOMAIN_SEPARATOR",
+        outputs: [
+            {
+                internalType: "bytes32",
+                name: "",
+                type: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+        ],
+        name: "allowance",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "approve",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "balanceOf",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "decimals",
+        outputs: [
+            {
+                internalType: "uint8",
+                name: "",
+                type: "uint8",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "subtractedValue",
+                type: "uint256",
+            },
+        ],
+        name: "decreaseAllowance",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "_wstETHAmount",
+                type: "uint256",
+            },
+        ],
+        name: "getStETHByWstETH",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "_stETHAmount",
+                type: "uint256",
+            },
+        ],
+        name: "getWstETHByStETH",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "addedValue",
+                type: "uint256",
+            },
+        ],
+        name: "increaseAllowance",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "name",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+        ],
+        name: "nonces",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "deadline",
+                type: "uint256",
+            },
+            {
+                internalType: "uint8",
+                name: "v",
+                type: "uint8",
+            },
+            {
+                internalType: "bytes32",
+                name: "r",
+                type: "bytes32",
+            },
+            {
+                internalType: "bytes32",
+                name: "s",
+                type: "bytes32",
+            },
+        ],
+        name: "permit",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "stETH",
+        outputs: [
+            {
+                internalType: "contract IStETH",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "stEthPerToken",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "symbol",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "tokensPerStEth",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "totalSupply",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "recipient",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "transfer",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "recipient",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "transferFrom",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "_wstETHAmount",
+                type: "uint256",
+            },
+        ],
+        name: "unwrap",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "_stETHAmount",
+                type: "uint256",
+            },
+        ],
+        name: "wrap",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        stateMutability: "payable",
+        type: "receive",
+    },
+];
+/** MetaMorpho factory ABI used to verify vault factory membership. */
+export const metaMorphoFactoryAbi = [
+    {
+        inputs: [{ internalType: "address", name: "morpho", type: "address" }],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    { inputs: [], name: "ZeroAddress", type: "error" },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "metaMorpho",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "caller",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "address",
+                name: "initialOwner",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "initialTimelock",
+                type: "uint256",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "asset",
+                type: "address",
+            },
+            { indexed: false, internalType: "string", name: "name", type: "string" },
+            {
+                indexed: false,
+                internalType: "string",
+                name: "symbol",
+                type: "string",
+            },
+            {
+                indexed: false,
+                internalType: "bytes32",
+                name: "salt",
+                type: "bytes32",
+            },
+        ],
+        name: "CreateMetaMorpho",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "MORPHO",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            { internalType: "address", name: "initialOwner", type: "address" },
+            { internalType: "uint256", name: "initialTimelock", type: "uint256" },
+            { internalType: "address", name: "asset", type: "address" },
+            { internalType: "string", name: "name", type: "string" },
+            { internalType: "string", name: "symbol", type: "string" },
+            { internalType: "bytes32", name: "salt", type: "bytes32" },
+        ],
+        name: "createMetaMorpho",
+        outputs: [
+            {
+                internalType: "contract IMetaMorphoV1_1",
+                name: "metaMorpho",
+                type: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "address", name: "", type: "address" }],
+        name: "isMetaMorpho",
+        outputs: [{ internalType: "bool", name: "", type: "bool" }],
+        stateMutability: "view",
+        type: "function",
+    },
+];
+/** MetaMorpho vault ABI used for vault reads and MetaMorpho action encoding. */
+export const metaMorphoAbi = [
+    {
+        type: "constructor",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "morpho",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "initialTimelock",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "_asset",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_name",
+                type: "string",
+                internalType: "string",
+            },
+            {
+                name: "_symbol",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "DECIMALS_OFFSET",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint8",
+                internalType: "uint8",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "DOMAIN_SEPARATOR",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "MORPHO",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "contract IMorpho",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "acceptCap",
+        inputs: [
+            {
+                name: "marketParams",
+                type: "tuple",
+                internalType: "struct MarketParams",
+                components: [
+                    {
+                        name: "loanToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "collateralToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "oracle",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "irm",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "lltv",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "acceptGuardian",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "acceptOwnership",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "acceptTimelock",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "allowance",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "approve",
+        inputs: [
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "value",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "asset",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "balanceOf",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "config",
+        inputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+        outputs: [
+            {
+                name: "cap",
+                type: "uint184",
+                internalType: "uint184",
+            },
+            {
+                name: "enabled",
+                type: "bool",
+                internalType: "bool",
+            },
+            {
+                name: "removableAt",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "convertToAssets",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "convertToShares",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "curator",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "decimals",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint8",
+                internalType: "uint8",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "deposit",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "eip712Domain",
+        inputs: [],
+        outputs: [
+            {
+                name: "fields",
+                type: "bytes1",
+                internalType: "bytes1",
+            },
+            {
+                name: "name",
+                type: "string",
+                internalType: "string",
+            },
+            {
+                name: "version",
+                type: "string",
+                internalType: "string",
+            },
+            {
+                name: "chainId",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "verifyingContract",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "salt",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "extensions",
+                type: "uint256[]",
+                internalType: "uint256[]",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "fee",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint96",
+                internalType: "uint96",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "feeRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "guardian",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "isAllocator",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "lastTotalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "lostAssets", // Only defined for MetaMorpho V1.1 vaults.
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxDeposit",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxMint",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxRedeem",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxWithdraw",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "mint",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "multicall",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes[]",
+                internalType: "bytes[]",
+            },
+        ],
+        outputs: [
+            {
+                name: "results",
+                type: "bytes[]",
+                internalType: "bytes[]",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "name",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "nonces",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "owner",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "pendingCap",
+        inputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+        outputs: [
+            {
+                name: "value",
+                type: "uint192",
+                internalType: "uint192",
+            },
+            {
+                name: "validAt",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "pendingGuardian",
+        inputs: [],
+        outputs: [
+            {
+                name: "value",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "validAt",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "pendingOwner",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "pendingTimelock",
+        inputs: [],
+        outputs: [
+            {
+                name: "value",
+                type: "uint192",
+                internalType: "uint192",
+            },
+            {
+                name: "validAt",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "permit",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "value",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "deadline",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "v",
+                type: "uint8",
+                internalType: "uint8",
+            },
+            {
+                name: "r",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "s",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "previewDeposit",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewMint",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewRedeem",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewWithdraw",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "reallocate",
+        inputs: [
+            {
+                name: "allocations",
+                type: "tuple[]",
+                internalType: "struct MarketAllocation[]",
+                components: [
+                    {
+                        name: "marketParams",
+                        type: "tuple",
+                        internalType: "struct MarketParams",
+                        components: [
+                            {
+                                name: "loanToken",
+                                type: "address",
+                                internalType: "address",
+                            },
+                            {
+                                name: "collateralToken",
+                                type: "address",
+                                internalType: "address",
+                            },
+                            {
+                                name: "oracle",
+                                type: "address",
+                                internalType: "address",
+                            },
+                            {
+                                name: "irm",
+                                type: "address",
+                                internalType: "address",
+                            },
+                            {
+                                name: "lltv",
+                                type: "uint256",
+                                internalType: "uint256",
+                            },
+                        ],
+                    },
+                    {
+                        name: "assets",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "redeem",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "renounceOwnership",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "revokePendingCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "revokePendingGuardian",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "revokePendingMarketRemoval",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "revokePendingTimelock",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setCurator",
+        inputs: [
+            {
+                name: "newCurator",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setFee",
+        inputs: [
+            {
+                name: "newFee",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setFeeRecipient",
+        inputs: [
+            {
+                name: "newFeeRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setIsAllocator",
+        inputs: [
+            {
+                name: "newAllocator",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newIsAllocator",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSkimRecipient",
+        inputs: [
+            {
+                name: "newSkimRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSupplyQueue",
+        inputs: [
+            {
+                name: "newSupplyQueue",
+                type: "bytes32[]",
+                internalType: "Id[]",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "skim",
+        inputs: [
+            {
+                name: "token",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "skimRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "submitCap",
+        inputs: [
+            {
+                name: "marketParams",
+                type: "tuple",
+                internalType: "struct MarketParams",
+                components: [
+                    {
+                        name: "loanToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "collateralToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "oracle",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "irm",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "lltv",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                ],
+            },
+            {
+                name: "newSupplyCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "submitGuardian",
+        inputs: [
+            {
+                name: "newGuardian",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "submitMarketRemoval",
+        inputs: [
+            {
+                name: "marketParams",
+                type: "tuple",
+                internalType: "struct MarketParams",
+                components: [
+                    {
+                        name: "loanToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "collateralToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "oracle",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "irm",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "lltv",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                ],
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "submitTimelock",
+        inputs: [
+            {
+                name: "newTimelock",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "supplyQueue",
+        inputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "supplyQueueLength",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "symbol",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "timelock",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "totalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "totalSupply",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "transfer",
+        inputs: [
+            {
+                name: "to",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "value",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "transferFrom",
+        inputs: [
+            {
+                name: "from",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "to",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "value",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "transferOwnership",
+        inputs: [
+            {
+                name: "newOwner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "updateWithdrawQueue",
+        inputs: [
+            {
+                name: "indexes",
+                type: "uint256[]",
+                internalType: "uint256[]",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "withdraw",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "withdrawQueue",
+        inputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "withdrawQueueLength",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "event",
+        name: "AccrueInterest",
+        inputs: [
+            {
+                name: "newTotalAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "feeShares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Approval",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "value",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Deposit",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "EIP712DomainChanged",
+        inputs: [],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "OwnershipTransferStarted",
+        inputs: [
+            {
+                name: "previousOwner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newOwner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "OwnershipTransferred",
+        inputs: [
+            {
+                name: "previousOwner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newOwner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "ReallocateSupply",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "Id",
+            },
+            {
+                name: "suppliedAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "suppliedShares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "ReallocateWithdraw",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "Id",
+            },
+            {
+                name: "withdrawnAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "withdrawnShares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "RevokePendingCap",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "Id",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "RevokePendingGuardian",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "RevokePendingMarketRemoval",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "Id",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "RevokePendingTimelock",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetCap",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "Id",
+            },
+            {
+                name: "cap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetCurator",
+        inputs: [
+            {
+                name: "newCurator",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetFee",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newFee",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetFeeRecipient",
+        inputs: [
+            {
+                name: "newFeeRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetGuardian",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "guardian",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetIsAllocator",
+        inputs: [
+            {
+                name: "allocator",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "isAllocator",
+                type: "bool",
+                indexed: false,
+                internalType: "bool",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetName",
+        inputs: [
+            {
+                name: "name",
+                type: "string",
+                indexed: false,
+                internalType: "string",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSymbol",
+        inputs: [
+            {
+                name: "symbol",
+                type: "string",
+                indexed: false,
+                internalType: "string",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSkimRecipient",
+        inputs: [
+            {
+                name: "newSkimRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSupplyQueue",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newSupplyQueue",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "Id[]",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetTimelock",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newTimelock",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetWithdrawQueue",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newWithdrawQueue",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "Id[]",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Skim",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "token",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "amount",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SubmitCap",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "Id",
+            },
+            {
+                name: "cap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SubmitGuardian",
+        inputs: [
+            {
+                name: "newGuardian",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SubmitMarketRemoval",
+        inputs: [
+            {
+                name: "caller",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "Id",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SubmitTimelock",
+        inputs: [
+            {
+                name: "newTimelock",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Transfer",
+        inputs: [
+            {
+                name: "from",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "to",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "value",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "UpdateLastTotalAssets",
+        inputs: [
+            {
+                name: "updatedTotalAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Withdraw",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "error",
+        name: "AboveMaxTimelock",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AddressEmptyCode",
+        inputs: [
+            {
+                name: "target",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "AddressInsufficientBalance",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "AllCapsReached",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AlreadyPending",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AlreadySet",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "BelowMinTimelock",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "DuplicateMarket",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ECDSAInvalidSignature",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ECDSAInvalidSignatureLength",
+        inputs: [
+            {
+                name: "length",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ECDSAInvalidSignatureS",
+        inputs: [
+            {
+                name: "s",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC20InsufficientAllowance",
+        inputs: [
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "allowance",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "needed",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC20InsufficientBalance",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "balance",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "needed",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC20InvalidApprover",
+        inputs: [
+            {
+                name: "approver",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC20InvalidReceiver",
+        inputs: [
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC20InvalidSender",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC20InvalidSpender",
+        inputs: [
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC2612ExpiredSignature",
+        inputs: [
+            {
+                name: "deadline",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC2612InvalidSigner",
+        inputs: [
+            {
+                name: "signer",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC4626ExceededMaxDeposit",
+        inputs: [
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "max",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC4626ExceededMaxMint",
+        inputs: [
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "max",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC4626ExceededMaxRedeem",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "max",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ERC4626ExceededMaxWithdraw",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "max",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "FailedInnerCall",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "InconsistentAsset",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "InconsistentReallocation",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "InvalidAccountNonce",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "currentNonce",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "InvalidMarketRemovalNonZeroCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "InvalidMarketRemovalNonZeroSupply",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "InvalidMarketRemovalTimelockNotElapsed",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "InvalidShortString",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "MarketNotCreated",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "MarketNotEnabled",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "MathOverflowedMulDiv",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "MaxFeeExceeded",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "MaxQueueLengthExceeded",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NoPendingValue",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NonZeroCap",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotAllocatorRole",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotCuratorNorGuardianRole",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotCuratorRole",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotEnoughLiquidity",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotGuardianRole",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "OwnableInvalidOwner",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "OwnableUnauthorizedAccount",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "PendingCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "PendingRemoval",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "SafeCastOverflowedUintDowncast",
+        inputs: [
+            {
+                name: "bits",
+                type: "uint8",
+                internalType: "uint8",
+            },
+            {
+                name: "value",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "SafeERC20FailedOperation",
+        inputs: [
+            {
+                name: "token",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "StringTooLong",
+        inputs: [
+            {
+                name: "str",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "SupplyCapExceeded",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "TimelockNotElapsed",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "UnauthorizedMarket",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "Id",
+            },
+        ],
+    },
+    {
+        type: "error",
+        name: "ZeroAddress",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ZeroFeeRecipient",
+        inputs: [],
+    },
+];
+/** PublicAllocator ABI used to read vault allocator configuration and flow caps. */
+export const publicAllocatorAbi = [
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "morpho",
+                type: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    {
+        inputs: [],
+        name: "AlreadySet",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "DepositMarketInWithdrawals",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "EmptyWithdrawals",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "InconsistentWithdrawals",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "IncorrectFee",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "Id",
+                name: "id",
+                type: "bytes32",
+            },
+        ],
+        name: "MarketNotEnabled",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "Id",
+                name: "id",
+                type: "bytes32",
+            },
+        ],
+        name: "MaxInflowExceeded",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "Id",
+                name: "id",
+                type: "bytes32",
+            },
+        ],
+        name: "MaxOutflowExceeded",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "MaxSettableFlowCapExceeded",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "NotAdminNorVaultOwner",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "Id",
+                name: "id",
+                type: "bytes32",
+            },
+        ],
+        name: "NotEnoughSupply",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "Id",
+                name: "id",
+                type: "bytes32",
+            },
+        ],
+        name: "WithdrawZero",
+        type: "error",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "Id",
+                name: "supplyMarketId",
+                type: "bytes32",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "suppliedAssets",
+                type: "uint256",
+            },
+        ],
+        name: "PublicReallocateTo",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "Id",
+                name: "id",
+                type: "bytes32",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "withdrawnAssets",
+                type: "uint256",
+            },
+        ],
+        name: "PublicWithdrawal",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "address",
+                name: "admin",
+                type: "address",
+            },
+        ],
+        name: "SetAdmin",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "fee",
+                type: "uint256",
+            },
+        ],
+        name: "SetFee",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                components: [
+                    {
+                        internalType: "Id",
+                        name: "id",
+                        type: "bytes32",
+                    },
+                    {
+                        components: [
+                            {
+                                internalType: "uint128",
+                                name: "maxIn",
+                                type: "uint128",
+                            },
+                            {
+                                internalType: "uint128",
+                                name: "maxOut",
+                                type: "uint128",
+                            },
+                        ],
+                        internalType: "struct FlowCaps",
+                        name: "caps",
+                        type: "tuple",
+                    },
+                ],
+                indexed: false,
+                internalType: "struct FlowCapsConfig[]",
+                name: "config",
+                type: "tuple[]",
+            },
+        ],
+        name: "SetFlowCaps",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "feeRecipient",
+                type: "address",
+            },
+        ],
+        name: "TransferFee",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "MORPHO",
+        outputs: [
+            {
+                internalType: "contract IMorpho",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        name: "accruedFee",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        name: "admin",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        name: "fee",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+            {
+                internalType: "Id",
+                name: "",
+                type: "bytes32",
+            },
+        ],
+        name: "flowCaps",
+        outputs: [
+            {
+                internalType: "uint128",
+                name: "maxIn",
+                type: "uint128",
+            },
+            {
+                internalType: "uint128",
+                name: "maxOut",
+                type: "uint128",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                components: [
+                    {
+                        components: [
+                            {
+                                internalType: "address",
+                                name: "loanToken",
+                                type: "address",
+                            },
+                            {
+                                internalType: "address",
+                                name: "collateralToken",
+                                type: "address",
+                            },
+                            {
+                                internalType: "address",
+                                name: "oracle",
+                                type: "address",
+                            },
+                            {
+                                internalType: "address",
+                                name: "irm",
+                                type: "address",
+                            },
+                            {
+                                internalType: "uint256",
+                                name: "lltv",
+                                type: "uint256",
+                            },
+                        ],
+                        internalType: "struct MarketParams",
+                        name: "marketParams",
+                        type: "tuple",
+                    },
+                    {
+                        internalType: "uint128",
+                        name: "amount",
+                        type: "uint128",
+                    },
+                ],
+                internalType: "struct Withdrawal[]",
+                name: "withdrawals",
+                type: "tuple[]",
+            },
+            {
+                components: [
+                    {
+                        internalType: "address",
+                        name: "loanToken",
+                        type: "address",
+                    },
+                    {
+                        internalType: "address",
+                        name: "collateralToken",
+                        type: "address",
+                    },
+                    {
+                        internalType: "address",
+                        name: "oracle",
+                        type: "address",
+                    },
+                    {
+                        internalType: "address",
+                        name: "irm",
+                        type: "address",
+                    },
+                    {
+                        internalType: "uint256",
+                        name: "lltv",
+                        type: "uint256",
+                    },
+                ],
+                internalType: "struct MarketParams",
+                name: "supplyMarketParams",
+                type: "tuple",
+            },
+        ],
+        name: "reallocateTo",
+        outputs: [],
+        stateMutability: "payable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "newAdmin",
+                type: "address",
+            },
+        ],
+        name: "setAdmin",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "newFee",
+                type: "uint256",
+            },
+        ],
+        name: "setFee",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                components: [
+                    {
+                        internalType: "Id",
+                        name: "id",
+                        type: "bytes32",
+                    },
+                    {
+                        components: [
+                            {
+                                internalType: "uint128",
+                                name: "maxIn",
+                                type: "uint128",
+                            },
+                            {
+                                internalType: "uint128",
+                                name: "maxOut",
+                                type: "uint128",
+                            },
+                        ],
+                        internalType: "struct FlowCaps",
+                        name: "caps",
+                        type: "tuple",
+                    },
+                ],
+                internalType: "struct FlowCapsConfig[]",
+                name: "config",
+                type: "tuple[]",
+            },
+        ],
+        name: "setFlowCaps",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "vault",
+                type: "address",
+            },
+            {
+                internalType: "address payable",
+                name: "feeRecipient",
+                type: "address",
+            },
+        ],
+        name: "transferFee",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+];
+/** Wrapped Backed token ABI used to discover permissioning controllers. */
+export const wrappedBackedTokenAbi = [
+    {
+        inputs: [],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+        ],
+        name: "NonWhitelistedFromAddress",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+        ],
+        name: "NonWhitelistedToAddress",
+        type: "error",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Approval",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [],
+        name: "EIP712DomainChanged",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: "uint8",
+                name: "version",
+                type: "uint8",
+            },
+        ],
+        name: "Initialized",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "previousOwner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "newOwner",
+                type: "address",
+            },
+        ],
+        name: "OwnershipTransferred",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "Paused",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Transfer",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "whitelistedBy",
+                type: "address",
+            },
+        ],
+        name: "TransferDestinationAuthorized",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "whitelistedBy",
+                type: "address",
+            },
+        ],
+        name: "TransferOriginatorAuthorized",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "Unpaused",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "DOMAIN_SEPARATOR",
+        outputs: [
+            {
+                internalType: "bytes32",
+                name: "",
+                type: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+        ],
+        name: "allowance",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "approve",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "balanceOf",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "decimals",
+        outputs: [
+            {
+                internalType: "uint8",
+                name: "",
+                type: "uint8",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "subtractedValue",
+                type: "uint256",
+            },
+        ],
+        name: "decreaseAllowance",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "depositFor",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "eip712Domain",
+        outputs: [
+            {
+                internalType: "bytes1",
+                name: "fields",
+                type: "bytes1",
+            },
+            {
+                internalType: "string",
+                name: "name",
+                type: "string",
+            },
+            {
+                internalType: "string",
+                name: "version",
+                type: "string",
+            },
+            {
+                internalType: "uint256",
+                name: "chainId",
+                type: "uint256",
+            },
+            {
+                internalType: "address",
+                name: "verifyingContract",
+                type: "address",
+            },
+            {
+                internalType: "bytes32",
+                name: "salt",
+                type: "bytes32",
+            },
+            {
+                internalType: "uint256[]",
+                name: "extensions",
+                type: "uint256[]",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "addedValue",
+                type: "uint256",
+            },
+        ],
+        name: "increaseAllowance",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "underlyingToken",
+                type: "address",
+            },
+        ],
+        name: "initialize",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "name",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+        ],
+        name: "nonces",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "owner",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "pause",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "paused",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "deadline",
+                type: "uint256",
+            },
+            {
+                internalType: "uint8",
+                name: "v",
+                type: "uint8",
+            },
+            {
+                internalType: "bytes32",
+                name: "r",
+                type: "bytes32",
+            },
+            {
+                internalType: "bytes32",
+                name: "s",
+                type: "bytes32",
+            },
+        ],
+        name: "permit",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "renounceOwnership",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "controllerAggregator",
+                type: "address",
+            },
+        ],
+        name: "setWhitelistController",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "symbol",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "totalSupply",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "transfer",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "transferFrom",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "newOwner",
+                type: "address",
+            },
+        ],
+        name: "transferOwnership",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "underlying",
+        outputs: [
+            {
+                internalType: "contract IERC20Upgradeable",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "unpause",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "whitelistControllerAggregator",
+        outputs: [
+            {
+                internalType: "contract WhitelistControllerAggregator",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "amount",
+                type: "uint256",
+            },
+        ],
+        name: "withdrawTo",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+];
+/** WhitelistControllerAggregatorV2 ABI used to read transfer permission status. */
+export const whitelistControllerAggregatorV2Abi = [
+    {
+        inputs: [],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "controller",
+                type: "address",
+            },
+        ],
+        name: "AddedController",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: "uint8",
+                name: "version",
+                type: "uint8",
+            },
+        ],
+        name: "Initialized",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "previousOwner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "newOwner",
+                type: "address",
+            },
+        ],
+        name: "OwnershipTransferred",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "controller",
+                type: "address",
+            },
+        ],
+        name: "RemovedController",
+        type: "event",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "controller",
+                type: "address",
+            },
+        ],
+        name: "add",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        name: "controllers",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "initialize",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "addressToCheck",
+                type: "address",
+            },
+        ],
+        name: "isWhitelisted",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "owner",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "index",
+                type: "uint256",
+            },
+        ],
+        name: "remove",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "renounceOwnership",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "newOwner",
+                type: "address",
+            },
+        ],
+        name: "transferOwnership",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+];
+/** Permissioned ERC20 wrapper ABI used to read account transfer permission status. */
+export const permissionedErc20WrapperAbi = [
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "target",
+                type: "address",
+            },
+        ],
+        name: "AddressEmptyCode",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "ECDSAInvalidSignature",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "length",
+                type: "uint256",
+            },
+        ],
+        name: "ECDSAInvalidSignatureLength",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "bytes32",
+                name: "s",
+                type: "bytes32",
+            },
+        ],
+        name: "ECDSAInvalidSignatureS",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "allowance",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "needed",
+                type: "uint256",
+            },
+        ],
+        name: "ERC20InsufficientAllowance",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "balance",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "needed",
+                type: "uint256",
+            },
+        ],
+        name: "ERC20InsufficientBalance",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "approver",
+                type: "address",
+            },
+        ],
+        name: "ERC20InvalidApprover",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "receiver",
+                type: "address",
+            },
+        ],
+        name: "ERC20InvalidReceiver",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+        ],
+        name: "ERC20InvalidSender",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+        ],
+        name: "ERC20InvalidSpender",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+        ],
+        name: "ERC20InvalidUnderlying",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "deadline",
+                type: "uint256",
+            },
+        ],
+        name: "ERC2612ExpiredSignature",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "signer",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+        ],
+        name: "ERC2612InvalidSigner",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "FailedCall",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "uint256",
+                name: "balance",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "needed",
+                type: "uint256",
+            },
+        ],
+        name: "InsufficientBalance",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "currentNonce",
+                type: "uint256",
+            },
+        ],
+        name: "InvalidAccountNonce",
+        type: "error",
+    },
+    {
+        inputs: [],
+        name: "InvalidShortString",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "NoPermission",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+        ],
+        name: "SafeERC20FailedOperation",
+        type: "error",
+    },
+    {
+        inputs: [
+            {
+                internalType: "string",
+                name: "str",
+                type: "string",
+            },
+        ],
+        name: "StringTooLong",
+        type: "error",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Approval",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [],
+        name: "EIP712DomainChanged",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "Transfer",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "BUNDLER",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "DOMAIN_SEPARATOR",
+        outputs: [
+            {
+                internalType: "bytes32",
+                name: "",
+                type: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "MORPHO",
+        outputs: [
+            {
+                internalType: "address",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+        ],
+        name: "allowance",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "approve",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "balanceOf",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "decimals",
+        outputs: [
+            {
+                internalType: "uint8",
+                name: "",
+                type: "uint8",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "depositFor",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "eip712Domain",
+        outputs: [
+            {
+                internalType: "bytes1",
+                name: "fields",
+                type: "bytes1",
+            },
+            {
+                internalType: "string",
+                name: "name",
+                type: "string",
+            },
+            {
+                internalType: "string",
+                name: "version",
+                type: "string",
+            },
+            {
+                internalType: "uint256",
+                name: "chainId",
+                type: "uint256",
+            },
+            {
+                internalType: "address",
+                name: "verifyingContract",
+                type: "address",
+            },
+            {
+                internalType: "bytes32",
+                name: "salt",
+                type: "bytes32",
+            },
+            {
+                internalType: "uint256[]",
+                name: "extensions",
+                type: "uint256[]",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+        ],
+        name: "hasPermission",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "attested",
+                type: "bool",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "name",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+        ],
+        name: "nonces",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "owner",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "spender",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+            {
+                internalType: "uint256",
+                name: "deadline",
+                type: "uint256",
+            },
+            {
+                internalType: "uint8",
+                name: "v",
+                type: "uint8",
+            },
+            {
+                internalType: "bytes32",
+                name: "r",
+                type: "bytes32",
+            },
+            {
+                internalType: "bytes32",
+                name: "s",
+                type: "bytes32",
+            },
+        ],
+        name: "permit",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "symbol",
+        outputs: [
+            {
+                internalType: "string",
+                name: "",
+                type: "string",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "totalSupply",
+        outputs: [
+            {
+                internalType: "uint256",
+                name: "",
+                type: "uint256",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "transfer",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "from",
+                type: "address",
+            },
+            {
+                internalType: "address",
+                name: "to",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "transferFrom",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "underlying",
+        outputs: [
+            {
+                internalType: "contract IERC20",
+                name: "",
+                type: "address",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                internalType: "address",
+                name: "account",
+                type: "address",
+            },
+            {
+                internalType: "uint256",
+                name: "value",
+                type: "uint256",
+            },
+        ],
+        name: "withdrawTo",
+        outputs: [
+            {
+                internalType: "bool",
+                name: "",
+                type: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+];
+/** EIP-5267 ABI used to read ERC20 EIP-712 domain metadata. */
+export const erc5267Abi = [
+    {
+        inputs: [],
+        name: "eip712Domain",
+        outputs: [
+            {
+                internalType: "bytes1",
+                name: "fields",
+                type: "bytes1",
+            },
+            {
+                internalType: "string",
+                name: "name",
+                type: "string",
+            },
+            {
+                internalType: "string",
+                name: "version",
+                type: "string",
+            },
+            {
+                internalType: "uint256",
+                name: "chainId",
+                type: "uint256",
+            },
+            {
+                internalType: "address",
+                name: "verifyingContract",
+                type: "address",
+            },
+            {
+                internalType: "bytes32",
+                name: "salt",
+                type: "bytes32",
+            },
+            {
+                internalType: "uint256[]",
+                name: "extensions",
+                type: "uint256[]",
+            },
+        ],
+        stateMutability: "view",
+        type: "function",
+    },
+];
+/** VaultV2 ABI used to read vault accounting, adapter, and allocation state. */
+export const vaultV2Abi = [
+    {
+        type: "constructor",
+        inputs: [
+            {
+                name: "_owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_asset",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "DOMAIN_SEPARATOR",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "_totalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint128",
+                internalType: "uint128",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "abdicate",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "abdicated",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "absoluteCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "accrueInterest",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "accrueInterestView",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "adapterRegistry",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "adapters",
+        inputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "adaptersLength",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "addAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "allocate",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "allocation",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "allowance",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "approve",
+        inputs: [
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "asset",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "balanceOf",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canReceiveAssets",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canReceiveShares",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canSendAssets",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canSendShares",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "convertToAssets",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "convertToShares",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "curator",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "deallocate",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "decimals",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint8",
+                internalType: "uint8",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "decreaseAbsoluteCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "decreaseRelativeCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "decreaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "deposit",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "executableAt",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "firstTotalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "forceDeallocate",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "forceDeallocatePenalty",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "increaseAbsoluteCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "increaseRelativeCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "increaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "isAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "isAllocator",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "isSentinel",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "lastUpdate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "liquidityAdapter",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "liquidityData",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "managementFee",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint96",
+                internalType: "uint96",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "managementFeeRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxDeposit",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "maxMint",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "maxRate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxRedeem",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "maxWithdraw",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "mint",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "multicall",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes[]",
+                internalType: "bytes[]",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "name",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "nonces",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "owner",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "performanceFee",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint96",
+                internalType: "uint96",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "performanceFeeRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "permit",
+        inputs: [
+            {
+                name: "_owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "deadline",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "v",
+                type: "uint8",
+                internalType: "uint8",
+            },
+            {
+                name: "r",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "s",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "previewDeposit",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewMint",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewRedeem",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewWithdraw",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "receiveAssetsGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "receiveSharesGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "redeem",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "relativeCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "removeAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "revoke",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "sendAssetsGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "sendSharesGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "setAdapterRegistry",
+        inputs: [
+            {
+                name: "newAdapterRegistry",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setCurator",
+        inputs: [
+            {
+                name: "newCurator",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setForceDeallocatePenalty",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newForceDeallocatePenalty",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setIsAllocator",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newIsAllocator",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setIsSentinel",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newIsSentinel",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setLiquidityAdapterAndData",
+        inputs: [
+            {
+                name: "newLiquidityAdapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newLiquidityData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setManagementFee",
+        inputs: [
+            {
+                name: "newManagementFee",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setManagementFeeRecipient",
+        inputs: [
+            {
+                name: "newManagementFeeRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setMaxRate",
+        inputs: [
+            {
+                name: "newMaxRate",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setName",
+        inputs: [
+            {
+                name: "newName",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setOwner",
+        inputs: [
+            {
+                name: "newOwner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setPerformanceFee",
+        inputs: [
+            {
+                name: "newPerformanceFee",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setPerformanceFeeRecipient",
+        inputs: [
+            {
+                name: "newPerformanceFeeRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setReceiveAssetsGate",
+        inputs: [
+            {
+                name: "newReceiveAssetsGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setReceiveSharesGate",
+        inputs: [
+            {
+                name: "newReceiveSharesGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSendAssetsGate",
+        inputs: [
+            {
+                name: "newSendAssetsGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSendSharesGate",
+        inputs: [
+            {
+                name: "newSendSharesGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSymbol",
+        inputs: [
+            {
+                name: "newSymbol",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "submit",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "symbol",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "timelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "totalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "totalSupply",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "transfer",
+        inputs: [
+            {
+                name: "to",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "transferFrom",
+        inputs: [
+            {
+                name: "from",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "to",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "virtualShares",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "withdraw",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "event",
+        name: "Abdicate",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Accept",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "AccrueInterest",
+        inputs: [
+            {
+                name: "previousTotalAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "newTotalAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "performanceFeeShares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "managementFeeShares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "AddAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Allocate",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "adapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "ids",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "bytes32[]",
+            },
+            {
+                name: "change",
+                type: "int256",
+                indexed: false,
+                internalType: "int256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "AllowanceUpdatedByTransferFrom",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Approval",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Constructor",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Deallocate",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "adapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "ids",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "bytes32[]",
+            },
+            {
+                name: "change",
+                type: "int256",
+                indexed: false,
+                internalType: "int256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "DecreaseAbsoluteCap",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "DecreaseRelativeCap",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "DecreaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Deposit",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "ForceDeallocate",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "adapter",
+                type: "address",
+                indexed: false,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "ids",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "bytes32[]",
+            },
+            {
+                name: "penaltyAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "IncreaseAbsoluteCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "IncreaseRelativeCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "IncreaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Permit",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "nonce",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "deadline",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "RemoveAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Revoke",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetAdapterRegistry",
+        inputs: [
+            {
+                name: "newAdapterRegistry",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetCurator",
+        inputs: [
+            {
+                name: "newCurator",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetForceDeallocatePenalty",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "forceDeallocatePenalty",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetIsAllocator",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newIsAllocator",
+                type: "bool",
+                indexed: false,
+                internalType: "bool",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetIsSentinel",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newIsSentinel",
+                type: "bool",
+                indexed: false,
+                internalType: "bool",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetLiquidityAdapterAndData",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newLiquidityAdapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newLiquidityData",
+                type: "bytes",
+                indexed: true,
+                internalType: "bytes",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetManagementFee",
+        inputs: [
+            {
+                name: "newManagementFee",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetManagementFeeRecipient",
+        inputs: [
+            {
+                name: "newManagementFeeRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetMaxRate",
+        inputs: [
+            {
+                name: "newMaxRate",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetName",
+        inputs: [
+            {
+                name: "newName",
+                type: "string",
+                indexed: false,
+                internalType: "string",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetOwner",
+        inputs: [
+            {
+                name: "newOwner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetPerformanceFee",
+        inputs: [
+            {
+                name: "newPerformanceFee",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetPerformanceFeeRecipient",
+        inputs: [
+            {
+                name: "newPerformanceFeeRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetReceiveAssetsGate",
+        inputs: [
+            {
+                name: "newReceiveAssetsGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetReceiveSharesGate",
+        inputs: [
+            {
+                name: "newReceiveSharesGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSendAssetsGate",
+        inputs: [
+            {
+                name: "newSendAssetsGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSendSharesGate",
+        inputs: [
+            {
+                name: "newSendSharesGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSymbol",
+        inputs: [
+            {
+                name: "newSymbol",
+                type: "string",
+                indexed: false,
+                internalType: "string",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Submit",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "executableAt",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Transfer",
+        inputs: [
+            {
+                name: "from",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "to",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Withdraw",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "error",
+        name: "Abdicated",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AbsoluteCapExceeded",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AbsoluteCapNotDecreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AbsoluteCapNotIncreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AutomaticallyTimelocked",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotReceiveAssets",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotReceiveShares",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotSendAssets",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotSendShares",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CastOverflow",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "DataAlreadyPending",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "DataNotTimelocked",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "FeeInvariantBroken",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "FeeTooHigh",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "InvalidSigner",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "MaxRateTooHigh",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NoCode",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotAdapter",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotInAdapterRegistry",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "PenaltyTooHigh",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "PermitDeadlineExpired",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapAboveOne",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapExceeded",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapNotDecreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapNotIncreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TimelockNotDecreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TimelockNotExpired",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TimelockNotIncreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferFromReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferFromReverted",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReverted",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "Unauthorized",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ZeroAbsoluteCap",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ZeroAddress",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ZeroAllocation",
+        inputs: [],
+    },
+];
+/** VaultV2 factory ABI used to verify VaultV2 factory membership. */
+export const vaultV2FactoryAbi = [
+    {
+        type: "function",
+        name: "createVaultV2",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "salt",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "isVaultV2",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "vaultV2",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "salt",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "event",
+        name: "CreateVaultV2",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "salt",
+                type: "bytes32",
+                indexed: false,
+                internalType: "bytes32",
+            },
+            {
+                name: "newVaultV2",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+];
+/** MorphoVaultV1Adapter factory ABI used to verify adapter factory membership. */
+export const morphoVaultV1AdapterFactoryAbi = [
+    {
+        type: "function",
+        name: "createMorphoVaultV1Adapter",
+        inputs: [
+            {
+                name: "parentVault",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "morphoVaultV1",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "isMorphoVaultV1Adapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "morphoVaultV1Adapter",
+        inputs: [
+            {
+                name: "parentVault",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "morphoVaultV1",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "event",
+        name: "CreateMorphoVaultV1Adapter",
+        inputs: [
+            {
+                name: "parentVault",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "morphoVaultV1",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "morphoVaultV1Adapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+];
+/** MorphoVaultV1Adapter ABI used to read VaultV2 adapter state. */
+export const morphoVaultV1AdapterAbi = [
+    {
+        type: "constructor",
+        inputs: [
+            {
+                name: "_parentVault",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_morphoVaultV1",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "adapterId",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "allocate",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32[]",
+                internalType: "bytes32[]",
+            },
+            {
+                name: "",
+                type: "int256",
+                internalType: "int256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "allocation",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "deallocate",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32[]",
+                internalType: "bytes32[]",
+            },
+            {
+                name: "",
+                type: "int256",
+                internalType: "int256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "factory",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "ids",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32[]",
+                internalType: "bytes32[]",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "morphoVaultV1",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "parentVault",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "realAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "setSkimRecipient",
+        inputs: [
+            {
+                name: "newSkimRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "skim",
+        inputs: [
+            {
+                name: "token",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "skimRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "event",
+        name: "SetSkimRecipient",
+        inputs: [
+            {
+                name: "newSkimRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Skim",
+        inputs: [
+            {
+                name: "token",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "error",
+        name: "ApproveReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ApproveReverted",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AssetMismatch",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotSkimMorphoVaultV1Shares",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "InvalidData",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NoCode",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotAuthorized",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReverted",
+        inputs: [],
+    },
+];
+/** MorphoMarketV1Adapter ABI used to read VaultV2 market adapter state. */
+export const morphoMarketV1AdapterAbi = [
+    {
+        type: "constructor",
+        inputs: [
+            {
+                name: "_parentVault",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_morpho",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "adapterId",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "allocate",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32[]",
+                internalType: "bytes32[]",
+            },
+            {
+                name: "",
+                type: "int256",
+                internalType: "int256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "allocation",
+        inputs: [
+            {
+                name: "marketParams",
+                type: "tuple",
+                internalType: "struct MarketParams",
+                components: [
+                    {
+                        name: "loanToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "collateralToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "oracle",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "irm",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "lltv",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                ],
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "asset",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "deallocate",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32[]",
+                internalType: "bytes32[]",
+            },
+            {
+                name: "",
+                type: "int256",
+                internalType: "int256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "factory",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "ids",
+        inputs: [
+            {
+                name: "marketParams",
+                type: "tuple",
+                internalType: "struct MarketParams",
+                components: [
+                    {
+                        name: "loanToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "collateralToken",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "oracle",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "irm",
+                        type: "address",
+                        internalType: "address",
+                    },
+                    {
+                        name: "lltv",
+                        type: "uint256",
+                        internalType: "uint256",
+                    },
+                ],
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32[]",
+                internalType: "bytes32[]",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "marketParamsList",
+        inputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "loanToken",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "collateralToken",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "oracle",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "irm",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "lltv",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "marketParamsListLength",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "morpho",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "parentVault",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "realAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "setSkimRecipient",
+        inputs: [
+            {
+                name: "newSkimRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "skim",
+        inputs: [
+            {
+                name: "token",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "skimRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "event",
+        name: "SetSkimRecipient",
+        inputs: [
+            {
+                name: "newSkimRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Skim",
+        inputs: [
+            {
+                name: "token",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "error",
+        name: "ApproveReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ApproveReverted",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "LoanAssetMismatch",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NoCode",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotAuthorized",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReverted",
+        inputs: [],
+    },
+];
+/** MorphoMarketV1Adapter factory ABI used to verify adapter factory membership. */
+export const morphoMarketV1AdapterFactoryAbi = [
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "parentVault",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "morpho",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "morphoMarketV1Adapter",
+                type: "address",
+            },
+        ],
+        name: "CreateMorphoMarketV1Adapter",
+        type: "event",
+    },
+    {
+        inputs: [
+            { internalType: "address", name: "parentVault", type: "address" },
+            { internalType: "address", name: "morpho", type: "address" },
+        ],
+        name: "createMorphoMarketV1Adapter",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "address", name: "account", type: "address" }],
+        name: "isMorphoMarketV1Adapter",
+        outputs: [{ internalType: "bool", name: "", type: "bool" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            { internalType: "address", name: "parentVault", type: "address" },
+            { internalType: "address", name: "morpho", type: "address" },
+        ],
+        name: "morphoMarketV1Adapter",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+];
+/**
+ * Alias for the MorphoVaultV1Adapter factory ABI.
+ *
+ * @deprecated Use `morphoVaultV1AdapterFactoryAbi` instead.
+ */
+export const vaultV1AdapterFactoryAbi = morphoVaultV1AdapterFactoryAbi;
+/**
+ * Alias for the MorphoVaultV1Adapter ABI.
+ *
+ * @deprecated Use `morphoVaultV1AdapterAbi` instead.
+ */
+export const vaultV1AdapterAbi = morphoVaultV1AdapterAbi;
+/** MorphoMarketV1AdapterV2 ABI used to read VaultV2 market adapter state. */
+export const morphoMarketV1AdapterV2Abi = [
+    {
+        inputs: [
+            { internalType: "address", name: "_parentVault", type: "address" },
+            { internalType: "address", name: "_morpho", type: "address" },
+            { internalType: "address", name: "_adaptiveCurveIrm", type: "address" },
+        ],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    { inputs: [], name: "Abdicated", type: "error" },
+    { inputs: [], name: "ApproveReturnedFalse", type: "error" },
+    { inputs: [], name: "ApproveReverted", type: "error" },
+    { inputs: [], name: "AutomaticallyTimelocked", type: "error" },
+    { inputs: [], name: "DataAlreadyPending", type: "error" },
+    { inputs: [], name: "DataNotTimelocked", type: "error" },
+    { inputs: [], name: "IrmMismatch", type: "error" },
+    { inputs: [], name: "LoanAssetMismatch", type: "error" },
+    { inputs: [], name: "NoCode", type: "error" },
+    { inputs: [], name: "SharePriceAboveOne", type: "error" },
+    { inputs: [], name: "TimelockNotDecreasing", type: "error" },
+    { inputs: [], name: "TimelockNotExpired", type: "error" },
+    { inputs: [], name: "TimelockNotIncreasing", type: "error" },
+    { inputs: [], name: "TransferReturnedFalse", type: "error" },
+    { inputs: [], name: "TransferReverted", type: "error" },
+    { inputs: [], name: "Unauthorized", type: "error" },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes4",
+                name: "selector",
+                type: "bytes4",
+            },
+        ],
+        name: "Abdicate",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes4",
+                name: "selector",
+                type: "bytes4",
+            },
+            { indexed: false, internalType: "bytes", name: "data", type: "bytes" },
+        ],
+        name: "Accept",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes32",
+                name: "marketId",
+                type: "bytes32",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "newAllocation",
+                type: "uint256",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "mintedShares",
+                type: "uint256",
+            },
+        ],
+        name: "Allocate",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes32",
+                name: "marketId",
+                type: "bytes32",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "supplyShares",
+                type: "uint256",
+            },
+        ],
+        name: "BurnShares",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes32",
+                name: "marketId",
+                type: "bytes32",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "newAllocation",
+                type: "uint256",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "burnedShares",
+                type: "uint256",
+            },
+        ],
+        name: "Deallocate",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes4",
+                name: "selector",
+                type: "bytes4",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "newDuration",
+                type: "uint256",
+            },
+        ],
+        name: "DecreaseTimelock",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes4",
+                name: "selector",
+                type: "bytes4",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "newDuration",
+                type: "uint256",
+            },
+        ],
+        name: "IncreaseTimelock",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "sender",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "bytes4",
+                name: "selector",
+                type: "bytes4",
+            },
+            { indexed: false, internalType: "bytes", name: "data", type: "bytes" },
+        ],
+        name: "Revoke",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "newSkimRecipient",
+                type: "address",
+            },
+        ],
+        name: "SetSkimRecipient",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "token",
+                type: "address",
+            },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "assets",
+                type: "uint256",
+            },
+        ],
+        name: "Skim",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "bytes4",
+                name: "selector",
+                type: "bytes4",
+            },
+            { indexed: false, internalType: "bytes", name: "data", type: "bytes" },
+            {
+                indexed: false,
+                internalType: "uint256",
+                name: "executableAt",
+                type: "uint256",
+            },
+        ],
+        name: "Submit",
+        type: "event",
+    },
+    {
+        inputs: [{ internalType: "bytes4", name: "selector", type: "bytes4" }],
+        name: "abdicate",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes4", name: "selector", type: "bytes4" }],
+        name: "abdicated",
+        outputs: [{ internalType: "bool", name: "", type: "bool" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "adapterId",
+        outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "adaptiveCurveIrm",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            { internalType: "bytes", name: "data", type: "bytes" },
+            { internalType: "uint256", name: "assets", type: "uint256" },
+            { internalType: "bytes4", name: "", type: "bytes4" },
+            { internalType: "address", name: "", type: "address" },
+        ],
+        name: "allocate",
+        outputs: [
+            { internalType: "bytes32[]", name: "", type: "bytes32[]" },
+            { internalType: "int256", name: "", type: "int256" },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    { internalType: "address", name: "loanToken", type: "address" },
+                    { internalType: "address", name: "collateralToken", type: "address" },
+                    { internalType: "address", name: "oracle", type: "address" },
+                    { internalType: "address", name: "irm", type: "address" },
+                    { internalType: "uint256", name: "lltv", type: "uint256" },
+                ],
+                internalType: "struct MarketParams",
+                name: "marketParams",
+                type: "tuple",
+            },
+        ],
+        name: "allocation",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "asset",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes32", name: "marketId", type: "bytes32" }],
+        name: "burnShares",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            { internalType: "bytes", name: "data", type: "bytes" },
+            { internalType: "uint256", name: "assets", type: "uint256" },
+            { internalType: "bytes4", name: "", type: "bytes4" },
+            { internalType: "address", name: "", type: "address" },
+        ],
+        name: "deallocate",
+        outputs: [
+            { internalType: "bytes32[]", name: "", type: "bytes32[]" },
+            { internalType: "int256", name: "", type: "int256" },
+        ],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            { internalType: "bytes4", name: "selector", type: "bytes4" },
+            { internalType: "uint256", name: "newDuration", type: "uint256" },
+        ],
+        name: "decreaseTimelock",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes", name: "data", type: "bytes" }],
+        name: "executableAt",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes32", name: "marketId", type: "bytes32" }],
+        name: "expectedSupplyAssets",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "factory",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            {
+                components: [
+                    { internalType: "address", name: "loanToken", type: "address" },
+                    { internalType: "address", name: "collateralToken", type: "address" },
+                    { internalType: "address", name: "oracle", type: "address" },
+                    { internalType: "address", name: "irm", type: "address" },
+                    { internalType: "uint256", name: "lltv", type: "uint256" },
+                ],
+                internalType: "struct MarketParams",
+                name: "marketParams",
+                type: "tuple",
+            },
+        ],
+        name: "ids",
+        outputs: [{ internalType: "bytes32[]", name: "", type: "bytes32[]" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [
+            { internalType: "bytes4", name: "selector", type: "bytes4" },
+            { internalType: "uint256", name: "newDuration", type: "uint256" },
+        ],
+        name: "increaseTimelock",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        name: "marketIds",
+        outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "marketIdsLength",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "morpho",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "parentVault",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "realAssets",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes", name: "data", type: "bytes" }],
+        name: "revoke",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [
+            { internalType: "address", name: "newSkimRecipient", type: "address" },
+        ],
+        name: "setSkimRecipient",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "address", name: "token", type: "address" }],
+        name: "skim",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "skimRecipient",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes", name: "data", type: "bytes" }],
+        name: "submit",
+        outputs: [],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes32", name: "marketId", type: "bytes32" }],
+        name: "supplyShares",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "bytes4", name: "selector", type: "bytes4" }],
+        name: "timelock",
+        outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+];
+/** MorphoMarketV1AdapterV2 factory ABI used to verify adapter factory membership. */
+export const morphoMarketV1AdapterV2FactoryAbi = [
+    {
+        inputs: [
+            { internalType: "address", name: "_morpho", type: "address" },
+            { internalType: "address", name: "_adaptiveCurveIrm", type: "address" },
+        ],
+        stateMutability: "nonpayable",
+        type: "constructor",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "parentVault",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "morphoMarketV1AdapterV2",
+                type: "address",
+            },
+        ],
+        name: "CreateMorphoMarketV1AdapterV2",
+        type: "event",
+    },
+    {
+        anonymous: false,
+        inputs: [
+            {
+                indexed: true,
+                internalType: "address",
+                name: "morpho",
+                type: "address",
+            },
+            {
+                indexed: true,
+                internalType: "address",
+                name: "adaptiveCurveIrm",
+                type: "address",
+            },
+        ],
+        name: "CreateMorphoMarketV1AdapterV2Factory",
+        type: "event",
+    },
+    {
+        inputs: [],
+        name: "adaptiveCurveIrm",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "address", name: "parentVault", type: "address" }],
+        name: "createMorphoMarketV1AdapterV2",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "nonpayable",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "address", name: "account", type: "address" }],
+        name: "isMorphoMarketV1AdapterV2",
+        outputs: [{ internalType: "bool", name: "", type: "bool" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [],
+        name: "morpho",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+    {
+        inputs: [{ internalType: "address", name: "parentVault", type: "address" }],
+        name: "morphoMarketV1AdapterV2",
+        outputs: [{ internalType: "address", name: "", type: "address" }],
+        stateMutability: "view",
+        type: "function",
+    },
+];

--- a/packages/protocols/morpho/package.json
+++ b/packages/protocols/morpho/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@themoss/protocol-morpho",
+  "version": "0.1.0",
+  "description": "Moss protocol adapter for Morpho — Vaults V2 yield deposits on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "update:abis": "tsx scripts/update-abis.ts",
+    "gen:abis": "tsx scripts/gen-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/simulator": "workspace:*",
+    "@themoss/system": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/morpho/scripts/abis.ts
+++ b/packages/protocols/morpho/scripts/abis.ts
@@ -1,0 +1,83 @@
+/**
+ * The DETERMINISTIC half of the ABI pipeline: derive src/abis/morpho.ts purely
+ * from the committed abis-src/ files + VENDOR.json metadata. No network, no
+ * clock — same inputs, same bytes. This is what makes the provenance chain
+ * enforceable: test/abis.test.ts asserts generate() === the committed file,
+ * so hand-edits to the generated TS, generator edits without regeneration,
+ * and abis-src edits without regeneration all fail the suite.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface SourceSpec {
+  localFile: string;
+  upstreamPath: string;
+  upstreamName: string;
+  exportName: string;
+}
+
+/** Full upstream ABIs are exported (ADR 0007) — the adapter's callable surface
+ * is reviewed where Capabilities and Receipt parsers live, and simulation is
+ * the enforcement layer. Both constants live in the same upstream module. */
+export const SOURCES: readonly SourceSpec[] = [
+  {
+    localFile: "abis.js.txt",
+    upstreamPath: "lib/esm/abis.js",
+    upstreamName: "vaultV2Abi",
+    exportName: "MorphoVaultV2Abi",
+  },
+  {
+    localFile: "abis.js.txt",
+    upstreamPath: "lib/esm/abis.js",
+    upstreamName: "vaultV2FactoryAbi",
+    exportName: "MorphoVaultV2FactoryAbi",
+  },
+];
+
+export interface VendorInfo {
+  name: string;
+  version: string;
+  tarballSha256: string;
+  vendoredAt: string;
+  releaseAgeGuardDays: number;
+}
+
+/** The upstream module holds many `export const <name>Abi = [...]` literals in
+ * one file, so each extraction is bounded by the next `export const` rather
+ * than the end of the file. */
+function extractAbiLiteral(source: string, spec: SourceSpec): string {
+  const marker = `export const ${spec.upstreamName} = `;
+  const start = source.indexOf(marker);
+  if (start < 0) throw new Error(`${spec.localFile}: missing ${marker.trim()}`);
+  const body = source.slice(start + marker.length);
+  const nextExport = body.indexOf("export const ");
+  const scope = nextExport < 0 ? body : body.slice(0, nextExport);
+  const end = scope.lastIndexOf("];");
+  if (end < 0) throw new Error(`${spec.localFile}: missing ABI array terminator`);
+  return scope.slice(0, end + 1);
+}
+
+export function generate(packageRoot: string): string {
+  const vendor = JSON.parse(
+    readFileSync(join(packageRoot, "abis-src", "VENDOR.json"), "utf8"),
+  ) as VendorInfo;
+
+  let generated = `// GENERATED FILE - do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   ${vendor.name}@${vendor.version} (npm), full upstream ABI constants
+//   tarball:  sha256 ${vendor.tarballSha256}
+//   vendored: ${vendor.vendoredAt} (release-age guard: ${vendor.releaseAgeGuardDays}d)
+//   verification: the fixed factory deployment and exercised functions are
+//   checked live on Monad mainnet; the adapter's e2e tests pin observable behavior.
+`;
+
+  for (const spec of SOURCES) {
+    const source = readFileSync(join(packageRoot, "abis-src", spec.localFile), "utf8");
+    const literal = extractAbiLiteral(source, spec);
+    generated += `\nexport const ${spec.exportName} = ${literal} as const;\n`;
+  }
+
+  return generated;
+}

--- a/packages/protocols/morpho/scripts/gen-abis.ts
+++ b/packages/protocols/morpho/scripts/gen-abis.ts
@@ -1,0 +1,13 @@
+/**
+ * Offline regeneration: derive src/abis/morpho.ts from the COMMITTED abis-src/
+ * files. Use after changing the deterministic generator in ./abis.ts — no network involved.
+ * test/abis.test.ts enforces that the committed output matches this exactly.
+ */
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate } from "./abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+writeFileSync(join(packageRoot, "src/abis/morpho.ts"), generate(packageRoot));
+console.log("regenerated src/abis/morpho.ts from abis-src/ (offline)");

--- a/packages/protocols/morpho/scripts/update-abis.ts
+++ b/packages/protocols/morpho/scripts/update-abis.ts
@@ -1,0 +1,105 @@
+/**
+ * The NETWORK half of the ABI pipeline: re-vendor upstream files into
+ * abis-src/ (verbatim, with provenance metadata in VENDOR.json), then derive
+ * src/abis/morpho.ts via the deterministic generator in ./abis.ts.
+ *
+ * Version policy: follow upstream's **dist-tags.latest** with a release-age
+ * guard — never highest-semver, which is the exact shape of a
+ * version-squatting attack. If latest is younger than the guard window, walk
+ * back BY PUBLISH TIME (same semantics as pnpm's minimumReleaseAge).
+ *
+ * Usage: pnpm update:abis [exact-version]   (the optional pin reproduces a
+ * past state in review; pinned releases must still satisfy the age guard)
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate, SOURCES, type VendorInfo } from "./abis.js";
+
+const SDK_NAME = "@morpho-org/morpho-ts";
+const MIN_RELEASE_AGE_DAYS = 7;
+
+interface RegistryDoc {
+  "dist-tags": Record<string, string>;
+  time: Record<string, string>;
+  versions: Record<string, { dist: { tarball: string } }>;
+}
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const dayMs = 24 * 60 * 60 * 1_000;
+const registryResponse = await fetch(`https://registry.npmjs.org/${SDK_NAME.replace("/", "%2F")}`);
+if (!registryResponse.ok) {
+  throw new Error(`failed to read npm metadata: HTTP ${registryResponse.status}`);
+}
+const registry = (await registryResponse.json()) as RegistryDoc;
+const publishedAt = (version: string) => Date.parse(registry.time[version] ?? "");
+const ageDays = (version: string) => Math.floor((Date.now() - publishedAt(version)) / dayMs);
+const cutoff = Date.now() - MIN_RELEASE_AGE_DAYS * dayMs;
+
+const pinned = process.argv[2];
+let picked: string;
+if (pinned) {
+  if (!registry.versions[pinned]) throw new Error(`${SDK_NAME}@${pinned} does not exist`);
+  if (!Number.isFinite(publishedAt(pinned))) {
+    throw new Error(`${SDK_NAME}@${pinned} has no valid publication timestamp`);
+  }
+  if (publishedAt(pinned) > cutoff) {
+    throw new Error(
+      `${SDK_NAME}@${pinned} is only ${ageDays(pinned)}d old; pinned releases must satisfy the ${MIN_RELEASE_AGE_DAYS}d age guard`,
+    );
+  }
+  picked = pinned;
+  console.log(`pinned to ${picked} by argument (${ageDays(picked)}d old; age guard satisfied)`);
+} else {
+  const latest = registry["dist-tags"].latest;
+  if (!latest) throw new Error(`${SDK_NAME} has no dist-tags.latest`);
+  if (publishedAt(latest) <= cutoff) {
+    picked = latest;
+    console.log(`picked ${SDK_NAME}@${picked} (dist-tags.latest, ${ageDays(picked)}d old)`);
+  } else {
+    const fallback = Object.keys(registry.versions)
+      .filter((version) => /^\d+\.\d+\.\d+$/.test(version))
+      .filter((version) => publishedAt(version) <= cutoff)
+      .sort((left, right) => publishedAt(right) - publishedAt(left))[0];
+    if (!fallback) throw new Error(`no ${SDK_NAME} release is at least 7 days old`);
+    picked = fallback;
+    console.log(
+      `picked ${SDK_NAME}@${picked} (${ageDays(picked)}d old); latest ${latest} is only ${ageDays(latest)}d old`,
+    );
+  }
+}
+
+const tarballUrl = registry.versions[picked]?.dist.tarball;
+if (!tarballUrl) throw new Error(`no tarball URL for ${SDK_NAME}@${picked}`);
+const tarballResponse = await fetch(tarballUrl);
+if (!tarballResponse.ok) throw new Error(`failed to download SDK: HTTP ${tarballResponse.status}`);
+const bytes = Buffer.from(await tarballResponse.arrayBuffer());
+const sha256 = createHash("sha256").update(bytes).digest("hex");
+const work = mkdtempSync(join(tmpdir(), "morpho-abis-"));
+const tarball = join(work, "sdk.tgz");
+writeFileSync(tarball, bytes);
+execFileSync("tar", ["-xzf", tarball, "-C", work]);
+
+mkdirSync(join(packageRoot, "abis-src"), { recursive: true });
+const vendoredFiles = new Map(SOURCES.map((source) => [source.localFile, source.upstreamPath]));
+for (const [localFile, upstreamPath] of vendoredFiles) {
+  const raw = readFileSync(join(work, "package", upstreamPath), "utf8");
+  writeFileSync(join(packageRoot, "abis-src", localFile), raw);
+}
+const vendor: VendorInfo = {
+  name: SDK_NAME,
+  version: picked,
+  tarballSha256: sha256,
+  vendoredAt: new Date().toISOString().slice(0, 10),
+  releaseAgeGuardDays: MIN_RELEASE_AGE_DAYS,
+};
+writeFileSync(join(packageRoot, "abis-src", "VENDOR.json"), `${JSON.stringify(vendor, null, 2)}\n`);
+
+mkdirSync(join(packageRoot, "src", "abis"), { recursive: true });
+writeFileSync(join(packageRoot, "src", "abis", "morpho.ts"), generate(packageRoot));
+console.log(
+  `vendored ${vendoredFiles.size} upstream file(s) from ${SDK_NAME}@${picked} (tarball sha256 ${sha256.slice(0, 16)}…)`,
+);

--- a/packages/protocols/morpho/src/abis/morpho.ts
+++ b/packages/protocols/morpho/src/abis/morpho.ts
@@ -1,0 +1,2839 @@
+// GENERATED FILE - do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   @morpho-org/morpho-ts@2.8.0 (npm), full upstream ABI constants
+//   tarball:  sha256 be0bb0e608b73d44983f20735503f9352ef52d289b11b40ef8a0479cab6eb1b1
+//   vendored: 2026-07-18 (release-age guard: 7d)
+//   verification: the fixed factory deployment and exercised functions are
+//   checked live on Monad mainnet; the adapter's e2e tests pin observable behavior.
+
+export const MorphoVaultV2Abi = [
+    {
+        type: "constructor",
+        inputs: [
+            {
+                name: "_owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "_asset",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "DOMAIN_SEPARATOR",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "_totalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint128",
+                internalType: "uint128",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "abdicate",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "abdicated",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "absoluteCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "accrueInterest",
+        inputs: [],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "accrueInterestView",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "adapterRegistry",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "adapters",
+        inputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "adaptersLength",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "addAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "allocate",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "allocation",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "allowance",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "approve",
+        inputs: [
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "asset",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "balanceOf",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canReceiveAssets",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canReceiveShares",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canSendAssets",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "canSendShares",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "convertToAssets",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "convertToShares",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "curator",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "deallocate",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "decimals",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint8",
+                internalType: "uint8",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "decreaseAbsoluteCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "decreaseRelativeCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "decreaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "deposit",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "executableAt",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "firstTotalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "forceDeallocate",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "forceDeallocatePenalty",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "increaseAbsoluteCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "increaseRelativeCap",
+        inputs: [
+            {
+                name: "idData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "increaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "isAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "isAllocator",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "isSentinel",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "lastUpdate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "liquidityAdapter",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "liquidityData",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "managementFee",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint96",
+                internalType: "uint96",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "managementFeeRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxDeposit",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "maxMint",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "maxRate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint64",
+                internalType: "uint64",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "maxRedeem",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "maxWithdraw",
+        inputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "pure",
+    },
+    {
+        type: "function",
+        name: "mint",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "multicall",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes[]",
+                internalType: "bytes[]",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "name",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "nonces",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "owner",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "performanceFee",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint96",
+                internalType: "uint96",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "performanceFeeRecipient",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "permit",
+        inputs: [
+            {
+                name: "_owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "deadline",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "v",
+                type: "uint8",
+                internalType: "uint8",
+            },
+            {
+                name: "r",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+            {
+                name: "s",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "previewDeposit",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewMint",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewRedeem",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "previewWithdraw",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "receiveAssetsGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "receiveSharesGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "redeem",
+        inputs: [
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "relativeCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "removeAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "revoke",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "sendAssetsGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "sendSharesGate",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "setAdapterRegistry",
+        inputs: [
+            {
+                name: "newAdapterRegistry",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setCurator",
+        inputs: [
+            {
+                name: "newCurator",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setForceDeallocatePenalty",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newForceDeallocatePenalty",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setIsAllocator",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newIsAllocator",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setIsSentinel",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newIsSentinel",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setLiquidityAdapterAndData",
+        inputs: [
+            {
+                name: "newLiquidityAdapter",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "newLiquidityData",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setManagementFee",
+        inputs: [
+            {
+                name: "newManagementFee",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setManagementFeeRecipient",
+        inputs: [
+            {
+                name: "newManagementFeeRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setMaxRate",
+        inputs: [
+            {
+                name: "newMaxRate",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setName",
+        inputs: [
+            {
+                name: "newName",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setOwner",
+        inputs: [
+            {
+                name: "newOwner",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setPerformanceFee",
+        inputs: [
+            {
+                name: "newPerformanceFee",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setPerformanceFeeRecipient",
+        inputs: [
+            {
+                name: "newPerformanceFeeRecipient",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setReceiveAssetsGate",
+        inputs: [
+            {
+                name: "newReceiveAssetsGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setReceiveSharesGate",
+        inputs: [
+            {
+                name: "newReceiveSharesGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSendAssetsGate",
+        inputs: [
+            {
+                name: "newSendAssetsGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSendSharesGate",
+        inputs: [
+            {
+                name: "newSendSharesGate",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "setSymbol",
+        inputs: [
+            {
+                name: "newSymbol",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "submit",
+        inputs: [
+            {
+                name: "data",
+                type: "bytes",
+                internalType: "bytes",
+            },
+        ],
+        outputs: [],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "symbol",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "string",
+                internalType: "string",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "timelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                internalType: "bytes4",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "totalAssets",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "totalSupply",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "transfer",
+        inputs: [
+            {
+                name: "to",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "transferFrom",
+        inputs: [
+            {
+                name: "from",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "to",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "virtualShares",
+        inputs: [],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "withdraw",
+        inputs: [
+            {
+                name: "assets",
+                type: "uint256",
+                internalType: "uint256",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "event",
+        name: "Abdicate",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Accept",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "AccrueInterest",
+        inputs: [
+            {
+                name: "previousTotalAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "newTotalAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "performanceFeeShares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "managementFeeShares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "AddAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Allocate",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "adapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "ids",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "bytes32[]",
+            },
+            {
+                name: "change",
+                type: "int256",
+                indexed: false,
+                internalType: "int256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "AllowanceUpdatedByTransferFrom",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Approval",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Constructor",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Deallocate",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "adapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "ids",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "bytes32[]",
+            },
+            {
+                name: "change",
+                type: "int256",
+                indexed: false,
+                internalType: "int256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "DecreaseAbsoluteCap",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "DecreaseRelativeCap",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "DecreaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Deposit",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "ForceDeallocate",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "adapter",
+                type: "address",
+                indexed: false,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "ids",
+                type: "bytes32[]",
+                indexed: false,
+                internalType: "bytes32[]",
+            },
+            {
+                name: "penaltyAssets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "IncreaseAbsoluteCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newAbsoluteCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "IncreaseRelativeCap",
+        inputs: [
+            {
+                name: "id",
+                type: "bytes32",
+                indexed: true,
+                internalType: "bytes32",
+            },
+            {
+                name: "idData",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "newRelativeCap",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "IncreaseTimelock",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "newDuration",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Permit",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "spender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "nonce",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "deadline",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "RemoveAdapter",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Revoke",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetAdapterRegistry",
+        inputs: [
+            {
+                name: "newAdapterRegistry",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetCurator",
+        inputs: [
+            {
+                name: "newCurator",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetForceDeallocatePenalty",
+        inputs: [
+            {
+                name: "adapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "forceDeallocatePenalty",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetIsAllocator",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newIsAllocator",
+                type: "bool",
+                indexed: false,
+                internalType: "bool",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetIsSentinel",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newIsSentinel",
+                type: "bool",
+                indexed: false,
+                internalType: "bool",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetLiquidityAdapterAndData",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newLiquidityAdapter",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "newLiquidityData",
+                type: "bytes",
+                indexed: true,
+                internalType: "bytes",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetManagementFee",
+        inputs: [
+            {
+                name: "newManagementFee",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetManagementFeeRecipient",
+        inputs: [
+            {
+                name: "newManagementFeeRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetMaxRate",
+        inputs: [
+            {
+                name: "newMaxRate",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetName",
+        inputs: [
+            {
+                name: "newName",
+                type: "string",
+                indexed: false,
+                internalType: "string",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetOwner",
+        inputs: [
+            {
+                name: "newOwner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetPerformanceFee",
+        inputs: [
+            {
+                name: "newPerformanceFee",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetPerformanceFeeRecipient",
+        inputs: [
+            {
+                name: "newPerformanceFeeRecipient",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetReceiveAssetsGate",
+        inputs: [
+            {
+                name: "newReceiveAssetsGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetReceiveSharesGate",
+        inputs: [
+            {
+                name: "newReceiveSharesGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSendAssetsGate",
+        inputs: [
+            {
+                name: "newSendAssetsGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSendSharesGate",
+        inputs: [
+            {
+                name: "newSendSharesGate",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "SetSymbol",
+        inputs: [
+            {
+                name: "newSymbol",
+                type: "string",
+                indexed: false,
+                internalType: "string",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Submit",
+        inputs: [
+            {
+                name: "selector",
+                type: "bytes4",
+                indexed: true,
+                internalType: "bytes4",
+            },
+            {
+                name: "data",
+                type: "bytes",
+                indexed: false,
+                internalType: "bytes",
+            },
+            {
+                name: "executableAt",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Transfer",
+        inputs: [
+            {
+                name: "from",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "to",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "event",
+        name: "Withdraw",
+        inputs: [
+            {
+                name: "sender",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "receiver",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "onBehalf",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "assets",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+            {
+                name: "shares",
+                type: "uint256",
+                indexed: false,
+                internalType: "uint256",
+            },
+        ],
+        anonymous: false,
+    },
+    {
+        type: "error",
+        name: "Abdicated",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AbsoluteCapExceeded",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AbsoluteCapNotDecreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AbsoluteCapNotIncreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "AutomaticallyTimelocked",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotReceiveAssets",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotReceiveShares",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotSendAssets",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CannotSendShares",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "CastOverflow",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "DataAlreadyPending",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "DataNotTimelocked",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "FeeInvariantBroken",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "FeeTooHigh",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "InvalidSigner",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "MaxRateTooHigh",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NoCode",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotAdapter",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "NotInAdapterRegistry",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "PenaltyTooHigh",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "PermitDeadlineExpired",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapAboveOne",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapExceeded",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapNotDecreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "RelativeCapNotIncreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TimelockNotDecreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TimelockNotExpired",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TimelockNotIncreasing",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferFromReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferFromReverted",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReturnedFalse",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "TransferReverted",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "Unauthorized",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ZeroAbsoluteCap",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ZeroAddress",
+        inputs: [],
+    },
+    {
+        type: "error",
+        name: "ZeroAllocation",
+        inputs: [],
+    },
+] as const;
+
+export const MorphoVaultV2FactoryAbi = [
+    {
+        type: "function",
+        name: "createVaultV2",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "salt",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "nonpayable",
+    },
+    {
+        type: "function",
+        name: "isVaultV2",
+        inputs: [
+            {
+                name: "account",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "bool",
+                internalType: "bool",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "function",
+        name: "vaultV2",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                internalType: "address",
+            },
+            {
+                name: "salt",
+                type: "bytes32",
+                internalType: "bytes32",
+            },
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "address",
+                internalType: "address",
+            },
+        ],
+        stateMutability: "view",
+    },
+    {
+        type: "event",
+        name: "CreateVaultV2",
+        inputs: [
+            {
+                name: "owner",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "asset",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+            {
+                name: "salt",
+                type: "bytes32",
+                indexed: false,
+                internalType: "bytes32",
+            },
+            {
+                name: "newVaultV2",
+                type: "address",
+                indexed: true,
+                internalType: "address",
+            },
+        ],
+        anonymous: false,
+    },
+] as const;

--- a/packages/protocols/morpho/src/index.ts
+++ b/packages/protocols/morpho/src/index.ts
@@ -1,0 +1,3 @@
+export { MorphoVaultV2Abi, MorphoVaultV2FactoryAbi } from "./abis/morpho.js";
+export { MORPHO_VAULT_V2_FACTORY_ADDRESS, Morpho } from "./morpho.js";
+export type { MorphoDepositOutcome, MorphoWithdrawOutcome, VaultSummary } from "./types.js";

--- a/packages/protocols/morpho/src/morpho.ts
+++ b/packages/protocols/morpho/src/morpho.ts
@@ -1,0 +1,474 @@
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type CapabilityResult,
+  type Change,
+  createHandle,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type MossRuntime,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+} from "@themoss/core";
+import { ERC20 } from "@themoss/erc";
+import { decodeEventLog, formatUnits, getAddress, isAddress, parseUnits } from "viem";
+import { MorphoVaultV2Abi, MorphoVaultV2FactoryAbi } from "./abis/morpho.js";
+import type {
+  MorphoDepositOutcome,
+  MorphoWithdrawOutcome,
+  VaultCandidate,
+  VaultSummary,
+  VerifiedVault,
+} from "./types.js";
+
+// Official Morpho Vaults V2 factory on Monad mainnet: vendored
+// @morpho-org/morpho-ts `lib/esm/addresses.js` entry
+// `addresses[143].vaultV2Factory` (version and tarball digest in
+// abis-src/VENDOR.json), cross-checked against api.morpho.org, which reports
+// the same `factory.address` for every listed Monad vault (retrieved
+// 2026-07-18). The live test verifies deployed bytecode, and every vault this
+// adapter touches must pass this factory's on-chain `isVaultV2` attestation.
+export const MORPHO_VAULT_V2_FACTORY_ADDRESS =
+  "0x8B2F922162FBb60A6a072cC784A2E4168fB0bb0c" as const;
+const MORPHO_API_URL = "https://api.morpho.org/graphql";
+// Moss v1 is Monad-mainnet only; the Runtime rejects any RPC whose chain ID
+// is not 143, so the multichain Morpho API must be filtered to the same chain.
+const MONAD_CHAIN_ID = 143;
+const MAX_DISCOVERED_VAULTS = 100;
+
+// Discovery requests only `listed: true` vaults: the unlisted Monad set
+// includes junk and adversarial display data, and API responses are only
+// candidates for on-chain verification either way (ADR 0012).
+const VAULTS_QUERY = `query MossVaults($first: Int!, $where: VaultV2sFilters!) {
+  vaultV2s(first: $first, where: $where, orderBy: TotalAssetsUsd, orderDirection: Desc) {
+    items {
+      address
+      name
+      symbol
+      netApy
+      netApyExcludingRewards
+      totalAssetsUsd
+      liquidityAdapter { address }
+      asset { address }
+    }
+  }
+}`;
+
+const OptionalAddress = Address.optional().describe(
+  "An optional 20-byte EVM address encoded as a 0x-prefixed hexadecimal string.",
+);
+
+const vaultField = {
+  type: Address,
+  description:
+    "Morpho Vault V2 contract this operation targets; must be attested by the on-chain VaultV2 factory.",
+};
+
+const discoverParams = {
+  asset: {
+    type: OptionalAddress,
+    description:
+      "Restrict results to vaults denominated in this underlying ERC-20 asset; omit to list every curated vault.",
+  },
+} satisfies ParamsSpec;
+
+const positionParams = {
+  vault: vaultField,
+  owner: { type: Address, description: "Address whose vault position is read." },
+} satisfies ParamsSpec;
+
+const depositParams = {
+  vault: vaultField,
+  amount: {
+    type: PositiveDecimalString,
+    description: "Quantity of the vault's underlying asset to deposit, in its display units.",
+  },
+} satisfies ParamsSpec;
+
+const withdrawParams = {
+  vault: vaultField,
+  amount: {
+    type: PositiveDecimalString,
+    description: "Quantity of the vault's underlying asset to withdraw, in its display units.",
+  },
+} satisfies ParamsSpec;
+
+@Protocol({
+  name: "morpho",
+  category: "lending",
+  description:
+    "Morpho Vaults V2 on Monad: deposit into and withdraw from curated ERC-4626 yield vaults discovered via the Morpho API and verified on-chain.",
+  contracts: {
+    factory: { abi: MorphoVaultV2FactoryAbi, addr: MORPHO_VAULT_V2_FACTORY_ADDRESS },
+  },
+  protocols: { erc20: ERC20 },
+})
+export class Morpho {
+  declare runtime: MossRuntime;
+  declare factory: Handle<typeof MorphoVaultV2FactoryAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  vaults(
+    params: { asset?: AddressValue },
+    ctx: ActionCtx,
+  ): Promise<{ vaults: readonly VaultSummary[] }>;
+  @Query({
+    intent: "List curated Morpho V2 vaults on Monad with on-chain asset facts and advisory APY",
+    params: discoverParams,
+    tags: ["vault", "erc4626", "yield"],
+  })
+  async vaults(
+    params: InferParams<typeof discoverParams>,
+    ctx: ActionCtx,
+  ): Promise<{ vaults: readonly VaultSummary[] }> {
+    const candidates = await fetchVaultCandidates(params.asset);
+    const vaults = await Promise.all(
+      candidates.map(async (candidate) => {
+        const vault = await this.#verifyVault(candidate.address, ctx.account);
+        if (!sameAddress(vault.asset, candidate.asset)) {
+          throw new Error(`Morpho API returned vault ${candidate.address} with a mismatched asset`);
+        }
+        if (params.asset && !sameAddress(vault.asset, params.asset)) {
+          throw new Error(
+            `Morpho API returned vault ${candidate.address} outside the requested asset filter`,
+          );
+        }
+        const totalAssets = await vault.handle.read.totalAssets();
+        return {
+          address: vault.address,
+          name: candidate.name ?? null,
+          symbol: candidate.symbol ?? null,
+          asset: { address: vault.asset, symbol: vault.assetSymbol, decimals: vault.assetDecimals },
+          totalAssets: totalAssets.toString(),
+          totalAssetsDisplay: formatUnits(totalAssets, vault.assetDecimals),
+          netApy: candidate.netApy ?? null,
+          netApyExcludingRewards: candidate.netApyExcludingRewards ?? null,
+          totalAssetsUsd: candidate.totalAssetsUsd ?? null,
+          liquidityAdapter: candidate.liquidityAdapter ?? null,
+        };
+      }),
+    );
+    return { vaults };
+  }
+
+  @Query({
+    intent: "Read a Morpho V2 vault position as shares and redeemable assets",
+    params: positionParams,
+    tags: ["vault", "balance"],
+  })
+  async position(params: InferParams<typeof positionParams>, ctx: ActionCtx) {
+    const vault = await this.#verifyVault(params.vault, ctx.account);
+    const shares = await vault.handle.read.balanceOf([params.owner]);
+    const assets = await vault.handle.read.convertToAssets([shares]);
+    return {
+      vault: vault.address,
+      owner: params.owner,
+      shares: shares.toString(),
+      assets: assets.toString(),
+      assetsDisplay: formatUnits(assets, vault.assetDecimals),
+      asset: { address: vault.asset, symbol: vault.assetSymbol, decimals: vault.assetDecimals },
+    };
+  }
+
+  @Query({
+    intent: "Preview the vault shares minted by a Morpho V2 deposit",
+    params: depositParams,
+    tags: ["vault", "quote"],
+  })
+  async previewDeposit(params: InferParams<typeof depositParams>, ctx: ActionCtx) {
+    const vault = await this.#verifyVault(params.vault, ctx.account);
+    const assets = parseUnits(params.amount, vault.assetDecimals);
+    // VaultV2 previews via the ERC-4626 preview functions only; its
+    // maxDeposit/maxMint/maxWithdraw/maxRedeem always return 0 by design.
+    const shares = await vault.handle.read.previewDeposit([assets]);
+    return {
+      vault: vault.address,
+      amount: params.amount,
+      assets: assets.toString(),
+      shares: shares.toString(),
+    };
+  }
+
+  @Capability<Morpho, typeof depositParams>({
+    intent: "Deposit an asset into a verified Morpho V2 vault to earn yield",
+    verb: "supply",
+    params: depositParams,
+    receipt: "depositReceipt",
+    risk: ["fundOut", "approval"],
+    tags: ["vault", "erc4626", "yield"],
+  })
+  async deposit(
+    params: InferParams<typeof depositParams>,
+    ctx: ActionCtx,
+  ): Promise<CapabilityResult> {
+    const vault = await this.#verifyVault(params.vault, ctx.account);
+    const assets = parseUnits(params.amount, vault.assetDecimals);
+    const approval = await this.erc20.approve({
+      token: vault.asset,
+      spender: vault.address,
+      amount: assets.toString(),
+    });
+    // Shares always mint to the caller: onBehalf is pinned to ctx.account so
+    // discovery data can never redirect a position to a third party.
+    return [approval, vault.handle.deposit([assets, ctx.account])];
+  }
+
+  @Capability<Morpho, typeof withdrawParams>({
+    intent: "Withdraw an asset from a Morpho V2 vault position",
+    verb: "withdraw",
+    params: withdrawParams,
+    receipt: "withdrawReceipt",
+    risk: ["fundOut"],
+    tags: ["vault", "erc4626", "yield"],
+  })
+  async withdraw(
+    params: InferParams<typeof withdrawParams>,
+    ctx: ActionCtx,
+  ): Promise<CapabilityResult> {
+    const vault = await this.#verifyVault(params.vault, ctx.account);
+    const assets = parseUnits(params.amount, vault.assetDecimals);
+    // receiver and onBehalf are pinned to ctx.account: the caller burns its
+    // own shares and receives the assets itself; no approval is needed.
+    return [vault.handle.withdraw([assets, ctx.account, ctx.account])];
+  }
+
+  @Receipt()
+  depositReceipt(changes: readonly Change[]): ReceiptResult<MorphoDepositOutcome> {
+    let outcome: MorphoDepositOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") return this.erc20.changesReceipt([change]);
+      const event = tryDecodeMorphoEvent(change);
+      if (!event || event.eventName === "Transfer" || event.eventName === "Approval") {
+        // Underlying asset movements, share mints, and allowance updates are
+        // ERC-20 semantics; delegate them so coverage stays exhaustive.
+        return this.erc20.changesReceipt([change]);
+      }
+      if (event.eventName === "AccrueInterest") return accrueInterestChange(change, event.args);
+      if (event.eventName !== "Deposit") {
+        throw new Error(`Unexpected Change: Morpho vault emitted ${event.eventName}`);
+      }
+      if (outcome) throw new Error("Morpho deposit emitted multiple Deposit events");
+      outcome = {
+        operation: "deposit",
+        protocol: "morpho",
+        vault: getAddress(change.address),
+        sender: event.args.sender,
+        onBehalf: event.args.onBehalf,
+        assets: event.args.assets.toString(),
+        shares: event.args.shares.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: outcome,
+        text: `Morpho Deposit: ${outcome.assets} asset units into ${outcome.vault} minted ${outcome.shares} shares for ${outcome.onBehalf}`,
+      };
+    });
+    if (!outcome) throw new Error("Morpho deposit Receipt requires a Deposit event");
+    return {
+      kind: "receipt",
+      outcome,
+      text: `Morpho Deposit: ${outcome.assets} asset units into ${outcome.vault} for ${outcome.shares} shares`,
+      changes: parsed,
+    };
+  }
+
+  @Receipt()
+  withdrawReceipt(changes: readonly Change[]): ReceiptResult<MorphoWithdrawOutcome> {
+    let outcome: MorphoWithdrawOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") return this.erc20.changesReceipt([change]);
+      const event = tryDecodeMorphoEvent(change);
+      if (!event || event.eventName === "Transfer" || event.eventName === "Approval") {
+        return this.erc20.changesReceipt([change]);
+      }
+      if (event.eventName === "AccrueInterest") return accrueInterestChange(change, event.args);
+      if (event.eventName !== "Withdraw") {
+        throw new Error(`Unexpected Change: Morpho vault emitted ${event.eventName}`);
+      }
+      if (outcome) throw new Error("Morpho withdraw emitted multiple Withdraw events");
+      outcome = {
+        operation: "withdraw",
+        protocol: "morpho",
+        vault: getAddress(change.address),
+        sender: event.args.sender,
+        receiver: event.args.receiver,
+        onBehalf: event.args.onBehalf,
+        assets: event.args.assets.toString(),
+        shares: event.args.shares.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: outcome,
+        text: `Morpho Withdraw: ${outcome.assets} asset units from ${outcome.vault} to ${outcome.receiver} burned ${outcome.shares} shares`,
+      };
+    });
+    if (!outcome) throw new Error("Morpho withdraw Receipt requires a Withdraw event");
+    return {
+      kind: "receipt",
+      outcome,
+      text: `Morpho Withdraw: ${outcome.assets} asset units from ${outcome.vault} for ${outcome.shares} shares`,
+      changes: parsed,
+    };
+  }
+
+  /** The ADR 0012 gate: every vault this adapter touches — API-discovered or
+   * user-supplied — must be attested by the fixed factory on-chain, and every
+   * asset fact used afterwards is read from chain state, never from the API. */
+  async #verifyVault(vault: AddressValue, account: AddressValue): Promise<VerifiedVault> {
+    const attested = await this.factory.read.isVaultV2([vault]);
+    if (!attested) {
+      throw new Error(`address ${vault} is not a factory-attested Morpho Vault V2`);
+    }
+    const address = getAddress(vault);
+    const handle = createHandle(MorphoVaultV2Abi, address, this.runtime.client, account);
+    const asset = await handle.read.asset();
+    const { symbol, decimals } = await this.erc20.metadata({ token: asset });
+    return { address, handle, asset, assetDecimals: decimals, assetSymbol: symbol };
+  }
+}
+
+async function fetchVaultCandidates(asset?: AddressValue): Promise<readonly VaultCandidate[]> {
+  let response: Response;
+  try {
+    response = await fetch(MORPHO_API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: VAULTS_QUERY,
+        variables: {
+          first: MAX_DISCOVERED_VAULTS,
+          where: {
+            chainId_in: [MONAD_CHAIN_ID],
+            listed: true,
+            ...(asset ? { assetAddress_in: [asset] } : {}),
+          },
+        },
+      }),
+    });
+  } catch (error) {
+    throw new Error(`Morpho vault discovery failed: ${errorMessage(error)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`Morpho vault discovery failed with HTTP ${response.status}`);
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new Error(`Morpho vault discovery returned invalid JSON: ${errorMessage(error)}`);
+  }
+  if (!isRecord(payload)) throw new Error("Morpho vault discovery returned an invalid response");
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    const [first] = payload.errors;
+    const message =
+      isRecord(first) && typeof first.message === "string" ? first.message : "unknown";
+    throw new Error(`Morpho vault discovery returned a GraphQL error: ${message}`);
+  }
+  const vaultV2s = isRecord(payload.data) ? payload.data.vaultV2s : undefined;
+  if (!isRecord(vaultV2s) || !Array.isArray(vaultV2s.items)) {
+    throw new Error("Morpho vault discovery returned an invalid response");
+  }
+  const candidates = vaultV2s.items.map(parseVaultCandidate);
+  const unique = new Map<string, VaultCandidate>();
+  for (const candidate of candidates) {
+    const key = candidate.address.toLowerCase();
+    const previous = unique.get(key);
+    if (previous && !sameAddress(previous.asset, candidate.asset)) {
+      throw new Error(`Morpho vault discovery returned conflicting vault ${candidate.address}`);
+    }
+    unique.set(key, candidate);
+  }
+  return [...unique.values()];
+}
+
+function parseVaultCandidate(value: unknown): VaultCandidate {
+  if (!isRecord(value)) throw new Error("Morpho vault discovery returned an invalid vault");
+  if (!isRecord(value.asset)) {
+    throw new Error("Morpho vault discovery returned a vault without an asset");
+  }
+  const liquidityAdapter = value.liquidityAdapter;
+  if (liquidityAdapter !== null && liquidityAdapter !== undefined && !isRecord(liquidityAdapter)) {
+    throw new Error("Morpho vault discovery returned an invalid liquidityAdapter");
+  }
+  return {
+    address: parseApiAddress(value.address, "address"),
+    asset: parseApiAddress(value.asset.address, "asset.address"),
+    ...(typeof value.name === "string" ? { name: value.name } : {}),
+    ...(typeof value.symbol === "string" ? { symbol: value.symbol } : {}),
+    ...(typeof value.netApy === "number" ? { netApy: value.netApy } : {}),
+    ...(typeof value.netApyExcludingRewards === "number"
+      ? { netApyExcludingRewards: value.netApyExcludingRewards }
+      : {}),
+    ...(typeof value.totalAssetsUsd === "number" ? { totalAssetsUsd: value.totalAssetsUsd } : {}),
+    ...(isRecord(liquidityAdapter)
+      ? { liquidityAdapter: parseApiAddress(liquidityAdapter.address, "liquidityAdapter.address") }
+      : {}),
+  };
+}
+
+function parseApiAddress(value: unknown, field: string): AddressValue {
+  if (typeof value !== "string" || !isAddress(value, { strict: false })) {
+    throw new Error(`Morpho vault discovery returned invalid ${field}`);
+  }
+  return getAddress(value);
+}
+
+function accrueInterestChange(
+  change: Extract<Change, { kind: "event" }>,
+  args: {
+    previousTotalAssets: bigint;
+    newTotalAssets: bigint;
+    performanceFeeShares: bigint;
+    managementFeeShares: bigint;
+  },
+) {
+  const data = {
+    event: "AccrueInterest",
+    emitter: change.address,
+    previousTotalAssets: args.previousTotalAssets.toString(),
+    newTotalAssets: args.newTotalAssets.toString(),
+    performanceFeeShares: args.performanceFeeShares.toString(),
+    managementFeeShares: args.managementFeeShares.toString(),
+  } as const;
+  return {
+    kind: "change" as const,
+    change,
+    data,
+    text: `Morpho Vault Interest Accrual: totalAssets ${data.previousTotalAssets} to ${data.newTotalAssets} on ${data.emitter}`,
+  };
+}
+
+function tryDecodeMorphoEvent(change: Extract<Change, { kind: "event" }>) {
+  try {
+    return decodeEventLog({
+      abi: MorphoVaultV2Abi,
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/protocols/morpho/src/types.ts
+++ b/packages/protocols/morpho/src/types.ts
@@ -1,0 +1,63 @@
+import type { AddressValue, Handle } from "@themoss/core";
+import type { MorphoVaultV2Abi } from "./abis/morpho.js";
+
+/** A vault reported by the Morpho API. Candidates are display-only until
+ * verified on-chain; only `address` and `asset` are required because they are
+ * cross-checked against chain state before any use. */
+export type VaultCandidate = {
+  address: AddressValue;
+  asset: AddressValue;
+  name?: string;
+  symbol?: string;
+  netApy?: number;
+  netApyExcludingRewards?: number;
+  totalAssetsUsd?: number;
+  liquidityAdapter?: AddressValue;
+};
+
+/** A vault that passed the factory attestation gate, with its asset facts
+ * read from chain state. */
+export type VerifiedVault = {
+  address: AddressValue;
+  handle: Handle<typeof MorphoVaultV2Abi>;
+  asset: AddressValue;
+  assetDecimals: number;
+  assetSymbol: string;
+};
+
+/** JSON-safe discovery result item. Asset address, symbol, decimals, and
+ * totalAssets come from chain reads; name, symbol, APY, and USD TVL are
+ * advisory API display data and never become transaction inputs. */
+export type VaultSummary = {
+  address: AddressValue;
+  name: string | null;
+  symbol: string | null;
+  asset: { address: AddressValue; symbol: string; decimals: number };
+  totalAssets: string;
+  totalAssetsDisplay: string;
+  netApy: number | null;
+  netApyExcludingRewards: number | null;
+  totalAssetsUsd: number | null;
+  liquidityAdapter: AddressValue | null;
+};
+
+export type MorphoDepositOutcome = {
+  operation: "deposit";
+  protocol: "morpho";
+  vault: AddressValue;
+  sender: AddressValue;
+  onBehalf: AddressValue;
+  assets: string;
+  shares: string;
+};
+
+export type MorphoWithdrawOutcome = {
+  operation: "withdraw";
+  protocol: "morpho";
+  vault: AddressValue;
+  sender: AddressValue;
+  receiver: AddressValue;
+  onBehalf: AddressValue;
+  assets: string;
+  shares: string;
+};

--- a/packages/protocols/morpho/test/abis.test.ts
+++ b/packages/protocols/morpho/test/abis.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { generate } from "../scripts/abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// The provenance chain, enforced: the committed generated TS must be exactly
+// what the deterministic generator derives from the committed abis-src/.
+// Fails on: hand-edits to src/abis/morpho.ts, generator edits without
+// `pnpm gen:abis`, abis-src/ edits without regeneration.
+describe("abi provenance chain", () => {
+  it("src/abis/morpho.ts derives byte-for-byte from abis-src/", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "morpho.ts"), "utf8");
+    expect(committed).toBe(generate(packageRoot));
+  });
+});

--- a/packages/protocols/morpho/test/morpho.test.ts
+++ b/packages/protocols/morpho/test/morpho.test.ts
@@ -1,0 +1,755 @@
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  type ReceiptResult,
+  Registry,
+} from "@themoss/core";
+import { ERC20Abi } from "@themoss/erc";
+import { createTraceSimulator } from "@themoss/simulator";
+import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  getAddress,
+  parseAbiItem,
+} from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MorphoVaultV2Abi } from "../src/abis/morpho.js";
+import { MORPHO_VAULT_V2_FACTORY_ADDRESS, Morpho } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const OWNER = getAddress("0xdddddddddddddddddddddddddddddddddddddddd");
+const ZERO = getAddress("0x0000000000000000000000000000000000000000");
+const VAULT_USDC = getAddress("0x1111111111111111111111111111111111111111");
+const VAULT_WETH = getAddress("0x2222222222222222222222222222222222222222");
+const WETH = getAddress("0x3333333333333333333333333333333333333333");
+const ADAPTER = getAddress("0x4444444444444444444444444444444444444444");
+
+type MockVault = {
+  address: `0x${string}`;
+  asset: `0x${string}`;
+  attested: boolean;
+  totalAssets: bigint;
+  liquidityAdapter?: `0x${string}`;
+};
+
+type MockToken = { name: string; symbol: string; decimals: number };
+
+const VAULTS: readonly MockVault[] = [
+  { address: VAULT_USDC, asset: USDC_ADDRESS, attested: true, totalAssets: 26_359_442_020_937n },
+  {
+    address: VAULT_WETH,
+    asset: WETH,
+    attested: true,
+    totalAssets: 13_089_515_250_132_911_569_813n,
+    liquidityAdapter: ADAPTER,
+  },
+];
+
+const TOKENS = new Map<string, MockToken>([
+  [USDC_ADDRESS.toLowerCase(), { name: "USD Coin", symbol: "USDC", decimals: 6 }],
+  [WETH.toLowerCase(), { name: "Wrapped Ether", symbol: "WETH", decimals: 18 }],
+]);
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Morpho", () => {
+  it("loads separate field and type descriptions for deposit", async () => {
+    const { registry } = offlineRegistry();
+    const [loaded] = registry.load([{ protocol: "morpho", method: "deposit" }]);
+    expect(loaded?.params.vault).toMatchObject({
+      description: expect.stringContaining("attested by the on-chain VaultV2 factory"),
+      type: { description: expect.stringContaining("20-byte EVM address") },
+    });
+    expect(loaded?.params.amount).toMatchObject({
+      description: expect.stringContaining("underlying asset to deposit"),
+      type: { description: expect.stringContaining("decimal string") },
+    });
+  });
+
+  it("rejects malformed amounts and unknown parameters", async () => {
+    const { registry } = offlineRegistry();
+    for (const amount of ["0", "-1", "1,5", ""]) {
+      await expect(
+        registry.action("morpho", "deposit", ACCOUNT, { vault: VAULT_USDC, amount }),
+      ).rejects.toThrow("invalid parameters");
+    }
+    await expect(
+      registry.action("morpho", "withdraw", ACCOUNT, {
+        vault: VAULT_USDC,
+        amount: "1",
+        extra: true,
+      }),
+    ).rejects.toThrow("invalid parameters");
+  });
+
+  it("discovers listed vaults, verifies them on-chain, and keeps API data advisory", async () => {
+    const { registry, fetchMock } = offlineRegistry();
+    const result = await registry.action("morpho", "vaults", ACCOUNT, {});
+    if (result.kind !== "query") throw new Error("expected query");
+    expect(result.data).toEqual({
+      vaults: [
+        {
+          address: VAULT_USDC,
+          name: "Hyperithm USDC Apex",
+          symbol: "hyperUSDCa",
+          asset: { address: USDC_ADDRESS, symbol: "USDC", decimals: 6 },
+          totalAssets: "26359442020937",
+          totalAssetsDisplay: "26359442.020937",
+          netApy: 0.0843,
+          netApyExcludingRewards: 0.0641,
+          totalAssetsUsd: 26356321.73,
+          liquidityAdapter: null,
+        },
+        {
+          address: VAULT_WETH,
+          name: "Steakhouse Prime ETH",
+          symbol: "steakETH",
+          asset: { address: WETH, symbol: "WETH", decimals: 18 },
+          totalAssets: "13089515250132911569813",
+          totalAssetsDisplay: "13089.515250132911569813",
+          netApy: null,
+          netApyExcludingRewards: null,
+          totalAssetsUsd: null,
+          liquidityAdapter: ADAPTER,
+        },
+      ],
+    });
+    const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as {
+      query: string;
+      variables: { first: number; where: Record<string, unknown> };
+    };
+    expect(request.query).toContain("vaultV2s");
+    expect(request.variables.where).toEqual({ chainId_in: [143], listed: true });
+
+    await registry.action("morpho", "vaults", ACCOUNT, { asset: USDC_ADDRESS });
+    const filtered = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as {
+      variables: { where: Record<string, unknown> };
+    };
+    expect(filtered.variables.where).toEqual({
+      chainId_in: [143],
+      listed: true,
+      assetAddress_in: [USDC_ADDRESS],
+    });
+  });
+
+  it("rejects vaults the factory does not attest, for discovery and direct params alike", async () => {
+    const unattested = { ...VAULTS[0], attested: false } as MockVault;
+    const { registry } = offlineRegistry([unattested]);
+    await expect(registry.action("morpho", "vaults", ACCOUNT, {})).rejects.toThrow(
+      `address ${VAULT_USDC} is not a factory-attested Morpho Vault V2`,
+    );
+    await expect(
+      registry.action("morpho", "deposit", ACCOUNT, { vault: VAULT_USDC, amount: "1" }),
+    ).rejects.toThrow("not a factory-attested");
+    await expect(
+      registry.action("morpho", "position", ACCOUNT, { vault: VAULT_USDC, owner: OWNER }),
+    ).rejects.toThrow("not a factory-attested");
+  });
+
+  it("rejects API candidates whose claimed asset mismatches chain state", async () => {
+    const { registry } = offlineRegistry(VAULTS, [
+      { address: VAULT_USDC, asset: { address: WETH } },
+    ]);
+    await expect(registry.action("morpho", "vaults", ACCOUNT, {})).rejects.toThrow(
+      `Morpho API returned vault ${VAULT_USDC} with a mismatched asset`,
+    );
+  });
+
+  it("rejects malformed discovery responses", async () => {
+    const { registry } = offlineRegistry(VAULTS, [
+      { address: "not-an-address", asset: { address: USDC_ADDRESS } },
+    ]);
+    await expect(registry.action("morpho", "vaults", ACCOUNT, {})).rejects.toThrow(
+      "invalid address",
+    );
+
+    for (const [payload, message] of [
+      [{ data: { vaultV2s: { items: "nope" } } }, "invalid response"],
+      [{ errors: [{ message: "boom" }] }, "GraphQL error: boom"],
+      [
+        {
+          data: {
+            vaultV2s: {
+              items: [
+                { address: VAULT_USDC, asset: { address: USDC_ADDRESS } },
+                { address: VAULT_USDC.toLowerCase(), asset: { address: WETH } },
+              ],
+            },
+          },
+        },
+        `conflicting vault ${VAULT_USDC.toLowerCase()}`,
+      ],
+    ] as const) {
+      const { registry: fresh } = offlineRegistry(VAULTS, undefined, {
+        json: async () => payload,
+      });
+      await expect(fresh.action("morpho", "vaults", ACCOUNT, {})).rejects.toThrow(message);
+    }
+
+    const { registry: badStatus } = offlineRegistry(VAULTS, undefined, { ok: false, status: 500 });
+    await expect(badStatus.action("morpho", "vaults", ACCOUNT, {})).rejects.toThrow("HTTP 500");
+
+    const { registry: badJson } = offlineRegistry(VAULTS, undefined, {
+      json: async () => {
+        throw new Error("bad json");
+      },
+    });
+    await expect(badJson.action("morpho", "vaults", ACCOUNT, {})).rejects.toThrow("invalid JSON");
+  });
+
+  it("builds deposit as one approve child plus exactly one direct vault transaction", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("morpho", "deposit", ACCOUNT, {
+      vault: VAULT_USDC,
+      amount: "1.5",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const transactions = flattenCapabilityTree(capability);
+    expect(transactions).toHaveLength(2);
+    const [approval, deposit] = transactions;
+    if (!approval || !deposit) throw new Error("missing Morpho transactions");
+    expect(approval.transaction.to).toBe(USDC_ADDRESS);
+    expect(decodeFunctionData({ abi: ERC20Abi, data: approval.transaction.data })).toMatchObject({
+      functionName: "approve",
+      args: [VAULT_USDC, 1_500_000n],
+    });
+    expect(deposit.transaction.to).toBe(VAULT_USDC);
+    expect(decodeFunctionData({ abi: MorphoVaultV2Abi, data: deposit.transaction.data })).toEqual({
+      functionName: "deposit",
+      args: [1_500_000n, ACCOUNT],
+    });
+  });
+
+  it("builds withdraw as exactly one direct vault transaction pinned to the caller", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("morpho", "withdraw", ACCOUNT, {
+      vault: VAULT_USDC,
+      amount: "2",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const transactions = flattenCapabilityTree(capability);
+    expect(transactions).toHaveLength(1);
+    const [withdraw] = transactions;
+    if (!withdraw) throw new Error("missing Morpho transaction");
+    expect(withdraw.transaction.to).toBe(VAULT_USDC);
+    expect(decodeFunctionData({ abi: MorphoVaultV2Abi, data: withdraw.transaction.data })).toEqual({
+      functionName: "withdraw",
+      args: [2_000_000n, ACCOUNT, ACCOUNT],
+    });
+  });
+
+  it("reads positions and previews deposits from chain state only", async () => {
+    const { registry, fetchMock } = offlineRegistry();
+    const position = await registry.action("morpho", "position", ACCOUNT, {
+      vault: VAULT_USDC,
+      owner: OWNER,
+    });
+    if (position.kind !== "query") throw new Error("expected query");
+    expect(position.data).toEqual({
+      vault: VAULT_USDC,
+      owner: OWNER,
+      shares: "5000000",
+      assets: "10000000",
+      assetsDisplay: "10",
+      asset: { address: USDC_ADDRESS, symbol: "USDC", decimals: 6 },
+    });
+
+    const preview = await registry.action("morpho", "previewDeposit", ACCOUNT, {
+      vault: VAULT_USDC,
+      amount: "1",
+    });
+    if (preview.kind !== "query") throw new Error("expected query");
+    expect(preview.data).toEqual({
+      vault: VAULT_USDC,
+      amount: "1",
+      assets: "1000000",
+      shares: "3000000",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("translates the observed deposit Change grammar into an exhaustive Receipt", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("morpho", "deposit", ACCOUNT, {
+      vault: VAULT_USDC,
+      amount: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // The empirical Monad mainnet grammar: underlying Transfer(payer->vault),
+    // underlying Approval (allowance decrement on transferFrom), vault
+    // AccrueInterest, share-mint Transfer(0x0->onBehalf), vault Deposit.
+    const changes = [
+      erc20Transfer(USDC_ADDRESS, ACCOUNT, VAULT_USDC, 1_000_000n),
+      erc20Approval(USDC_ADDRESS, ACCOUNT, VAULT_USDC, 0n),
+      accrueInterest(VAULT_USDC, 5n, 7n),
+      erc20Transfer(VAULT_USDC, ZERO, ACCOUNT, 999_000n),
+      depositEvent(VAULT_USDC, ACCOUNT, ACCOUNT, 1_000_000n, 999_000n),
+    ] as const;
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toEqual({
+      operation: "deposit",
+      protocol: "morpho",
+      vault: VAULT_USDC,
+      sender: ACCOUNT,
+      onBehalf: ACCOUNT,
+      assets: "1000000",
+      shares: "999000",
+    });
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "receipt",
+      outcome: [
+        {
+          operation: "transfer",
+          token: USDC_ADDRESS,
+          from: ACCOUNT,
+          to: VAULT_USDC,
+          amount: "1000000",
+        },
+      ],
+    });
+    expect(receipt.changes[2]).toMatchObject({
+      kind: "change",
+      data: {
+        event: "AccrueInterest",
+        emitter: VAULT_USDC,
+        previousTotalAssets: "5",
+        newTotalAssets: "7",
+      },
+    });
+    expect(receipt.changes[3]).toMatchObject({
+      kind: "receipt",
+      outcome: [
+        { operation: "transfer", token: VAULT_USDC, from: ZERO, to: ACCOUNT, amount: "999000" },
+      ],
+    });
+    expect(receipt.changes.map(firstChange)).toEqual(changes);
+  });
+
+  it("translates a withdraw Change grammar into an exhaustive Receipt", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("morpho", "withdraw", ACCOUNT, {
+      vault: VAULT_USDC,
+      amount: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const changes = [
+      accrueInterest(VAULT_USDC, 7n, 9n),
+      erc20Transfer(VAULT_USDC, ACCOUNT, ZERO, 999_000n),
+      erc20Transfer(USDC_ADDRESS, VAULT_USDC, ACCOUNT, 1_000_000n),
+      withdrawEvent(VAULT_USDC, ACCOUNT, ACCOUNT, ACCOUNT, 1_000_000n, 999_000n),
+    ] as const;
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toEqual({
+      operation: "withdraw",
+      protocol: "morpho",
+      vault: VAULT_USDC,
+      sender: ACCOUNT,
+      receiver: ACCOUNT,
+      onBehalf: ACCOUNT,
+      assets: "1000000",
+      shares: "999000",
+    });
+    expect(receipt.changes.map(firstChange)).toEqual(changes);
+  });
+
+  it("fails loudly on missing, duplicated, or unexpected vault events", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("morpho", "deposit", ACCOUNT, {
+      vault: VAULT_USDC,
+      amount: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    expect(() =>
+      registry.parseReceipt(capability, [
+        erc20Transfer(USDC_ADDRESS, ACCOUNT, VAULT_USDC, 1_000_000n),
+      ]),
+    ).toThrow("Morpho deposit Receipt requires a Deposit event");
+
+    const deposit = depositEvent(VAULT_USDC, ACCOUNT, ACCOUNT, 1_000_000n, 999_000n);
+    expect(() => registry.parseReceipt(capability, [deposit, deposit])).toThrow(
+      "multiple Deposit events",
+    );
+
+    expect(() =>
+      registry.parseReceipt(capability, [deposit, removeAdapterEvent(VAULT_USDC, ADAPTER)]),
+    ).toThrow("Unexpected Change: Morpho vault emitted RemoveAdapter");
+
+    // A Withdraw during a deposit is just as unexpected.
+    expect(() =>
+      registry.parseReceipt(capability, [
+        withdrawEvent(VAULT_USDC, ACCOUNT, ACCOUNT, ACCOUNT, 1n, 1n),
+      ]),
+    ).toThrow("Unexpected Change: Morpho vault emitted Withdraw");
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Morpho mainnet", () => {
+  it("has deployed factory bytecode and discovers verified vaults live", {
+    timeout: 120_000,
+  }, async () => {
+    const runtime = await monadRuntime();
+    expect(
+      (await runtime.client.getCode({ address: MORPHO_VAULT_V2_FACTORY_ADDRESS }))?.length,
+    ).toBeGreaterThan(2);
+    const registry = new Registry(runtime).use(Morpho);
+    const result = await registry.action("morpho", "vaults", ACCOUNT, {});
+    if (result.kind !== "query") throw new Error("expected query");
+    const { vaults } = result.data as { vaults: readonly { address: `0x${string}` }[] };
+    expect(vaults.length).toBeGreaterThan(0);
+  });
+
+  it("simulates a live deposit into an exhaustive typed Receipt", {
+    timeout: 300_000,
+  }, async () => {
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(Morpho);
+    const target = await liveSimulationTarget(runtime, registry);
+    if (!target) {
+      console.warn("Morpho deposit E2E skipped: no funded live account found");
+      return;
+    }
+    const capability = await registry.action("morpho", "deposit", target.owner, {
+      vault: target.vault,
+      amount: target.amount,
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+    expect(outcome.halted).toBeUndefined();
+    for (const result of outcome.results) expect(result.warnings).toEqual([]);
+    expect(outcome.results.at(-1)?.receipt?.outcome).toMatchObject({
+      operation: "deposit",
+      protocol: "morpho",
+      vault: target.vault,
+      onBehalf: target.owner,
+    });
+  });
+
+  it("simulates a live withdraw from a current shareholder", { timeout: 300_000 }, async () => {
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(Morpho);
+    const target = await liveWithdrawTarget(runtime, registry);
+    if (!target) {
+      console.warn("Morpho withdraw E2E skipped: no live shareholder found");
+      return;
+    }
+    const capability = await registry.action("morpho", "withdraw", target.owner, {
+      vault: target.vault,
+      amount: target.amount,
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+    expect(outcome.halted).toBeUndefined();
+    for (const result of outcome.results) expect(result.warnings).toEqual([]);
+    expect(outcome.results.at(-1)?.receipt?.outcome).toMatchObject({
+      operation: "withdraw",
+      protocol: "morpho",
+      vault: target.vault,
+      receiver: target.owner,
+    });
+  });
+});
+
+/** Simulation-only E2E target discovery (Moss never signs or sends): use the
+ * Morpho API to find recent depositors into idle-liquidity vaults, then keep
+ * only senders whose *current on-chain* underlying balance can fund a small
+ * deposit. The API only nominates candidates; balances decide. */
+async function liveSimulationTarget(runtime: MossRuntime, registry: Registry) {
+  for (const { vault, asset, decimals, owners } of await liveCandidates(registry)) {
+    for (const owner of owners) {
+      const balance = (await runtime.client.readContract({
+        address: asset,
+        abi: ERC20Abi,
+        functionName: "balanceOf",
+        args: [owner],
+      })) as bigint;
+      if (balance >= 10n ** BigInt(decimals)) return { vault, owner, amount: "1" };
+    }
+  }
+  return undefined;
+}
+
+async function liveWithdrawTarget(runtime: MossRuntime, registry: Registry) {
+  for (const { vault, decimals, owners } of await liveCandidates(registry)) {
+    for (const owner of owners) {
+      const shares = (await runtime.client.readContract({
+        address: vault,
+        abi: MorphoVaultV2Abi,
+        functionName: "balanceOf",
+        args: [owner],
+      })) as bigint;
+      if (shares === 0n) continue;
+      const assets = (await runtime.client.readContract({
+        address: vault,
+        abi: MorphoVaultV2Abi,
+        functionName: "convertToAssets",
+        args: [shares],
+      })) as bigint;
+      if (assets >= 10n ** BigInt(decimals)) return { vault, owner, amount: "1" };
+    }
+  }
+  return undefined;
+}
+
+type LiveCandidate = {
+  vault: `0x${string}`;
+  asset: `0x${string}`;
+  decimals: number;
+  owners: readonly `0x${string}`[];
+};
+
+async function liveCandidates(registry: Registry): Promise<readonly LiveCandidate[]> {
+  const result = await registry.action("morpho", "vaults", ACCOUNT, {});
+  if (result.kind !== "query") throw new Error("expected query");
+  const { vaults } = result.data as {
+    vaults: readonly {
+      address: `0x${string}`;
+      asset: { address: `0x${string}`; decimals: number };
+      liquidityAdapter: `0x${string}` | null;
+    }[];
+  };
+  // Idle-liquidity vaults only: adapter-routed flows emit allocation events
+  // the v1 Receipts deliberately reject.
+  const idle = vaults.filter((vault) => vault.liquidityAdapter === null).slice(0, 3);
+  const candidates: LiveCandidate[] = [];
+  for (const vault of idle) {
+    const response = await fetch("https://api.morpho.org/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: `query Owners($where: VaultV2TransactionFilters!) {
+          vaultV2transactions(first: 25, where: $where, orderBy: Time, orderDirection: Desc) {
+            items { data { ... on VaultV2DepositData { sender } ... on VaultV2WithdrawData { sender } } }
+          }
+        }`,
+        variables: { where: { chainId_in: [143], vaultAddress_in: [vault.address] } },
+      }),
+    });
+    if (!response.ok) continue;
+    const payload = (await response.json()) as {
+      data?: { vaultV2transactions?: { items?: readonly { data?: { sender?: string } }[] } };
+    };
+    const owners = [
+      ...new Set(
+        (payload.data?.vaultV2transactions?.items ?? [])
+          .map((item) => item.data?.sender)
+          .filter((sender): sender is string => typeof sender === "string")
+          .map((sender) => getAddress(sender)),
+      ),
+    ];
+    candidates.push({
+      vault: vault.address,
+      asset: vault.asset.address,
+      decimals: vault.asset.decimals,
+      owners,
+    });
+  }
+  return candidates;
+}
+
+function offlineRegistry(
+  vaults: readonly MockVault[] = VAULTS,
+  apiItems?: readonly unknown[],
+  responseOverrides: Partial<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+  }> = {},
+) {
+  const byAddress = new Map(vaults.map((vault) => [vault.address.toLowerCase(), vault]));
+  const items =
+    apiItems ??
+    vaults.map((vault, index) => ({
+      address: vault.address,
+      name: index === 0 ? "Hyperithm USDC Apex" : "Steakhouse Prime ETH",
+      symbol: index === 0 ? "hyperUSDCa" : "steakETH",
+      ...(index === 0
+        ? { netApy: 0.0843, netApyExcludingRewards: 0.0641, totalAssetsUsd: 26356321.73 }
+        : { netApy: null, netApyExcludingRewards: null, totalAssetsUsd: null }),
+      liquidityAdapter: vault.liquidityAdapter ? { address: vault.liquidityAdapter } : null,
+      asset: { address: vault.asset },
+    }));
+  const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+    const request = JSON.parse(String(init?.body ?? "{}")) as {
+      variables?: { where?: { assetAddress_in?: readonly string[] } };
+    };
+    const assetFilter = request.variables?.where?.assetAddress_in?.map((a) => a.toLowerCase());
+    const filtered = assetFilter
+      ? items.filter((item) => {
+          const record = item as { asset?: { address?: string } };
+          return assetFilter.includes(String(record.asset?.address).toLowerCase());
+        })
+      : items;
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { vaultV2s: { items: filtered } } }),
+      ...responseOverrides,
+    } as Response);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  const client = {
+    readContract: async ({
+      address,
+      functionName,
+      args = [],
+    }: {
+      address: string;
+      functionName: string;
+      args?: readonly unknown[];
+    }) => {
+      if (functionName === "isVaultV2") {
+        if (address.toLowerCase() !== MORPHO_VAULT_V2_FACTORY_ADDRESS.toLowerCase()) {
+          throw new Error(`isVaultV2 asked of non-factory ${address}`);
+        }
+        return byAddress.get(String(args[0]).toLowerCase())?.attested ?? false;
+      }
+      const vault = byAddress.get(address.toLowerCase());
+      if (vault) {
+        if (functionName === "asset") return vault.asset;
+        if (functionName === "totalAssets") return vault.totalAssets;
+        if (functionName === "balanceOf") {
+          return String(args[0]).toLowerCase() === OWNER.toLowerCase() ? 5_000_000n : 0n;
+        }
+        if (functionName === "convertToAssets") return (args[0] as bigint) * 2n;
+        if (functionName === "previewDeposit") return (args[0] as bigint) * 3n;
+        throw new Error(`unexpected vault read ${functionName}`);
+      }
+      const token = TOKENS.get(address.toLowerCase());
+      if (token) {
+        if (functionName === "name") return token.name;
+        if (functionName === "symbol") return token.symbol;
+        if (functionName === "decimals") return token.decimals;
+        throw new Error(`unexpected token read ${functionName}`);
+      }
+      throw new Error(`unexpected read of ${address}`);
+    },
+  } as unknown as MossRuntime["client"];
+  return {
+    registry: new Registry({ rpcUrl: "http://offline", client }).use(Morpho),
+    fetchMock,
+  };
+}
+
+function firstChange(entry: ReceiptResult["changes"][number]): Change {
+  if (entry.kind === "change") return entry.change;
+  const [child] = entry.changes;
+  if (child?.kind !== "change") throw new Error("expected one nested ReceiptChange");
+  return child.change;
+}
+
+function erc20Transfer(
+  token: `0x${string}`,
+  from: `0x${string}`,
+  to: `0x${string}`,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: token,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      args: { from, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function erc20Approval(
+  token: `0x${string}`,
+  owner: `0x${string}`,
+  spender: `0x${string}`,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: token,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Approval",
+      args: { owner, spender },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function depositEvent(
+  vault: `0x${string}`,
+  sender: `0x${string}`,
+  onBehalf: `0x${string}`,
+  assets: bigint,
+  shares: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: vault,
+    topics: encodeEventTopics({
+      abi: MorphoVaultV2Abi,
+      eventName: "Deposit",
+      args: { sender, onBehalf },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [assets, shares]),
+  };
+}
+
+function withdrawEvent(
+  vault: `0x${string}`,
+  sender: `0x${string}`,
+  receiver: `0x${string}`,
+  onBehalf: `0x${string}`,
+  assets: bigint,
+  shares: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: vault,
+    topics: encodeEventTopics({
+      abi: MorphoVaultV2Abi,
+      eventName: "Withdraw",
+      args: { sender, receiver, onBehalf },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [assets, shares]),
+  };
+}
+
+function accrueInterest(
+  vault: `0x${string}`,
+  previousTotalAssets: bigint,
+  newTotalAssets: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: vault,
+    topics: encodeEventTopics({
+      abi: MorphoVaultV2Abi,
+      eventName: "AccrueInterest",
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }, { type: "uint256" }, { type: "uint256" }],
+      [previousTotalAssets, newTotalAssets, 0n, 0n],
+    ),
+  };
+}
+
+function removeAdapterEvent(vault: `0x${string}`, adapter: `0x${string}`): Change {
+  return {
+    kind: "event",
+    address: vault,
+    topics: encodeEventTopics({
+      abi: [parseAbiItem("event RemoveAdapter(address indexed adapter)")],
+      eventName: "RemoveAdapter",
+      args: { adapter },
+    }) as readonly Hex[],
+    data: "0x",
+  };
+}

--- a/packages/protocols/morpho/test/types.fixture.ts
+++ b/packages/protocols/morpho/test/types.fixture.ts
@@ -1,0 +1,27 @@
+import type { ActionCtx, CapabilitySpec } from "@themoss/core";
+import { USDC_ADDRESS } from "@themoss/system";
+import type { Morpho } from "../src/index.js";
+
+declare const morpho: Morpho;
+declare const ctx: ActionCtx;
+declare const VAULT: `0x${string}`;
+
+void morpho.deposit({ vault: VAULT, amount: "1.5" }, ctx);
+void morpho.withdraw({ vault: VAULT, amount: "1" }, ctx);
+void morpho.position({ vault: VAULT, owner: USDC_ADDRESS }, ctx);
+void morpho.previewDeposit({ vault: VAULT, amount: "1" }, ctx);
+void morpho.vaults({}, ctx);
+void morpho.vaults({ asset: USDC_ADDRESS }, ctx);
+
+// @ts-expect-error vault is required
+void morpho.deposit({ amount: "1" }, ctx);
+
+// @ts-expect-error amount is a decimal string, not a number
+void morpho.withdraw({ vault: VAULT, amount: 1 }, ctx);
+
+// @ts-expect-error asset must be an address when provided
+void morpho.vaults({ asset: 123 }, ctx);
+
+// @ts-expect-error receipt must name an @Receipt method on Morpho
+const badReceiptName: CapabilitySpec<Morpho>["receipt"] = "nope";
+void badReceiptName;

--- a/packages/protocols/morpho/tsconfig.json
+++ b/packages/protocols/morpho/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test", "scripts"]
+}

--- a/packages/protocols/morpho/vitest.config.ts
+++ b/packages/protocols/morpho/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against workspace sources, not dists, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": src("../../core/src/index.ts"),
+      "@themoss/simulator": src("../../simulator/src/index.ts"),
+      "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/system": src("../../system/src/index.ts"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
+      '@themoss/protocol-morpho':
+        specifier: workspace:*
+        version: link:../protocols/morpho
       '@themoss/simulator':
         specifier: workspace:*
         version: link:../simulator
@@ -181,6 +184,37 @@ importers:
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
   packages/protocols/kuru:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/morpho:
     dependencies:
       '@themoss/core':
         specifier: workspace:*


### PR DESCRIPTION
## What and why

Adds `@themoss/protocol-morpho` — a Morpho **Vaults V2** adapter for Monad mainnet (category `lending`), the full-adapter scope of #9 (deposit/withdraw Capabilities on top of position reading).

- **`vaults` Query** — discovery through the official keyless Morpho GraphQL API (`https://api.morpho.org/graphql`, `vaultV2s`, `listed: true` only). Per ADR 0012 the API supplies **candidates only**: every vault must pass the fixed factory's on-chain `isVaultV2` attestation, and its claimed asset is cross-checked against the on-chain `asset()`; mismatches throw, with no static fallback. Asset address/symbol/decimals and `totalAssets` are read from chain state; API `name`/`netApy`/`totalAssetsUsd` are returned as advisory display data and never become transaction inputs.
- **`position` / `previewDeposit` Queries** — pure on-chain ERC-4626 reads. VaultV2's `maxDeposit/maxMint/maxWithdraw/maxRedeem` always return 0 by design and are never used.
- **`deposit` Capability** (verb `supply`, risk `fundOut, approval`) — nested `erc20.approve` child + exactly one direct `deposit(assets, onBehalf)` transaction. **`withdraw` Capability** (verb `withdraw`, risk `fundOut`) — one direct `withdraw(assets, receiver, onBehalf)` transaction. `receiver`/`onBehalf` are pinned to the acting account so discovery data can never redirect funds to a third party.
- **Receipts** (ADR 0011) — pure decode-or-delegate: exactly one `Deposit`/`Withdraw` typed outcome, `AccrueInterest` as an informational leaf, ERC-20 `Transfer`/`Approval` Changes delegated to the injected `erc20` Protocol, everything else throws. Vaults with a configured `liquidityAdapter` may emit allocation events during execution; v1 deliberately fails loudly on them (simulation surfaces a Warning instead of unverifiable evidence), and discovery surfaces each vault's `liquidityAdapter` so callers can prefer idle-liquidity vaults.

## Type of change

- [x] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

New workspace package `packages/protocols/morpho` plus explicit application composition-root registration (`packages/mcp-server/src/cli.ts`, `package.json`) and README protocol-table rows. No changes to `core`, `simulator`, `erc`, or `system`. Exports: `Morpho`, `MORPHO_VAULT_V2_FACTORY_ADDRESS`, generated `MorphoVaultV2Abi` / `MorphoVaultV2FactoryAbi`, and outcome/summary types.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (full live run: 16/16 in this package; whole workspace green)
- [x] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

### Protocol changes

- [x] Parameters separate reusable Zod value types from field-purpose descriptions
- [x] Every Capability owns one direct TransactionNode and one typed Receipt
- [x] Receipt tests preserve every original Change object in exact length and order
- [x] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [x] Fixed addresses and ABIs include sources and verification — ABIs vendored from `@morpho-org/morpho-ts@2.8.0` (`lib/esm/abis.js`, tarball sha256 in `VENDOR.json`, 7-day release-age guard, byte-for-byte regeneration test); the factory address cites the same SDK's `addresses[143].vaultV2Factory` and is cross-checked against the API's per-vault `factory.address`, with the live test verifying deployed bytecode
- [x] A live Monad happy path returns zero Warnings — live E2E simulates a real deposit **and** withdraw via `debug_traceCall` from API-nominated, chain-confirmed funded accounts (Moss never signs or sends)

## Evidence

Live discovery (2026-07-18): 15 factory-attested vaults returned, e.g. `0x78999cc9…` Hyperithm USDC Apex (USDC, TVL ≈ 26.36M, netApy ≈ 8.44%).

Live deposit simulation (1 USDC into Hyperithm USDC Apex from a chain-confirmed funded holder), `halted: undefined`, all `warnings: []`:

```
--- erc20.approve
outcome: {"operation":"approve","token":"0x754704bc059f8c67012fed69bc8a327a5aafb603","owner":"0x089ACc703D9Fd8b14d6E03D4D38561C1d4672dFd","spender":"0x78999cc96d2Ba0341588C60CcB0E91c6C33CF371","amount":"1000000"}

--- morpho.deposit
receipt text: Morpho Deposit: 1000000 asset units into 0x78999cc96d2Ba0341588C60CcB0E91c6C33CF371 for 975853375997348857 shares
outcome: {"operation":"deposit","protocol":"morpho","vault":"0x78999cc96d2Ba0341588C60CcB0E91c6C33CF371","sender":"0x089ACc703D9Fd8b14d6E03D4D38561C1d4672dFd","onBehalf":"0x089ACc703D9Fd8b14d6E03D4D38561C1d4672dFd","assets":"1000000","shares":"975853375997348857"}
```

The live withdraw simulation in `test/morpho.test.ts` follows the same pattern from a current shareholder and also completes with zero Warnings.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
