### PR TITLE
feat(protocols): add FastLane ShMonad liquid staking adapter

### DIFF
--- a/.changeset/fastlane-shmonad-staking.md
+++ b/.changeset/fastlane-shmonad-staking.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-fastlane": minor
+---
+
+Added FastLane ShMonad liquid staking protocol adapter with stake/unstake capabilities and preview/balance/exchange-rate queries.

--- a/packages/protocols/fastlane/README.md
+++ b/packages/protocols/fastlane/README.md
@@ -1,0 +1,39 @@
+# @themoss/protocol-fastlane
+
+Moss Protocol adapter for **FastLane ShMonad** liquid staking on Monad mainnet.
+
+## What it does
+
+- **stake** — deposit native MON and receive yield-bearing shMON shares
+- **unstake** — redeem shMON for native MON via the atomic exit path
+- **Queries** — previewDeposit, previewRedeem, balanceOf, convertToAssets (exchange rate)
+
+## Verified deployment
+
+| Network | Chain ID | ShMonad proxy |
+|---------|----------|---------------|
+| Monad Mainnet | 143 | `0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c` |
+
+Source: [FastLane official deployment table](https://github.com/FastLane-Labs/fastlane-contracts/blob/main/use-shmonad/references/deployments-and-rpc.md)
+
+## ABI origin
+
+Explorer — retrieved from the Monad mainnet verified-contract page for the ShMonad proxy. Focused subset: ERC-4626 deposit/redeem, previews, ERC-20 metadata, and associated events.
+
+## Usage
+
+```ts
+import { Registry } from "@themoss/core";
+import { FastLane } from "@themoss/protocol-fastlane";
+
+const registry = new Registry(runtime).use(FastLane);
+
+// Stake 1 MON
+const stakeAction = await registry.action("fastlane", "stake", account, {
+  amount: "1",
+  receiver: account,
+});
+
+// Check shMON balance
+const balance = await registry.query("fastlane", "balanceOf", { owner: account });
+```

--- a/packages/protocols/fastlane/package.json
+++ b/packages/protocols/fastlane/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@themoss/protocol-fastlane",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Moss protocol adapter for FastLane shMONAD liquid staking on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/fastlane/src/abis/fastlane.ts
+++ b/packages/protocols/fastlane/src/abis/fastlane.ts
@@ -1,0 +1,36 @@
+// ABI origin: explorer — retrieved from the Monad mainnet block explorer
+// verified-contract page for ShMonad proxy at 0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c.
+// The FastLane official deployment table (use-shmonad/references/deployments-and-rpc.md)
+// confirms this proxy address. Retrieved 2026-07-18.
+//
+// The ABI is a focused subset covering the ERC-4626 deposit, redeem, and
+// associated view functions. Agent operations, policies, validators, and
+// administration selectors are excluded from this Protocol package.
+import { parseAbi } from "viem";
+
+export const ShMonadAbi = parseAbi([
+  // ──── ERC-4626-ish vault (native MON) ────
+  "function deposit(uint256 assets, address receiver) payable returns (uint256 shares)",
+  "function mint(uint256 shares, address receiver) payable returns (uint256 assets)",
+  "function redeem(uint256 shares, address receiver, address owner) returns (uint256 assets)",
+  "function withdraw(uint256 assets, address receiver, address owner) returns (uint256 shares)",
+
+  // ──── Previews & conversions ────
+  "function previewDeposit(uint256 assets) view returns (uint256 shares)",
+  "function previewRedeem(uint256 shares) view returns (uint256 assets)",
+  "function convertToAssets(uint256 shares) view returns (uint256 assets)",
+  "function convertToShares(uint256 assets) view returns (uint256 shares)",
+  "function totalAssets() view returns (uint256)",
+  "function totalSupply() view returns (uint256)",
+
+  // ──── ERC-20 metadata ────
+  "function name() view returns (string)",
+  "function symbol() view returns (string)",
+  "function decimals() view returns (uint8)",
+  "function balanceOf(address owner) view returns (uint256)",
+
+  // ──── Events ────
+  "event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)",
+  "event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares)",
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);

--- a/packages/protocols/fastlane/src/fastlane.ts
+++ b/packages/protocols/fastlane/src/fastlane.ts
@@ -1,0 +1,314 @@
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+} from "@themoss/core";
+import { ERC20 } from "@themoss/erc";
+import { decodeEventLog, formatUnits, parseUnits } from "viem";
+import { ShMonadAbi } from "./abis/fastlane.js";
+import type { FastLaneStakeOutcome, FastLaneUnstakeOutcome } from "./types.js";
+
+// ──── Verified constants ────
+
+/**
+ * FastLane ShMonad proxy on Monad mainnet.
+ *
+ * Source: FastLane official deployment table
+ * (use-shmonad/references/deployments-and-rpc.md, retrieved 2026-07-18).
+ * Confirmed as the canonical proxy for ShMonad on Monad mainnet (chain ID 143).
+ * Verified on-chain: nonempty code at proxy, EIP-1967 implementation slot
+ * matches 0x856a4019228c265dee336df705277607c4a18e1b, name() == "ShMonad",
+ * symbol() == "shMON", decimals() == 18.
+ */
+export const SHMONAD_ADDRESS: AddressValue = "0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c";
+
+const _SHMONAD_TOKEN = { address: SHMONAD_ADDRESS, symbol: "shMON", decimals: 18 } as const;
+
+// ──── Parameter schemas ────
+
+const stakeParams = {
+  amount: {
+    type: PositiveDecimalString,
+    description: "Human-readable native MON amount to stake; MON uses 18 decimals.",
+  },
+  receiver: {
+    type: Address,
+    description: "Address that will receive the minted shMON shares.",
+  },
+} satisfies ParamsSpec;
+
+const unstakeParams = {
+  shares: {
+    type: PositiveDecimalString,
+    description: "Human-readable shMON share amount to unstake; shMON uses 18 decimals.",
+  },
+  receiver: {
+    type: Address,
+    description: "Address that will receive the native MON from the unstake.",
+  },
+} satisfies ParamsSpec;
+
+const balanceParams = {
+  owner: { type: Address, description: "Address whose shMON balance is read." },
+} satisfies ParamsSpec;
+
+const exchangeRateParams = {
+  shares: {
+    type: PositiveDecimalString,
+    description: "Human-readable shMON share amount to convert; shMON uses 18 decimals.",
+  },
+} satisfies ParamsSpec;
+
+// ──── Protocol class ────
+
+@Protocol({
+  name: "fastlane",
+  category: "staking",
+  description:
+    "FastLane ShMonad liquid staking: stake native MON for yield-bearing shMON shares and unstake back to MON.",
+  contracts: { shmonad: { abi: ShMonadAbi, addr: SHMONAD_ADDRESS } },
+  protocols: { erc20: ERC20 },
+})
+export class FastLane {
+  declare shmonad: Handle<typeof ShMonadAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  // ──── Capability: stake ────
+
+  @Capability<FastLane, typeof stakeParams>({
+    intent: "Stake native MON to receive yield-bearing shMON from FastLane",
+    verb: "stake",
+    params: stakeParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+    tags: ["lst", "liquid-staking"],
+  })
+  async stake(params: InferParams<typeof stakeParams>) {
+    return [
+      this.shmonad.deposit([parseUnits(params.amount, 18), params.receiver], {
+        value: parseUnits(params.amount, 18),
+      }),
+    ];
+  }
+
+  // ──── Capability: unstake ────
+
+  @Capability<FastLane, typeof unstakeParams>({
+    intent: "Unstake shMON for native MON using the atomic redeem path (may include an atomic fee)",
+    verb: "unstake",
+    params: unstakeParams,
+    receipt: "unstakeReceipt",
+    risk: ["fundOut", "priceImpact"],
+    tags: ["lst", "liquid-staking"],
+  })
+  async unstake(params: InferParams<typeof unstakeParams>, ctx: ActionCtx) {
+    return [this.shmonad.redeem([parseUnits(params.shares, 18), params.receiver, ctx.account])];
+  }
+
+  // ──── Queries ────
+
+  @Query({
+    intent: "Preview how many shMON shares would be received for a given MON deposit",
+    params: {
+      assets: { type: PositiveDecimalString, description: "MON amount to preview." },
+    },
+    tags: ["preview"],
+  })
+  async previewDeposit(params: { assets: string }) {
+    const shares = await this.shmonad.read.previewDeposit([parseUnits(params.assets, 18)]);
+    return { assets: params.assets, shares: formatUnits(shares, 18) };
+  }
+
+  @Query({
+    intent:
+      "Preview how much MON would be received for redeeming a given shMON amount (atomic path)",
+    params: {
+      shares: { type: PositiveDecimalString, description: "shMON share amount to preview." },
+    },
+    tags: ["preview"],
+  })
+  async previewRedeem(params: { shares: string }) {
+    const assets = await this.shmonad.read.previewRedeem([parseUnits(params.shares, 18)]);
+    return { shares: params.shares, assets: formatUnits(assets, 18) };
+  }
+
+  @Query({ intent: "Read a shMON balance", params: balanceParams, tags: ["balance"] })
+  async balanceOf(params: InferParams<typeof balanceParams>) {
+    const balance = await this.shmonad.read.balanceOf([params.owner]);
+    return {
+      token: SHMONAD_ADDRESS,
+      symbol: "shMON",
+      decimals: 18,
+      balance: balance.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Convert shMON shares to MON assets (current exchange rate)",
+    params: exchangeRateParams,
+    tags: ["exchange-rate"],
+  })
+  async convertToAssets(params: InferParams<typeof exchangeRateParams>) {
+    const assets = await this.shmonad.read.convertToAssets([parseUnits(params.shares, 18)]);
+    return {
+      shares: params.shares,
+      assets: formatUnits(assets, 18),
+    };
+  }
+
+  // ──── Receipt: stake ────
+
+  @Receipt()
+  stakeReceipt(changes: readonly Change[]): ReceiptResult<FastLaneStakeOutcome> {
+    let depositEvent: FastLaneStakeOutcome | undefined;
+    let native: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") {
+        if (native) throw new Error("FastLane stake emitted multiple native transfers");
+        native = change;
+        return {
+          kind: "change" as const,
+          change,
+          data: { operation: "nativeTransfer", ...change },
+          text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
+        };
+      }
+
+      let decoded: ReturnType<typeof decodeEventLog<typeof ShMonadAbi>>;
+      try {
+        decoded = decodeEventLog({
+          abi: ShMonadAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error("Unexpected Change: unsupported FastLane event during stake");
+      }
+
+      if (decoded.eventName === "Transfer") {
+        // Mint Transfer (from zero address) — delegate to erc20
+        if (decoded.args.from !== "0x0000000000000000000000000000000000000000") {
+          throw new Error("Unexpected Change: FastLane stake emitted non-mint Transfer");
+        }
+        return this.erc20.changesReceipt([change]);
+      }
+
+      if (decoded.eventName !== "Deposit") {
+        throw new Error(`Unexpected Change: FastLane stake emitted ${decoded.eventName}`);
+      }
+      if (depositEvent) throw new Error("FastLane stake emitted multiple Deposit events");
+      depositEvent = {
+        operation: "stake",
+        depositor: decoded.args.sender,
+        receiver: decoded.args.owner,
+        assets: decoded.args.assets.toString(),
+        shares: decoded.args.shares.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: depositEvent,
+        text: `FastLane Stake: ${depositEvent.assets} MON → ${depositEvent.shares} shMON for ${depositEvent.receiver}`,
+      };
+    });
+
+    if (!depositEvent || !native) {
+      throw new Error("FastLane stake Receipt requires a Deposit event and native transfer");
+    }
+    if (depositEvent.assets !== native.value) {
+      throw new Error("FastLane stake: Deposit assets differ from native transfer value");
+    }
+    const outcome: FastLaneStakeOutcome = depositEvent;
+    return {
+      kind: "receipt",
+      outcome,
+      text: `FastLane Stake: ${outcome.assets} MON → ${outcome.shares} shMON for ${outcome.receiver}`,
+      changes: parsed,
+    };
+  }
+
+  // ──── Receipt: unstake ────
+
+  @Receipt()
+  unstakeReceipt(changes: readonly Change[]): ReceiptResult<FastLaneUnstakeOutcome> {
+    let withdrawEvent: FastLaneUnstakeOutcome | undefined;
+    let native: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") {
+        if (native) throw new Error("FastLane unstake emitted multiple native transfers");
+        native = change;
+        return {
+          kind: "change" as const,
+          change,
+          data: { operation: "nativeTransfer", ...change },
+          text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
+        };
+      }
+
+      let decoded: ReturnType<typeof decodeEventLog<typeof ShMonadAbi>>;
+      try {
+        decoded = decodeEventLog({
+          abi: ShMonadAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error("Unexpected Change: unsupported FastLane event during unstake");
+      }
+
+      if (decoded.eventName === "Transfer") {
+        // Burn Transfer (to zero address) — delegate to erc20
+        if (decoded.args.to !== "0x0000000000000000000000000000000000000000") {
+          throw new Error("Unexpected Change: FastLane unstake emitted non-burn Transfer");
+        }
+        return this.erc20.changesReceipt([change]);
+      }
+
+      if (decoded.eventName !== "Withdraw") {
+        throw new Error(`Unexpected Change: FastLane unstake emitted ${decoded.eventName}`);
+      }
+      if (withdrawEvent) throw new Error("FastLane unstake emitted multiple Withdraw events");
+      withdrawEvent = {
+        operation: "unstake",
+        redeemer: decoded.args.sender,
+        receiver: decoded.args.receiver,
+        assets: decoded.args.assets.toString(),
+        shares: decoded.args.shares.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: withdrawEvent,
+        text: `FastLane Unstake: ${withdrawEvent.shares} shMON → ${withdrawEvent.assets} MON to ${withdrawEvent.receiver}`,
+      };
+    });
+
+    if (!withdrawEvent || !native) {
+      throw new Error("FastLane unstake Receipt requires a Withdraw event and native transfer");
+    }
+    if (withdrawEvent.assets !== native.value) {
+      throw new Error("FastLane unstake: Withdraw assets differ from native transfer value");
+    }
+    const outcome: FastLaneUnstakeOutcome = withdrawEvent;
+    return {
+      kind: "receipt",
+      outcome,
+      text: `FastLane Unstake: ${outcome.shares} shMON → ${outcome.assets} MON to ${outcome.receiver}`,
+      changes: parsed,
+    };
+  }
+}

--- a/packages/protocols/fastlane/src/index.ts
+++ b/packages/protocols/fastlane/src/index.ts
@@ -1,0 +1,3 @@
+export { ShMonadAbi } from "./abis/fastlane.js";
+export { FastLane, SHMONAD_ADDRESS } from "./fastlane.js";
+export type { FastLaneOutcome, FastLaneStakeOutcome, FastLaneUnstakeOutcome } from "./types.js";

--- a/packages/protocols/fastlane/src/types.ts
+++ b/packages/protocols/fastlane/src/types.ts
@@ -1,0 +1,19 @@
+import type { AddressValue } from "@themoss/core";
+
+export type FastLaneStakeOutcome = {
+  operation: "stake";
+  depositor: AddressValue;
+  receiver: AddressValue;
+  assets: string;
+  shares: string;
+};
+
+export type FastLaneUnstakeOutcome = {
+  operation: "unstake";
+  redeemer: AddressValue;
+  receiver: AddressValue;
+  assets: string;
+  shares: string;
+};
+
+export type FastLaneOutcome = FastLaneStakeOutcome | FastLaneUnstakeOutcome;

--- a/packages/protocols/fastlane/test/adapter.test.ts
+++ b/packages/protocols/fastlane/test/adapter.test.ts
@@ -1,0 +1,201 @@
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  Registry,
+} from "@themoss/core";
+import { encodeAbiParameters, encodeEventTopics, getAddress, zeroAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ShMonadAbi } from "../src/abis/fastlane.js";
+import { FastLane, SHMONAD_ADDRESS } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const RECEIVER = getAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
+const ONE_MON = 1_000_000_000_000_000_000n;
+
+describe("FastLane Protocol", () => {
+  it("registers its exported Protocol directly and builds one transaction for stake", async () => {
+    const registry = new Registry(runtime).use(FastLane);
+    const capability = await registry.action("fastlane", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const flat = flattenCapabilityTree(capability);
+    expect(flat[0]?.transaction).toMatchObject({
+      to: SHMONAD_ADDRESS,
+      value: "0xde0b6b3a7640000",
+    });
+    // Exactly one direct transaction
+    expect(flat).toHaveLength(1);
+  });
+
+  it("registers its exported Protocol directly and builds one transaction for unstake", async () => {
+    const registry = new Registry(runtime).use(FastLane);
+    const capability = await registry.action("fastlane", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const flat = flattenCapabilityTree(capability);
+    expect(flat[0]?.transaction).toMatchObject({
+      to: SHMONAD_ADDRESS,
+    });
+    expect(flat).toHaveLength(1);
+  });
+
+  it("parses stake Changes without replacing their objects", async () => {
+    const registry = new Registry(runtime).use(FastLane);
+    const capability = await registry.action("fastlane", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native: Change = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: SHMONAD_ADDRESS,
+      value: ONE_MON.toString(),
+    };
+    // Deposit(sender indexed, owner indexed, assets, shares)
+    const deposit: Change = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Deposit",
+        args: { sender: ACCOUNT, owner: RECEIVER },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [ONE_MON, ONE_MON]),
+    };
+    // Transfer(from indexed, to indexed, value)
+    const mint: Change = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Transfer",
+        args: { from: zeroAddress, to: RECEIVER },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }], [ONE_MON]),
+    };
+
+    const receipt = registry.parseReceipt(capability, [native, deposit, mint]);
+    expect(receipt.outcome).toEqual({
+      operation: "stake",
+      depositor: ACCOUNT,
+      receiver: RECEIVER,
+      assets: ONE_MON.toString(),
+      shares: ONE_MON.toString(),
+    });
+  });
+
+  it("parses unstake Changes without replacing their objects", async () => {
+    const registry = new Registry(runtime).use(FastLane);
+    const capability = await registry.action("fastlane", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native: Change = {
+      kind: "nativeTransfer",
+      from: SHMONAD_ADDRESS,
+      to: RECEIVER,
+      value: ONE_MON.toString(),
+    };
+    // Withdraw(sender indexed, receiver indexed, owner indexed, assets, shares)
+    const withdraw: Change = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Withdraw",
+        args: { sender: ACCOUNT, receiver: RECEIVER, owner: ACCOUNT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [ONE_MON, ONE_MON]),
+    };
+    // Transfer(from indexed, to indexed, value) - burn
+    const burn: Change = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Transfer",
+        args: { from: ACCOUNT, to: zeroAddress },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }], [ONE_MON]),
+    };
+
+    const receipt = registry.parseReceipt(capability, [native, withdraw, burn]);
+    expect(receipt.outcome).toEqual({
+      operation: "unstake",
+      redeemer: ACCOUNT,
+      receiver: RECEIVER,
+      assets: ONE_MON.toString(),
+      shares: ONE_MON.toString(),
+    });
+  });
+
+  it("rejects a stake Receipt with mismatched native transfer and Deposit amounts", async () => {
+    const registry = new Registry(runtime).use(FastLane);
+    const capability = await registry.action("fastlane", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native: Change = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: SHMONAD_ADDRESS,
+      value: (ONE_MON / 2n).toString(), // half of expected
+    };
+    const deposit: Change = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Deposit",
+        args: { sender: ACCOUNT, owner: RECEIVER },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [ONE_MON, ONE_MON]),
+    };
+
+    expect(() => registry.parseReceipt(capability, [native, deposit])).toThrow();
+  });
+
+  it("rejects an unstake Receipt with extra unexpected events", async () => {
+    const registry = new Registry(runtime).use(FastLane);
+    const capability = await registry.action("fastlane", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native: Change = {
+      kind: "nativeTransfer",
+      from: SHMONAD_ADDRESS,
+      to: RECEIVER,
+      value: ONE_MON.toString(),
+    };
+    // Two Withdraw events — should be rejected
+    const withdraw: Change = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Withdraw",
+        args: { sender: ACCOUNT, receiver: RECEIVER, owner: ACCOUNT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [ONE_MON, ONE_MON]),
+    };
+
+    expect(() => registry.parseReceipt(capability, [native, withdraw, withdraw])).toThrow(
+      /multiple Withdraw/,
+    );
+  });
+});

--- a/packages/protocols/fastlane/test/types.fixture.ts
+++ b/packages/protocols/fastlane/test/types.fixture.ts
@@ -1,0 +1,74 @@
+import {
+  Capability,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  type ProtocolRef,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import { FastLane } from "../src/fastlane.js";
+
+const fixtureParams = {
+  amount: { type: UnsignedIntegerString, description: "Fixture amount." },
+} satisfies ParamsSpec;
+
+const validParams: InferParams<typeof fixtureParams> = { amount: "42" };
+// @ts-expect-error Params are inferred as strings, not numbers.
+const invalidParams: InferParams<typeof fixtureParams> = { amount: 42 };
+
+const dependency = null as unknown as ProtocolRef<FastLane>;
+void dependency.stake;
+void dependency.unstake;
+
+@Protocol({
+  name: "valid-dependency-fixture",
+  category: "staking",
+  description: "Compile-time dependency fixture.",
+  contracts: {},
+  protocols: { fastlane: FastLane },
+})
+class ValidDependencyFixture {
+  declare fastlane: ProtocolRef<FastLane>;
+}
+
+// @ts-expect-error Protocol dependencies require a matching typed instance field.
+@Protocol({
+  name: "invalid-dependency-fixture",
+  category: "staking",
+  description: "Compile-time dependency fixture.",
+  contracts: {},
+  protocols: { fastlane: FastLane },
+})
+class InvalidDependencyFixture {}
+
+class ReceiptNameFixture extends FastLane {
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "stake",
+    params: fixtureParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+  })
+  async valid(_: InferParams<typeof fixtureParams>) {
+    return [];
+  }
+
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "stake",
+    params: fixtureParams,
+    // @ts-expect-error Receipt names must reference an @Receipt method.
+    receipt: "missingReceipt",
+    risk: ["fundOut"],
+  })
+  async invalid() {
+    return [];
+  }
+}
+
+void validParams;
+void invalidParams;
+void dependency;
+void ValidDependencyFixture;
+void InvalidDependencyFixture;
+void ReceiptNameFixture;

--- a/packages/protocols/fastlane/tsconfig.json
+++ b/packages/protocols/fastlane/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/fastlane/vitest.config.ts
+++ b/packages/protocols/fastlane/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,28 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
+  packages/protocols/fastlane:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
   packages/protocols/kuru:
     dependencies:
       '@themoss/core':


### PR DESCRIPTION
## Summary

Add `@themoss/protocol-fastlane` — Protocol adapter for FastLane ShMonad liquid staking on Monad mainnet.

## Capabilities
- **stake** — deposit native MON for yield-bearing shMON shares
- **unstake** — redeem shMON for native MON (atomic path)

## Queries
- previewDeposit, previewRedeem, balanceOf, convertToAssets

## Verification
- [x] Verified proxy: `0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c`
- [x] ABI origin: explorer (Monad mainnet verified contract)
- [x] lint / build / typecheck / test:offline all pass
- [x] 6 unit tests + compile-time type fixtures

Closes #12