### PR TITLE
feat: add Chainlink Data Feed query adapter

### DIFF
--- a/.changeset/jolly-plants-kneel.md
+++ b/.changeset/jolly-plants-kneel.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-chainlink": minor
+---
+
+Add a read-only Chainlink Data Feed adapter for Monad.

--- a/packages/protocols/chainlink/README.md
+++ b/packages/protocols/chainlink/README.md
@@ -1,0 +1,114 @@
+# @themoss/protocol-chainlink
+
+Read-only Chainlink Data Feed Protocol adapter for Moss on Monad.
+
+The adapter allows an Agent to read the latest round and metadata from a
+caller-supplied Chainlink Data Feed proxy address.
+
+## Supported Query
+
+### `latestRound`
+
+Reads the latest round from a Chainlink Data Feed.
+
+Input:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `feed` | Address | Chainlink Data Feed proxy address to query |
+
+Output:
+
+| Field | Description |
+| --- | --- |
+| `feed` | Queried Feed proxy address |
+| `description` | Human-readable Feed description |
+| `decimals` | Number of decimals used by the Feed |
+| `version` | Feed proxy version |
+| `roundId` | Latest round identifier |
+| `answer` | Raw signed integer answer |
+| `formattedAnswer` | Answer formatted using Feed decimals |
+| `startedAt` | Round start timestamp |
+| `updatedAt` | Last update timestamp |
+| `answeredInRound` | Round in which the answer was produced |
+
+## Moss Discovery Metadata
+
+- Protocol: `chainlink`
+- Method: `latestRound`
+- Kind: `query`
+- Category: `token`
+- Tags: `oracle`, `price-feed`
+
+This adapter is read-only. It does not construct unsigned transactions,
+move assets, sign messages, or send transactions.
+
+## Example
+
+```typescript
+import { Registry } from "@themoss/core";
+import { Chainlink } from "@themoss/protocol-chainlink";
+import { monadRuntime } from "@themoss/system";
+
+const runtime = await monadRuntime();
+const registry = new Registry(runtime).use(Chainlink);
+
+const account = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+// Official MON / USD Feed used here as an example.
+const feed = "0xBcD78f76005B7515837af6b50c7C52BCf73822fb";
+
+const result = await registry.action(
+  "chainlink",
+  "latestRound",
+  account,
+  { feed },
+);
+
+console.log(result);
+```
+
+## ABI provenance
+
+The committed ABI is the complete verified-contract ABI retrieved from the
+Monad explorer through Etherscan API V2.
+
+The ABI source file records:
+
+- the Feed proxy address;
+- the explorer page;
+- the retrieval date;
+- the `explorer` origin required by Moss ADR 0007.
+
+The generated ABI should not be edited manually or replaced with a
+hand-selected function subset.
+
+## Testing
+
+Run the package checks from the repository root:
+
+```bash
+pnpm --filter @themoss/protocol-chainlink build
+pnpm --filter @themoss/protocol-chainlink typecheck
+pnpm --filter @themoss/protocol-chainlink test
+```
+
+Set `MOSS_SKIP_E2E=1` to skip the live Monad mainnet test.
+
+The live test verifies that the official MON / USD Feed:
+
+- has deployed bytecode;
+- can be queried from Monad mainnet;
+- returns a positive answer;
+- returns a non-zero update timestamp.
+
+## Security and limitations
+
+- The caller supplies the Feed proxy address.
+- This adapter does not maintain a trusted Feed allowlist.
+- Consumers must verify the Feed description and denomination.
+- Consumers must inspect `updatedAt` before using an answer.
+- The adapter does not enforce a maximum staleness period.
+- The adapter does not provide financial or price-validity guarantees.
+- A successful RPC response does not prove that a Feed is suitable for a
+  particular trading, lending, or liquidation decision.

--- a/packages/protocols/chainlink/package.json
+++ b/packages/protocols/chainlink/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@themoss/protocol-chainlink",
+  "version": "0.0.0",
+  "description": "Moss read-only Chainlink price feed adapter for Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/system": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/chainlink/src/abis/aggregator-v3.ts
+++ b/packages/protocols/chainlink/src/abis/aggregator-v3.ts
@@ -1,0 +1,520 @@
+/**
+ * ABI origin: explorer (ADR 0007)
+ * Contract: Chainlink MON / USD Standard Feed proxy
+ * Address: 0xBcD78f76005B7515837af6b50c7C52BCf73822fb
+ * Explorer: https://monadscan.com/address/0xBcD78f76005B7515837af6b50c7C52BCf73822fb#code
+ * Retrieved: 2026-07-18
+ *
+ * Generated from the complete verified-contract ABI returned by
+ * the Etherscan API V2 getabi endpoint for Monad mainnet (chain ID 143).
+ * Do not edit this generated ABI manually.
+ */
+export const aggregatorV3Abi = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_aggregator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_accessController",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "int256",
+        "name": "current",
+        "type": "int256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "roundId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "updatedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "AnswerUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "roundId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "startedBy",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "startedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewRound",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accessController",
+    "outputs": [
+      {
+        "internalType": "contract AccessControllerInterface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "aggregator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_aggregator",
+        "type": "address"
+      }
+    ],
+    "name": "confirmAggregator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "description",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_roundId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAnswer",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint80",
+        "name": "_roundId",
+        "type": "uint80"
+      }
+    ],
+    "name": "getRoundData",
+    "outputs": [
+      {
+        "internalType": "uint80",
+        "name": "roundId",
+        "type": "uint80"
+      },
+      {
+        "internalType": "int256",
+        "name": "answer",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "updatedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint80",
+        "name": "answeredInRound",
+        "type": "uint80"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_roundId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestAnswer",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestRound",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestRoundData",
+    "outputs": [
+      {
+        "internalType": "uint80",
+        "name": "roundId",
+        "type": "uint80"
+      },
+      {
+        "internalType": "int256",
+        "name": "answer",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "updatedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint80",
+        "name": "answeredInRound",
+        "type": "uint80"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "name": "phaseAggregators",
+    "outputs": [
+      {
+        "internalType": "contract AggregatorV2V3Interface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "phaseId",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_aggregator",
+        "type": "address"
+      }
+    ],
+    "name": "proposeAggregator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proposedAggregator",
+    "outputs": [
+      {
+        "internalType": "contract AggregatorV2V3Interface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint80",
+        "name": "_roundId",
+        "type": "uint80"
+      }
+    ],
+    "name": "proposedGetRoundData",
+    "outputs": [
+      {
+        "internalType": "uint80",
+        "name": "roundId",
+        "type": "uint80"
+      },
+      {
+        "internalType": "int256",
+        "name": "answer",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "updatedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint80",
+        "name": "answeredInRound",
+        "type": "uint80"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proposedLatestRoundData",
+    "outputs": [
+      {
+        "internalType": "uint80",
+        "name": "roundId",
+        "type": "uint80"
+      },
+      {
+        "internalType": "int256",
+        "name": "answer",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "updatedAt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint80",
+        "name": "answeredInRound",
+        "type": "uint80"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_accessController",
+        "type": "address"
+      }
+    ],
+    "name": "setController",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+] as const;

--- a/packages/protocols/chainlink/src/chainlink.ts
+++ b/packages/protocols/chainlink/src/chainlink.ts
@@ -1,0 +1,71 @@
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  createHandle,
+  type InferParams,
+  type MossRuntime,
+  type ParamsSpec,
+  Protocol,
+  Query,
+} from "@themoss/core";
+import { formatUnits } from "viem";
+import { aggregatorV3Abi } from "./abis/aggregator-v3.js";
+
+const latestRoundParams = {
+  feed: {
+    type: Address,
+    description: "Chainlink Data Feed proxy address whose latest round should be read.",
+  },
+} satisfies ParamsSpec;
+
+/**
+ * Read-only Chainlink Data Feed adapter.
+ *
+ * The caller supplies a Chainlink Feed proxy address. This Protocol does not
+ * build transactions, move assets, sign messages, or send transactions.
+ */
+@Protocol({
+  name: "chainlink",
+  category: "token",
+  description: "Read Chainlink Data Feed prices and metadata from caller-supplied proxy addresses.",
+  contracts: {},
+})
+export class Chainlink {
+  declare runtime: MossRuntime;
+
+  #feed(feed: AddressValue, account: AddressValue) {
+    return createHandle(aggregatorV3Abi, feed, this.runtime.client, account);
+  }
+
+  @Query({
+    intent: "Read the latest Chainlink Data Feed round",
+    params: latestRoundParams,
+    tags: ["oracle", "price-feed"],
+  })
+  async latestRound(params: InferParams<typeof latestRoundParams>, ctx: ActionCtx) {
+    const feed = this.#feed(params.feed, ctx.account);
+
+    const [description, decimals, version, roundData] = await Promise.all([
+      feed.read.description(),
+      feed.read.decimals(),
+      feed.read.version(),
+      feed.read.latestRoundData(),
+    ]);
+
+    const [roundId, answer, startedAt, updatedAt, answeredInRound] = roundData;
+
+    return {
+      feed: params.feed,
+      description,
+      decimals: Number(decimals),
+      version: version.toString(),
+      roundId: roundId.toString(),
+      answer: answer.toString(),
+      formattedAnswer: formatUnits(answer, Number(decimals)),
+      startedAt: startedAt.toString(),
+      updatedAt: updatedAt.toString(),
+      answeredInRound: answeredInRound.toString(),
+    };
+  }
+}

--- a/packages/protocols/chainlink/src/index.ts
+++ b/packages/protocols/chainlink/src/index.ts
@@ -1,0 +1,2 @@
+export { aggregatorV3Abi } from "./abis/aggregator-v3.js";
+export { Chainlink } from "./chainlink.js";

--- a/packages/protocols/chainlink/test/chainlink.test.ts
+++ b/packages/protocols/chainlink/test/chainlink.test.ts
@@ -1,0 +1,183 @@
+import { type MossRuntime, Registry } from "@themoss/core";
+import { monadRuntime } from "@themoss/system";
+import { getAddress } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { aggregatorV3Abi, Chainlink } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+
+/**
+ * Official Chainlink MON / USD Standard Feed on Monad mainnet.
+ *
+ * Source:
+ * https://data.chain.link/feeds/monad/monad/mon-usd
+ */
+const MON_USD_FEED = getAddress("0xBcD78f76005B7515837af6b50c7C52BCf73822fb");
+
+const FEED = getAddress("0x1111111111111111111111111111111111111111");
+
+describe("Chainlink", () => {
+  it("registers and exposes the latestRound Query", () => {
+    const { registry } = offlineRegistry();
+
+    expect(registry.discover({ protocol: "chainlink" })).toEqual([
+      {
+        protocol: "chainlink",
+        method: "latestRound",
+        kind: "query",
+        category: "token",
+        tags: ["oracle", "price-feed"],
+        summary: "Read the latest Chainlink Data Feed round",
+      },
+    ]);
+
+    const [loaded] = registry.load([
+      {
+        protocol: "chainlink",
+        method: "latestRound",
+      },
+    ]);
+
+    expect(loaded).toMatchObject({
+      protocol: "chainlink",
+      method: "latestRound",
+      kind: "query",
+      category: "token",
+      risk: [],
+      tags: ["oracle", "price-feed"],
+    });
+
+    expect(loaded?.params.feed).toMatchObject({
+      description: expect.stringContaining("proxy address"),
+    });
+  });
+
+  it("reads and formats the latest Feed round", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    const result = await registry.action("chainlink", "latestRound", ACCOUNT, {
+      feed: FEED,
+    });
+
+    expect(result).toEqual({
+      kind: "query",
+      protocol: "chainlink",
+      method: "latestRound",
+      data: {
+        feed: FEED,
+        description: "MON / USD",
+        decimals: 8,
+        version: "4",
+        roundId: "123",
+        answer: "123456789",
+        formattedAnswer: "1.23456789",
+        startedAt: "1700000000",
+        updatedAt: "1700000010",
+        answeredInRound: "123",
+      },
+    });
+
+    expect(readContract).toHaveBeenCalledTimes(4);
+  });
+
+  it("rejects an invalid Feed address before reading RPC data", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    await expect(
+      registry.action("chainlink", "latestRound", ACCOUNT, {
+        feed: "not-an-address",
+      }),
+    ).rejects.toThrow("invalid parameters");
+
+    expect(readContract).not.toHaveBeenCalled();
+  });
+
+  it("exports the complete AggregatorV3 interface", () => {
+    const functionNames = aggregatorV3Abi
+      .filter((item) => item.type === "function")
+      .map((item) => item.name);
+
+    expect(functionNames).toEqual(
+      expect.arrayContaining([
+        "decimals",
+        "description",
+        "version",
+        "getRoundData",
+        "latestRoundData",
+      ]),
+    );
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Chainlink Monad mainnet", () => {
+  it("reads the official MON / USD Feed", { timeout: 60_000 }, async () => {
+    const runtime = await monadRuntime();
+
+    const bytecode = await runtime.client.getCode({
+      address: MON_USD_FEED,
+    });
+
+    expect(bytecode?.length).toBeGreaterThan(2);
+
+    const result = await new Registry(runtime)
+      .use(Chainlink)
+      .action("chainlink", "latestRound", ACCOUNT, {
+        feed: MON_USD_FEED,
+      });
+
+    if (result.kind !== "query") {
+      throw new Error("expected Chainlink Query result");
+    }
+
+    const data = result.data as Record<string, unknown>;
+
+    expect(data).toMatchObject({
+      feed: MON_USD_FEED,
+      description: expect.stringContaining("MON"),
+      decimals: 8,
+    });
+
+    expect(BigInt(String(data.answer))).toBeGreaterThan(0n);
+    expect(BigInt(String(data.updatedAt))).toBeGreaterThan(0n);
+    expect(String(data.formattedAnswer)).not.toBe("");
+  });
+});
+
+function offlineRegistry() {
+  const readContract = vi.fn(
+    async ({ address, functionName }: { address: string; functionName: string }) => {
+      expect(address).toBe(FEED);
+
+      switch (functionName) {
+        case "description":
+          return "MON / USD";
+
+        case "decimals":
+          return 8;
+
+        case "version":
+          return 4n;
+
+        case "latestRoundData":
+          return [123n, 123456789n, 1700000000n, 1700000010n, 123n] as const;
+
+        default:
+          throw new Error(`unexpected Chainlink read: ${functionName}`);
+      }
+    },
+  );
+
+  const client = {
+    readContract,
+  } as unknown as MossRuntime["client"];
+
+  const runtime: MossRuntime = {
+    rpcUrl: "http://offline",
+    client,
+  };
+
+  return {
+    registry: new Registry(runtime).use(Chainlink),
+    readContract,
+  };
+}

--- a/packages/protocols/chainlink/tsconfig.json
+++ b/packages/protocols/chainlink/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/chainlink/vitest.config.ts
+++ b/packages/protocols/chainlink/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,28 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
+  packages/protocols/chainlink:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
   packages/protocols/kuru:
     dependencies:
       '@themoss/core':


### PR DESCRIPTION
## Motivation

Add a small read-only Chainlink Data Feed adapter that allows Moss Agents
to retrieve structured oracle price data on Monad.

The adapter keeps the initial scope focused on a single Query and does not
construct transactions, move assets, sign messages, or send transactions.

## Changes

- Added `@themoss/protocol-chainlink`
- Added the `chainlink.latestRound` Query
- Added support for caller-supplied Chainlink Feed proxy addresses
- Returned Feed metadata and latest round data in a JSON-safe format
- Added formatted price output using the Feed decimals
- Added a complete explorer-sourced ABI with provenance metadata
- Added Registry-based offline tests
- Added a live Monad mainnet test using the official MON / USD Feed
- Added package documentation and a release changeset

## Discovery metadata

- Protocol: `chainlink`
- Method: `latestRound`
- Kind: `query`
- Category: `token`
- Tags: `oracle`, `price-feed`

`token` is used as the closest existing category while the tags provide the
more specific oracle semantics.

## Scope

This PR is limited to the new Chainlink Protocol package, its tests,
documentation, workspace metadata, lockfile update, and changeset.

It does not modify Moss Core, Simulator, MCP registration, wallet behavior,
or transaction execution.

## Security and limitations

- The caller supplies the Feed proxy address.
- The adapter does not maintain a trusted Feed allowlist.
- Consumers should verify the Feed description and denomination.
- Consumers should inspect `updatedAt` before relying on an answer.
- The adapter does not enforce a maximum staleness period.
- The Query does not provide financial or price-validity guarantees.

## Verification

- [x] `pnpm install`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] Root offline test suite
- [x] Chainlink package offline tests
- [x] Chainlink Monad mainnet E2E test
- [x] Changeset status
- [x] Checked that no API key or temporary ABI script is included