### PR TITLE
feat(protocols): add Kintsu staking adapter

### DIFF
--- a/.changeset/calm-monkeys-stake.md
+++ b/.changeset/calm-monkeys-stake.md
@@ -1,0 +1,6 @@
+---
+"@themoss/protocol-kintsu": minor
+"@themoss/mcp-server": patch
+---
+
+Add the Kintsu Adapter for staking MON into sMON, quoting share values, and reading balances on Monad mainnet.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | ERC-20 and native MON | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `allowance`, `metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| Kintsu | `@themoss/protocol-kintsu` | `stake` | `convertToShares`, `convertToAssets`, `balanceOf` |
 
 ## Quickstart
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | ERC-20 与 native MON | `@themoss/erc` | `transfer`、`approve` | `balanceOf`、`allowance`、`metadata` |
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| Kintsu | `@themoss/protocol-kintsu` | `stake` | `convertToShares`、`convertToAssets`、`balanceOf` |
 
 ## 快速开始
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
+    "@themoss/protocol-kintsu": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
     "zod": "^3.25.0",
     "@themoss/erc": "workspace:*",

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import * as erc from "@themoss/erc";
+import * as kintsu from "@themoss/protocol-kintsu";
 import * as kuru from "@themoss/protocol-kuru";
 import * as system from "@themoss/system";
 import { monadRuntime } from "@themoss/system";
@@ -10,7 +11,7 @@ const rpcUrl = process.env.MOSS_RPC_URL;
 const runtime = await monadRuntime({ ...(rpcUrl ? { rpcUrl } : {}) });
 const { server, registry } = createMossServer({
   runtime,
-  protocols: [system, erc, kuru],
+  protocols: [system, erc, kuru, kintsu],
 });
 const catalog = registry.discover();
 console.error(

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "@themoss/core": src("../core/src/index.ts"),
       "@themoss/simulator": src("../simulator/src/index.ts"),
       "@themoss/erc": src("../erc/src/index.ts"),
+      "@themoss/protocol-kintsu": src("../protocols/kintsu/src/index.ts"),
       "@themoss/protocol-kuru": src("../protocols/kuru/src/index.ts"),
       "@themoss/system": src("../system/src/index.ts"),
     },

--- a/packages/protocols/kintsu/README.md
+++ b/packages/protocols/kintsu/README.md
@@ -1,0 +1,20 @@
+# Kintsu Protocol Adapter
+
+Moss adapter for staking native MON with Kintsu on Monad mainnet and receiving sMON shares.
+
+## Supported operations
+
+- `stake`: deposits MON through `deposit(minShares, receiver)` and protects the quote with a configurable slippage limit (default 50 bps).
+- `convertToShares`: quotes sMON for a MON amount.
+- `convertToAssets`: quotes the MON value of sMON shares.
+- `balanceOf`: reads an account's sMON balance.
+
+Kintsu withdrawals are asynchronous (`requestUnlock`, batch processing, then `redeem`) and are deliberately outside this first adapter scope.
+
+## Deployment and ABI
+
+- sMON proxy: `0xA3227C5969757783154C60bF0bC1944180ed81B9`
+- Canonical address: <https://github.com/monad-crypto/protocols/blob/main/mainnet/kintsu.jsonc>
+- ABI: full `143_artifact.json` vendored from `@water-cooler-studios/monad-contracts-core@2.2.0`; see `abis-src/VENDOR.json`.
+
+Moss builds and simulates unsigned transactions only. It never signs or broadcasts them.

--- a/packages/protocols/kintsu/abis-src/StakedMonad.artifact
+++ b/packages/protocols/kintsu/abis-src/StakedMonad.artifact
@@ -1,0 +1,4850 @@
+{
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "receive",
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "DEFAULT_ADMIN_ROLE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "MINIMUM_CONTRIBUTE_THRESHOLD",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_ADD_NODE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_DISABLE_NODE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_FEE_CLAIMER",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_FEE_EXEMPTION",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_FEE_SETTER",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_PAUSE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_REMOVE_NODE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_UPDATE_WEIGHTS",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "ROLE_UPGRADE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "UPGRADE_INTERFACE_VERSION",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "addNode",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "allowance",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "spender",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "approve",
+      "inputs": [
+        {
+          "name": "spender",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "balanceOf",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "batchDepositRequests",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "assets",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "batchSubmissions",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "submissionEpoch",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "activationEpoch",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "batchWithdrawRequests",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "assets",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "calculateStakeDeltas",
+      "inputs": [
+        {
+          "name": "newTotalStaked",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "totalExcess",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "totalDeficit",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "nodeExcesses",
+          "type": "uint96[]",
+          "internalType": "uint96[]"
+        },
+        {
+          "name": "nodeDeficits",
+          "type": "uint96[]",
+          "internalType": "uint96[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "cancelUnlockRequest",
+      "inputs": [
+        {
+          "name": "unlockIndex",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "claimProtocolFees",
+      "inputs": [
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "compound",
+      "inputs": [
+        {
+          "name": "nodeIds",
+          "type": "uint64[]",
+          "internalType": "uint64[]"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "contributeToPool",
+      "inputs": [
+        {
+          "name": "benefactor",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "convertToAssets",
+      "inputs": [
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "assets",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "convertToShares",
+      "inputs": [
+        {
+          "name": "assets",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "currentBatchId",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint40",
+          "internalType": "uint40"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "decimals",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "deposit",
+      "inputs": [
+        {
+          "name": "minShares",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "disableNode",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getAllUserUnlockRequests",
+      "inputs": [
+        {
+          "name": "user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct StakedMonadV2.UnlockRequest[]",
+          "components": [
+            {
+              "name": "shares",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "spotValue",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "batchId",
+              "type": "uint40",
+              "internalType": "uint40"
+            },
+            {
+              "name": "exitFeeInBips",
+              "type": "uint16",
+              "internalType": "uint16"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getDelegator",
+      "inputs": [
+        {
+          "name": "val_id",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "delegator",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "stake",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "acc_reward_per_token",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "rewards",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "delta_stake",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "next_delta_stake",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "delta_epoch",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "next_delta_epoch",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getExitFeeBips",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint16",
+          "internalType": "uint16"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getManagementFeeBips",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint16",
+          "internalType": "uint16"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMintableProtocolShares",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getNodeIds",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getNodes",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct Registry.Node[]",
+          "components": [
+            {
+              "name": "id",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "weight",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "staked",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getRoleAdmin",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWithdrawIds",
+      "inputs": [
+        {
+          "name": "val_id",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint8[]",
+          "internalType": "uint8[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getWithdrawIdsSize",
+      "inputs": [
+        {
+          "name": "val_id",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "grantRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "hasRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "admin",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "initializeFromV1",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "isExitFeeExempt",
+      "inputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "isForceWithdrawPending",
+      "inputs": [
+        {
+          "name": "val_id",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "isNodeDisabled",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "name",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "nodes",
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "id",
+          "type": "uint64",
+          "internalType": "uint64"
+        },
+        {
+          "name": "weight",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "staked",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "pause",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "paused",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "proxiableUUID",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "redeem",
+      "inputs": [
+        {
+          "name": "unlockIndex",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address payable"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "assets",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "removeNode",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "renounceRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "callerConfirmation",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "requestUnlock",
+      "inputs": [
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "minSpotValue",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "spotValue",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "revokeRole",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setExitFee",
+      "inputs": [
+        {
+          "name": "newFee",
+          "type": "uint16",
+          "internalType": "uint16"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setExitFeeExemption",
+      "inputs": [
+        {
+          "name": "user",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "isExempt",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setManagementFee",
+      "inputs": [
+        {
+          "name": "newFee",
+          "type": "uint16",
+          "internalType": "uint16"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "submitBatch",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "supportsInterface",
+      "inputs": [
+        {
+          "name": "interfaceId",
+          "type": "bytes4",
+          "internalType": "bytes4"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "sweep",
+      "inputs": [
+        {
+          "name": "nodeIds",
+          "type": "uint64[]",
+          "internalType": "uint64[]"
+        },
+        {
+          "name": "maxWithdrawsPerNode",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "sweepForced",
+      "inputs": [
+        {
+          "name": "nodeIds",
+          "type": "uint64[]",
+          "internalType": "uint64[]"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "symbol",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "string",
+          "internalType": "string"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalPooled",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalShares",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint96",
+          "internalType": "uint96"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalSupply",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "totalWeight",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "transfer",
+      "inputs": [
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferFrom",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unbondDisableNode",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unpause",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "updateWeights",
+      "inputs": [
+        {
+          "name": "weightDeltas",
+          "type": "tuple[]",
+          "internalType": "struct Registry.WeightDelta[]",
+          "components": [
+            {
+              "name": "nodeId",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "delta",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "isIncreasing",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "upgradeToAndCall",
+      "inputs": [
+        {
+          "name": "newImplementation",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "data",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "payable"
+    },
+    {
+      "type": "function",
+      "name": "userUnlockRequests",
+      "inputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "shares",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "spotValue",
+          "type": "uint96",
+          "internalType": "uint96"
+        },
+        {
+          "name": "batchId",
+          "type": "uint40",
+          "internalType": "uint40"
+        },
+        {
+          "name": "exitFeeInBips",
+          "type": "uint16",
+          "internalType": "uint16"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "viewNodeByNodeId",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "internalType": "uint64"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "node",
+          "type": "tuple",
+          "internalType": "struct Registry.Node",
+          "components": [
+            {
+              "name": "id",
+              "type": "uint64",
+              "internalType": "uint64"
+            },
+            {
+              "name": "weight",
+              "type": "uint96",
+              "internalType": "uint96"
+            },
+            {
+              "name": "staked",
+              "type": "uint96",
+              "internalType": "uint96"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "event",
+      "name": "Approval",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "spender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "BatchSent",
+      "inputs": [
+        {
+          "name": "batchId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "sharesBurnt",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "unstakeValue",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Compounded",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint256",
+          "indexed": true,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Contribution",
+      "inputs": [
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "benefactor",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Deposit",
+      "inputs": [
+        {
+          "name": "staker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "shares",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ExitFeeAdjusted",
+      "inputs": [
+        {
+          "name": "newFee",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "FeesWithdrawn",
+      "inputs": [
+        {
+          "name": "managementFeeShares",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "exitFeeShares",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Initialized",
+      "inputs": [
+        {
+          "name": "version",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "ManagementFeeAdjusted",
+      "inputs": [
+        {
+          "name": "newFee",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NodeAdded",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        },
+        {
+          "name": "index",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NodeDisabled",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NodeRemoved",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NodeUpdated",
+      "inputs": [
+        {
+          "name": "nodeId",
+          "type": "uint64",
+          "indexed": true,
+          "internalType": "uint64"
+        },
+        {
+          "name": "newWeight",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Paused",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleAdminChanged",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "previousAdminRole",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newAdminRole",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleGranted",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RoleRevoked",
+      "inputs": [
+        {
+          "name": "role",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "sender",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Transfer",
+      "inputs": [
+        {
+          "name": "from",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "to",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "UnlockCancelled",
+      "inputs": [
+        {
+          "name": "staker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "unlockId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "UnlockRedeemed",
+      "inputs": [
+        {
+          "name": "staker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "unlockId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "UnlockRequested",
+      "inputs": [
+        {
+          "name": "staker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "unlockId",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "shares",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "spotValue",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "toll",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Unpaused",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Upgraded",
+      "inputs": [
+        {
+          "name": "implementation",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "VirtualSharesSnapshot",
+      "inputs": [
+        {
+          "name": "shares",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AccessControlBadConfirmation",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "AccessControlUnauthorizedAccount",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "neededRole",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ActiveNode",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "AddressEmptyCode",
+      "inputs": [
+        {
+          "name": "target",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "BatchNotSubmitted",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "CancellationWindowClosed",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "DepositOverflow",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "DisabledNode",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "DuplicateNode",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "ERC1967InvalidImplementation",
+      "inputs": [
+        {
+          "name": "implementation",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ERC1967NonPayable",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "ERC20InsufficientAllowance",
+      "inputs": [
+        {
+          "name": "spender",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "allowance",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "needed",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ERC20InsufficientBalance",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "balance",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "needed",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ERC20InvalidApprover",
+      "inputs": [
+        {
+          "name": "approver",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ERC20InvalidReceiver",
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ERC20InvalidSender",
+      "inputs": [
+        {
+          "name": "sender",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ERC20InvalidSpender",
+      "inputs": [
+        {
+          "name": "spender",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "EmptyBatch",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "EnforcedPause",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "ExpectedPause",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "FailedCall",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "FeeTooLarge",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InsufficientPendingWithdrawals",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidInitialization",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidNode",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "MaxPendingWithdrawals",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "MinimumBatchDelay",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "MinimumContributeThreshold",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "MinimumDeposit",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "MinimumUnlock",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NoChange",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NotInitializing",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "PendingWithdrawals",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "PrecompileCallFailed",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "TransferFailed",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "UUPSUnauthorizedCallContext",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "UUPSUnsupportedProxiableUUID",
+      "inputs": [
+        {
+          "name": "slot",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "WithdrawDelay",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "ZeroTotalWeight",
+      "inputs": []
+    }
+  ],
+  "bytecode": {
+    "object": "0x60a060405230608052348015610013575f5ffd5b5061001c610021565b6100d3565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00805468010000000000000000900460ff16156100715760405163f92ee8a960e01b815260040160405180910390fd5b80546001600160401b03908116146100d05780546001600160401b0319166001600160401b0390811782556040519081527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15b50565b608051616fef6100f95f395f8181615280015281816152a9015261547b0152616fef5ff3fe608060405260043610610508575f3560e01c80635c975abb1161029f578063a30fefe111610170578063d6531de5116100d1578063e8ce892211610087578063fb9848e41161006d578063fb9848e41461118e578063fd012e34146111ad578063fde73f7d14611207575f5ffd5b8063e8ce89221461113c578063f75b04041461116f575f5ffd5b8063dd62ed3e116100b7578063dd62ed3e14611099578063df235fe6146110fc578063e29581aa1461111b575f5ffd5b8063d6531de51461104c578063d8a9fe501461107a575f5ffd5b8063bf7df8e011610126578063c4d66de81161010c578063c4d66de814610ffb578063cf5e27431461100e578063d547741f1461102d575f5ffd5b8063bf7df8e014610fc0578063c2fab77414610fe7575f5ffd5b8063a9059cbb11610156578063a9059cbb14610f3a578063ad3cb1cc14610f59578063aedf6d5114610fa1575f5ffd5b8063a30fefe114610ee8578063a4b0b5a314610f1b575f5ffd5b80637a6d59d51161021a57806391d14854116101d057806396c82e57116101b657806396c82e5714610ead578063a0e3cdd614610ec2578063a217fddf14610ed5575f5ffd5b806391d1485414610e3657806395d89b4114610e99575f5ffd5b80638456cb59116102005780638456cb5914610de657806386bb1d6e14610dfa5780638dd09af314610e17575f5ffd5b80637a6d59d514610d6b5780637bde82f214610dc7575f5ffd5b80636ec21cc81161026f578063733897b711610255578063733897b714610cac57806377654f3414610ccb57806378f908e114610d0a575f5ffd5b80636ec21cc814610c3a57806370a0823114610c59575f5ffd5b80635c975abb14610b9e578063615bfc4514610bd457806363311d3d14610be857806369ce6d4714610c1b575f5ffd5b80632a7d8acb116103d957806343abcf32116103545780634ff0241a1161030a578063540a26f3116102f0578063540a26f314610aeb578063573c1ce014610b175780635838b2fe14610b6b575f5ffd5b80634ff0241a14610aa457806352d1902d14610ad7575f5ffd5b80634a797bd51161033a5780634a797bd514610a035780634beae6e314610a325780634f1ef28614610a91575f5ffd5b806343abcf32146109d057806346115383146109ef575f5ffd5b806336568abe116103a95780633b5b47651161038f5780633b5b47651461096f5780633e367afa1461099b5780633f4ba83a146109bc575f5ffd5b806336568abe1461093c5780633a98ef391461095b575f5ffd5b80632a7d8acb146108b05780632f2ff15d146108e3578063313ce56714610902578063337b2b6e1461091d575f5ffd5b80631610247b1161048357806322fd4ad511610439578063248a9ca31161041f578063248a9ca3146107ed57806324f67e181461083a5780632584601f14610859575f5ffd5b806322fd4ad51461079b57806323b872dd146107ce575f5ffd5b80631b8e0db6116104695780631b8e0db6146106ee5780631c3477dd146107215780631c53c2801461074c575f5ffd5b80631610247b1461069c57806318160ddd146106bb575f5ffd5b80630a763da1116104d85780630b52f7b1116104be5780630b52f7b1146106235780630bf14d9b1461064f57806315230e801461067d575f5ffd5b80630a763da1146105c85780630a9f9ee214610602575f5ffd5b806301ffc9a71461051357806306c7dbc41461054757806306fdde0314610588578063095ea7b3146105a9575f5ffd5b3661050f57005b5f5ffd5b34801561051e575f5ffd5b5061053261052d3660046164a8565b61121f565b60405190151581526020015b60405180910390f35b348015610552575f5ffd5b5061057a7f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d881565b60405190815260200161053e565b348015610593575f5ffd5b5061059c6112b7565b60405161053e91906164e7565b3480156105b4575f5ffd5b506105326105c3366004616530565b61138a565b3480156105d3575f5ffd5b506046546105ec90600160601b900464ffffffffff1681565b60405164ffffffffff909116815260200161053e565b34801561060d575f5ffd5b5061062161061c36600461663d565b6113a1565b005b34801561062e575f5ffd5b5061064261063d366004616691565b611402565b60405161053e91906166ac565b34801561065a575f5ffd5b50610532610669366004616691565b60496020525f908152604090205460ff1681565b348015610688575f5ffd5b5061062161069736600461673e565b6114b0565b3480156106a7575f5ffd5b506106216106b636600461676a565b611505565b3480156106c6575f5ffd5b507f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace025461057a565b3480156106f9575f5ffd5b5061057a7f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa81565b61073461072f36600461679c565b611794565b6040516001600160601b03909116815260200161053e565b348015610757575f5ffd5b5061076b61076636600461676a565b611968565b6040805167ffffffffffffffff90941684526001600160601b03928316602085015291169082015260600161053e565b3480156107a6575f5ffd5b5061057a7f902b1971fb3d9217703fb59d9a8bf53ee64da1be6756f20cebc090dd4c37f7d881565b3480156107d9575f5ffd5b506105326107e83660046167c6565b6119ac565b3480156107f8575f5ffd5b5061057a61080736600461676a565b5f9081527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602052604090206001015490565b348015610845575f5ffd5b50610734610854366004616804565b6119d1565b348015610864575f5ffd5b50610532610873366004616835565b67ffffffffffffffff165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed601602052604090205460ff1690565b3480156108bb575f5ffd5b5061057a7f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b881565b3480156108ee575f5ffd5b506106216108fd366004616850565b611d50565b34801561090d575f5ffd5b506040516012815260200161053e565b348015610928575f5ffd5b50610621610937366004616835565b611d93565b348015610947575f5ffd5b50610621610956366004616850565b611ee8565b348015610966575f5ffd5b50610734611f39565b34801561097a575f5ffd5b5061098e610989366004616835565b611f73565b60405161053e9190616873565b3480156109a6575f5ffd5b506109af612062565b60405161053e91906168ad565b3480156109c7575f5ffd5b5061062161206d565b3480156109db575f5ffd5b506106216109ea3660046168e4565b6120a2565b3480156109fa575f5ffd5b50610621612173565b348015610a0e575f5ffd5b50610a22610a1d366004616916565b612680565b60405161053e9493929190616972565b348015610a3d575f5ffd5b50610a71610a4c36600461676a565b604c6020525f90815260409020546001600160601b0380821691600160601b90041682565b604080516001600160601b0393841681529290911660208301520161053e565b610621610a9f3660046169bf565b612728565b348015610aaf575f5ffd5b5061057a7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb81565b348015610ae2575f5ffd5b5061057a612747565b348015610af6575f5ffd5b50610b0a610b05366004616835565b612775565b60405161053e9190616a66565b348015610b22575f5ffd5b50610b36610b31366004616aa7565b6127dc565b604080519788526020880196909652948601939093526060850191909152608084015260a083015260c082015260e00161053e565b348015610b76575f5ffd5b5061057a7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b45181565b348015610ba9575f5ffd5b507fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005460ff16610532565b348015610bdf575f5ffd5b50610734612894565b348015610bf3575f5ffd5b5061057a7fe1777bd22f637fc57eadcf9d877079117b44537a53059b1670036696018f564c81565b348015610c26575f5ffd5b50610621610c35366004616691565b61296e565b348015610c45575f5ffd5b50604654610734906001600160601b031681565b348015610c64575f5ffd5b5061057a610c73366004616691565b6001600160a01b03165f9081527f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00602052604090205490565b348015610cb7575f5ffd5b50610621610cc6366004616835565b612a80565b348015610cd6575f5ffd5b50610a71610ce536600461676a565b604b6020525f90815260409020546001600160601b0380821691600160601b90041682565b348015610d15575f5ffd5b50610d4a610d2436600461676a565b604a6020525f908152604090205467ffffffffffffffff80821691600160401b90041682565b6040805167ffffffffffffffff93841681529290911660208301520161053e565b348015610d76575f5ffd5b5061057a610d85366004616835565b67ffffffffffffffff165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6006020526040902054610100900460ff1690565b348015610dd2575f5ffd5b50610734610de1366004616850565b612b51565b348015610df1575f5ffd5b50610621612d98565b348015610e05575f5ffd5b5061057a69010f0cf064dd5920000081565b348015610e22575f5ffd5b50610621610e31366004616ac3565b612dca565b348015610e41575f5ffd5b50610532610e50366004616850565b5f9182527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602090815260408084206001600160a01b0393909316845291905290205460ff1690565b348015610ea4575f5ffd5b5061059c612eb1565b348015610eb8575f5ffd5b5061057a60045481565b610621610ed0366004616691565b612f02565b348015610ee0575f5ffd5b5061057a5f81565b348015610ef3575f5ffd5b5061057a7f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f53881565b348015610f26575f5ffd5b50610621610f35366004616ae4565b61305d565b348015610f45575f5ffd5b50610532610f54366004616530565b61340a565b348015610f64575f5ffd5b5061059c6040518060400160405280600581526020017f352e302e3000000000000000000000000000000000000000000000000000000081525081565b348015610fac575f5ffd5b50610621610fbb366004616835565b613417565b348015610fcb575f5ffd5b5060485461ffff165b60405161ffff909116815260200161053e565b348015610ff2575f5ffd5b506106216136ca565b610621611009366004616691565b613815565b348015611019575f5ffd5b506106216110283660046168e4565b613c4f565b348015611038575f5ffd5b50610621611047366004616850565b613dcf565b348015611057575f5ffd5b50610532611066366004616835565b60056020525f908152604090205460ff1681565b348015611085575f5ffd5b50610621611094366004616835565b613e12565b3480156110a4575f5ffd5b5061057a6110b3366004616b55565b6001600160a01b039182165f9081527f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace016020908152604080832093909416825291909152205490565b348015611107575f5ffd5b50610734611116366004616916565b613efa565b348015611126575f5ffd5b5061112f613f50565b60405161053e9190616b71565b348015611147575f5ffd5b5061057a7fbb12ed6b435a5fce787412ceb233935082e39147d977bc587eb74d0f97f48d2c81565b34801561117a575f5ffd5b50610621611189366004616ac3565b613fd9565b348015611199575f5ffd5b506107346111a8366004616916565b6140b0565b3480156111b8575f5ffd5b506111cc6111c7366004616530565b6140f0565b604080516001600160601b03958616815294909316602085015264ffffffffff9091169183019190915261ffff16606082015260800161053e565b348015611212575f5ffd5b5060475461ffff16610fd4565b5f7fffffffff0000000000000000000000000000000000000000000000000000000082167f7965db0b0000000000000000000000000000000000000000000000000000000014806112b157507f01ffc9a7000000000000000000000000000000000000000000000000000000007fffffffff000000000000000000000000000000000000000000000000000000008316145b92915050565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0380546060917f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace009161130890616be6565b80601f016020809104026020016040519081016040528092919081815260200182805461133490616be6565b801561137f5780601f106113565761010080835404028352916020019161137f565b820191905f5260205f20905b81548152906001019060200180831161136257829003601f168201915b505050505091505090565b5f33611397818585614148565b5060019392505050565b6113a9614155565b81515f5b818167ffffffffffffffff1610156113fc576113ec848267ffffffffffffffff16815181106113de576113de616c18565b6020026020010151846141b3565b6113f581616c40565b90506113ad565b50505050565b6001600160a01b0381165f908152604d60209081526040808320805482518185028101850190935280835260609492939192909184015b828210156114a5575f84815260209081902060408051608081018252918501546001600160601b038082168452600160601b82041683850152600160c01b810464ffffffffff1691830191909152600160e81b900461ffff166060820152825260019092019101611439565b505050509050919050565b7f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f5386114da81614381565b506001600160a01b03919091165f908152604960205260409020805460ff1916911515919091179055565b61150d614155565b335f908152604d60205260408120805490919082908490811061153257611532616c18565b5f9182526020918290206040805160808101825292909101546001600160601b038082168452600160601b80830490911694840194909452600160c01b810464ffffffffff908116928401839052600160e81b90910461ffff16606084015260465492945092909104909116146115d5576040517fdcb958f400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6115f4825f01516001600160601b0316836060015161ffff1661438b565b90505f81835f01516116069190616c6c565b60408085015164ffffffffff165f908152604c6020908152908290208251808401909352546001600160601b03808216808552600160601b909204168383015290860151929350909190829061165d908390616c6c565b6001600160601b031690525060208101805183919061167d908390616c6c565b6001600160601b0390811690915260408087015164ffffffffff165f908152604c602090815291902084518154928601518416600160601b027fffffffffffffffff00000000000000000000000000000000000000000000000090931690841617919091179055841615905061173657604780548491906002906117119084906201000090046001600160601b0316616c6c565b92506101000a8154816001600160601b0302191690836001600160601b031602179055505b61174085876143bc565b6117573033865f01516001600160601b0316614556565b60405186815233907fd1bbb16d648df2dfd0b1b3d88a5bc3f262e0323d3af8fd678115b4f1e7b4b88a9060200160405180910390a2505050505050565b5f61179d614155565b6001600160601b033411156117de576040517f1132981b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6117e66145e5565b6117ef34613efa565b9050806001600160601b03165f0361181a5760405163a88ee57760e01b815260040160405180910390fd5b826001600160601b0316816001600160601b03161015611866576040517fc635a9f200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b61187982826001600160601b0316614769565b604680543491905f906118969084906001600160601b0316616c8b565b82546101009290920a6001600160601b03818102199093169183160217909155604654600160601b900464ffffffffff165f908152604b60205260408120805434945090926118e791859116616c8b565b92506101000a8154816001600160601b0302191690836001600160601b03160217905550816001600160a01b03167f90890809c654f11d6e72a28fa60149770a0d11ec6c92319d6ceb2bb0a4ea1a15823460405161195a9291906001600160601b03929092168252602082015260400190565b60405180910390a292915050565b60038181548110611977575f80fd5b5f9182526020909120015467ffffffffffffffff811691506001600160601b03600160401b8204811691600160a01b90041683565b5f336119b98582856147b6565b6119c4858585614556565b60019150505b9392505050565b5f6119da614155565b6119e26145e5565b335f90815260496020526040812054819060ff16611a195760475461ffff169150611a166001600160601b0386168361438b565b90505b5f611a248287616c6c565b9050611a2f816140b0565b9350836001600160601b03165f03611a5a5760405163a88ee57760e01b815260040160405180910390fd5b846001600160601b0316846001600160601b03161015611aa6576040517f641963a400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b604654335f908152604d6020908152604080832081516080810183526001600160601b03808d1682528a811682860190815264ffffffffff600160601b98899004811684870181815261ffff808f16606088019081528854600181018a55988c528a8c209751979098018054955192519851909116600160e81b027fff0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff98909416600160c01b02979097167fff00000000000000ffffffffffffffffffffffffffffffffffffffffffffffff9186168c027fffffffffffffffff0000000000000000000000000000000000000000000000009095169686169690961793909317929092169390931792909217909255808552604c8452938290208251808401909352548082168084529590041691810191909152909186908290611bea908390616c8b565b6001600160601b0316905250602081018051849190611c0a908390616c8b565b6001600160601b0390811690915264ffffffffff84165f908152604c6020908152604090912084518154928601518416600160601b027fffffffffffffffff000000000000000000000000000000000000000000000000909316908416179190911790558516159050611cc05760478054859190600290611c9b9084906201000090046001600160601b0316616c8b565b92506101000a8154816001600160601b0302191690836001600160601b031602179055505b611cd433308a6001600160601b0316614556565b335f818152604d60205260409020547fef31107568890496c8f16fec1278e709d23f1444e004e7973a9403880c28d91790611d1190600190616caa565b604080519182526001600160601b038088166020840152808b1691830191909152871660608201526080015b60405180910390a2505050505092915050565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b6268006020526040902060010154611d8981614381565b6113fc8383614864565b611d9b614930565b611daf5f67ffffffffffffffff831661495a565b15155f03611de9576040517f0fa1af0e00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b604080516060810182525f602080830182815283850183815267ffffffffffffffff8781168087526003805460018101825581885288517fc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b9091018054965195519190941673ffffffffffffffffffffffffffffffffffffffff1990961695909517600160401b6001600160601b0395861602176001600160a01b0316600160a01b94909516939093029390931790555481845260028352928590208390558451908152908101829052919290917fdd8aaf98a662995c3720dc78ea3773142e7d32c94f523a7d651e932ba0c44f8a91015b60405180910390a1505050565b6001600160a01b0381163314611f2a576040517f6697b23200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b611f348282614965565b505050565b5f611f42612894565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0254611f6e9190616c8b565b905090565b60605f7fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60067ffffffffffffffff8085165f9081526020838152604080832081518083019092525460ff8082168352610100909104169181018290529394509091811115611fe257611fe261655a565b60405190808252806020026020018201604052801561200b578160200160208202803683370190505b5090505f5b826020015160ff1681101561205957825161202d908260ff614a09565b82828151811061203f5761203f616c18565b60ff90921660209283029190910190910152600101612010565b50949350505050565b6060611f6e5f614a32565b7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb61209781614381565b61209f614a3e565b50565b6120aa614155565b805147905f5b818167ffffffffffffffff1610156120fe576120ee848267ffffffffffffffff16815181106120e1576120e1616c18565b6020026020010151614ab0565b6120f781616c40565b90506120b0565b505f61210a8347616caa565b905080156113fc57604654600160601b900464ffffffffff165f908152604b6020526040812080548392906121499084906001600160601b0316616c8b565b92506101000a8154816001600160601b0302191690836001600160601b0316021790555050505050565b61217b614155565b6121836145e5565b6046546001600160601b03811690600160601b900464ffffffffff165f806121a9614c16565b90925090505f604a816121bd600187616cbd565b64ffffffffff16815260208082019290925260409081015f2081518083019092525467ffffffffffffffff8082168352600160401b90910481169282018390529092508416101561223a576040517f4851faea00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b64ffffffffff84165f818152604b602090815260408083208151808301835290546001600160601b038082168352600160601b91829004811683860152958552604c8452828520835180850190945254808716808552919004861693830193909352805190949193929116111561234a57825182515f916122bb918b614c51565b835185519192505f9183916122cf91616c6c565b6122d99190616c6c565b90506001600160601b038116156123335780604b5f6122f98c6001616cda565b64ffffffffff16815260208101919091526040015f2080546bffffffffffffffffffffffff19166001600160601b03929092169190911790555b505067ffffffffffffffff8516602085015261245e565b825182516001600160601b039182169116111561240a57815183515f91612371918b614e72565b8451845191925082916123849190616c6c565b61238e9190616c6c565b91506001600160601b038216156123f45781604c5f6123ae8b6001616cda565b64ffffffffff16815260208101919091526040015f2080546bffffffffffffffffffffffff19166001600160601b03929092169190911790556123f1828a616c8b565b98505b5067ffffffffffffffff8516602085015261245e565b82516001600160601b03165f0361244d576040517fc2e5347d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b67ffffffffffffffff861660208501525b60208201516001600160601b031615612488576124883083602001516001600160601b0316615049565b81516001600160601b0316156124ca5781516124a49089616c6c565b604680546bffffffffffffffffffffffff19166001600160601b03929092169190911790555b6040805160608101825260475461ffff811682526001600160601b03620100008204811660208401819052600160701b9092041692820192909252901561257f578060200151816040018181516125219190616c8b565b6001600160601b039081169091525f60208401528251604780546040860151909316600160701b027fffffffffffff000000000000000000000000000000000000000000000000000090931661ffff90921691909117919091179055505b67ffffffffffffffff808816865264ffffffffff89165f908152604a6020908152604090912087518154928901518416600160401b027fffffffffffffffffffffffffffffffff000000000000000000000000000000009093169316929092171790556125ed886001616cda565b6046600c6101000a81548164ffffffffff021916908364ffffffffff1602179055507f0d52fcac1f24e16d612d7f4768640d2ec9407f68e8c172ec01887a96b068b9da88846020015184865f01516126459190616c6c565b6040805164ffffffffff90941684526001600160601b03928316602085015291169082015260600160405180910390a1505050505050505050565b5f5f6060806127196003805480602002602001604051908101604052809291908181526020015f905b82821015612706575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b90910416908201528252600190920191016126a9565b50505050866001600160601b0316615096565b93509350935093509193509193565b612730615275565b61273982615345565b612743828261536f565b5050565b5f612750615470565b507f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc90565b604080516060810182525f808252602082018190529181019190915261279a826154d2565b60408051606081018252915467ffffffffffffffff811683526001600160601b03600160401b820481166020850152600160a01b909104169082015292915050565b6040517f573c1ce000000000000000000000000000000000000000000000000000000000815267ffffffffffffffff831660048201526001600160a01b03821660248201525f908190819081908190819081906110009063573c1ce09060440160e0604051808303815f875af1158015612858573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061287c9190616cf7565b959f949e50929c50909a509850965090945092505050565b6040805160608101825260485461ffff811682526201000081046001600160601b031660208301819052600160701b90910464ffffffffff16928201839052915f906128e09042616caa565b90508015612969575f612933846001600160601b031661291e7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace025490565b6129289190616d46565b845161ffff1661438b565b6001600160601b031690505f6301e1338061294e8484616d59565b6129589190616d84565b90506129648186616c8b565b945050505b505090565b612976614155565b7f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d86129a081614381565b6129a86145e5565b6048546201000090046001600160601b031680156129f3576129ca8382614769565b604880547fffffffffffffffffffffffffffffffffffff000000000000000000000000ffff1690555b604754600160701b90046001600160601b03168015612a4057612a17308583614556565b604780547fffffffffffff000000000000000000000000ffffffffffffffffffffffffffff1690555b60408051838152602081018390527fd9787bf70d3926a4a81c52cba8799d18903ce0132aaa4b7de9e92dc893303a7f91015b60405180910390a150505050565b612a88614155565b7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b451612ab281614381565b67ffffffffffffffff82165f9081526005602052604090205460ff16612aeb5760405163194fdc7f60e31b815260040160405180910390fd5b5f612af5836154d2565b8054909150600160a01b90046001600160601b03165f819003612b2b5760405163a88ee57760e01b815260040160405180910390fd5b612b3e84826001600160601b0316615551565b505080546001600160a01b031690555050565b5f612b5a614155565b335f908152604d602052604081208054909190829086908110612b7f57612b7f616c18565b5f91825260208083206040805160808101825293909101546001600160601b038082168552600160601b82041684840152600160c01b810464ffffffffff16848301819052600160e81b90910461ffff1660608501528452604a825280842081518083019092525467ffffffffffffffff808216808452600160401b9092041692820192909252919350909103612c42576040517ffc08f5f200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f612c4b615620565b509050612c5661568c565b60ff168260200151612c689190616d97565b67ffffffffffffffff168167ffffffffffffffff161015612cb5576040517fba9bead700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b612cbf84886143bc565b826020015194505f866001600160a01b0316866001600160601b03166040515f6040518083038185875af1925050503d805f8114612d18576040519150601f19603f3d011682016040523d82523d5f602084013e612d1d565b606091505b5050905080612d58576040517f90b8ec1800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b604080518981526001600160601b038816602082015233917f53a80b7fa2025e3acb298abd7e222b36ce5d6a1425e7a6e53b451aac0c6e5a219101611d3d565b7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb612dc281614381565b61209f6156bf565b7f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa612df481614381565b60c88261ffff161115612e33576040517ffc5bee1200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60485461ffff90811690831603612e5d5760405163a88ee57760e01b815260040160405180910390fd5b612e656145e5565b6048805461ffff191661ffff84169081179091556040519081527f756367c310578acc96b78fcf4141ddb3cf532982d1342ec193f34a3600b9ae65906020015b60405180910390a15050565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0480546060917f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace009161130890616be6565b612f0a614155565b6001600160601b03341115612f4b576040517f1132981b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6046546001600160601b031669010f0cf064dd59200000811015612f9b576040517f500625f400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b612fa53482616c8b565b604680546bffffffffffffffffffffffff19166001600160601b039283161790819055600160601b900464ffffffffff165f908152604b6020526040812080543493919291612ff691859116616c8b565b92506101000a8154816001600160601b0302191690836001600160601b031602179055507f04e75fda068b8e114d7658bdff74280a0fd65586b7e026a034eae29dd5a9e68b3483604051612ea59291909182526001600160a01b0316602082015260400190565b61306561571a565b600454815f5b818110156134015784848281811061308557613085616c18565b905060600201604001602081019061309d9190616db7565b15613238575f6130d38686848181106130b8576130b8616c18565b6130ce9260206060909202019081019150616835565b6154d2565b805467ffffffffffffffff165f9081526005602052604090205490915060ff161561312a576040517f1db1d0c400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8054600160401b90046001600160601b03165f87878581811061314f5761314f616c18565b90506060020160200160208101906131679190616916565b6131719083616c8b565b835473ffffffffffffffffffffffff00000000000000001916600160401b6001600160601b038381169182029290921786559192506131b290841688616caa565b6131bc9190616d46565b95508787858181106131d0576131d0616c18565b6131e69260206060909202019081019150616835565b6040516001600160601b038316815267ffffffffffffffff91909116907fcfaa637aecf1e60e723842980c95e1f0a7ca0a264e46647e4656b98f7293e33b9060200160405180910390a25050506133f9565b5f60025f87878581811061324e5761324e616c18565b6132649260206060909202019081019150616835565b67ffffffffffffffff1667ffffffffffffffff1681526020019081526020015f20549050805f0361329557506133f9565b5f60036132a3600184616caa565b815481106132b3576132b3616c18565b5f91825260208220018054909250600160401b90046001600160601b0316908181036132e257505050506133f9565b5f8989878181106132f5576132f5616c18565b905060600201602001602081019061330d9190616916565b9050826001600160601b0316816001600160601b03161015613336576133338184616c6c565b91505b83546001600160601b03808416600160401b810273ffffffffffffffffffffffff0000000000000000199093169290921786556133759085168a616caa565b61337f9190616d46565b975089898781811061339357613393616c18565b6133a99260206060909202019081019150616835565b6040516001600160601b038416815267ffffffffffffffff91909116907fcfaa637aecf1e60e723842980c95e1f0a7ca0a264e46647e4656b98f7293e33b9060200160405180910390a250505050505b60010161306b565b50506004555050565b5f33611397818585614556565b61342081615744565b67ffffffffffffffff81165f9081526002602052604081205490819003613473576040517f30812d4200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6003613481600184616caa565b8154811061349157613491616c18565b5f91825260209182902060408051606081018252929091015467ffffffffffffffff811683526001600160601b03600160401b82048116948401859052600160a01b90910416908201529150156134fb5760405163194fdc7f60e31b815260040160405180910390fd5b60408101516001600160601b0316156135275760405163194fdc7f60e31b815260040160405180910390fd5b600380545f919061353a90600190616caa565b8154811061354a5761354a616c18565b5f9182526020808320909101805467ffffffffffffffff168352600290915260409091208490559050806003613581600186616caa565b8154811061359157613591616c18565b5f918252602080832084549201805467ffffffffffffffff9384167fffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000821681178355865473ffffffffffffffffffffffffffffffffffffffff1990921617600160401b918290046001600160601b039081169092021780835595546001600160a01b03909616600160a01b96879004909116909502949094179093558616815260029091526040812055600380548061364c5761364c616dd2565b5f8281526020812082015f199081018290559091019091556136789067ffffffffffffffff8616615858565b5067ffffffffffffffff84165f81815260056020908152604091829020805460ff1916905590519182527f8712d9d347359238729023dc8640e38f0d4f8ad25d0e079c2208a885a51a023f9101612a72565b6001806136d5615863565b67ffffffffffffffff161461374b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601c60248201527f4578706563746564206120646966666572656e742076657273696f6e0000000060448201526064015b60405180910390fd5b60025f61375661587c565b8054909150600160401b900460ff168061377e5750805467ffffffffffffffff808416911610155b156137b5576040517ff92ee8a900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b805468ffffffffffffffffff191667ffffffffffffffff8316908117600160401b1768ff0000000000000000191682556040519081527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d290602001611edb565b60025f61382061587c565b8054909150600160401b900460ff16806138485750805467ffffffffffffffff808416911610155b1561387f576040517ff92ee8a900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b805468ffffffffffffffffff191667ffffffffffffffff831617600160401b1781556138a96158a4565b6138b16158a4565b6139256040518060400160405280601381526020017f4b696e747375205374616b6564204d6f6e6164000000000000000000000000008152506040518060400160405280600481526020017f734d4f4e000000000000000000000000000000000000000000000000000000008152506158ac565b61392d6158a4565b6139356158a4565b61393f5f84614864565b5061396a7f902b1971fb3d9217703fb59d9a8bf53ee64da1be6756f20cebc090dd4c37f7d884614864565b506139957fe1777bd22f637fc57eadcf9d877079117b44537a53059b1670036696018f564c84614864565b506139c07fbb12ed6b435a5fce787412ceb233935082e39147d977bc587eb74d0f97f48d2c84614864565b506139eb7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b45184614864565b50613a167f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa84614864565b50613a417f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa806158be565b613a6b7f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d884614864565b50613a967f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d8806158be565b613ac07f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f53884614864565b50613aeb7f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f538806158be565b613b157f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b884614864565b50613b407f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b8806158be565b613b6a7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb84614864565b50604680547fffffffffffffffffffffffffffffff0000000000ffffffffffffffffffffffff16600160601b1790556040805160608101825260c88082525f60208301524264ffffffffff1691830182905260488054600160701b9093027fffffffffffffffffffffffffff00000000000000000000000000000000000000909316929092171790556047805461ffff19166005179055815468ff000000000000000019168255517fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d290611edb90849067ffffffffffffffff91909116815260200190565b613c57614155565b80515f904790825b818167ffffffffffffffff161015613d4057613c9d858267ffffffffffffffff1681518110613c9057613c90616c18565b602002602001015161595f565b5f84613ca98547616caa565b613cb39190616caa565b90508015613d2f57613cc58186616d46565b9450858267ffffffffffffffff1681518110613ce357613ce3616c18565b602002602001015167ffffffffffffffff167f8082b0dab6d73a8025e5f15e4fdd54b68197a613e361810d4a2446c634b98ada82604051613d2691815260200190565b60405180910390a25b50613d3981616c40565b9050613c5f565b50825f03613d615760405163a88ee57760e01b815260040160405180910390fd5b604680548491905f90613d7e9084906001600160601b0316616c8b565b82546101009290920a6001600160601b03818102199093169183160217909155604654600160601b900464ffffffffff165f908152604b602052604081208054879450909261214991859116616c8b565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b6268006020526040902060010154613e0881614381565b6113fc8383614965565b613e1a615a04565b67ffffffffffffffff81165f9081526005602052604090205460ff1615613e545760405163a88ee57760e01b815260040160405180910390fd5b5f613e5e826154d2565b805460048054929350600160401b9091046001600160601b0316915f90613e86908490616caa565b9091555050805473ffffffffffffffffffffffff00000000000000001916815567ffffffffffffffff82165f81815260056020908152604091829020805460ff1916600117905590519182527fa46b2e9bd92f27216c46d5a9772c39431f3f381285ee1dacb1f1034fe603b10b9101612ea5565b6046545f906001600160601b0316808203613f1757829150613f4a565b80613f20611f39565b6001600160601b0316846001600160601b0316613f3d9190616d59565b613f479190616d84565b91505b50919050565b60606003805480602002602001604051908101604052809291908181526020015f905b82821015613fd0575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b9091041690820152825260019092019101613f73565b50505050905090565b7f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa61400381614381565b60328261ffff161115614042576040517ffc5bee1200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60475461ffff9081169083160361406c5760405163a88ee57760e01b815260040160405180910390fd5b6047805461ffff191661ffff84169081179091556040519081527f0531f91c02fe1dc8b306233f5edba5c1b65a79a064d26a40b6082bc9d887ecba90602001612ea5565b5f5f6140ba611f39565b6001600160601b03169050805f036140d457829150613f4a565b6046548190613f3d906001600160601b03908116908616616d59565b604d602052815f5260405f208181548110614109575f80fd5b5f918252602090912001546001600160601b038082169350600160601b8204169150600160c01b810464ffffffffff1690600160e81b900461ffff1684565b611f348383836001615a2e565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005460ff16156141b1576040517fd93c066500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b5f7fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60067ffffffffffffffff84165f9081526020828152604080832081518083019092525460ff8082168352610100909104811692820183905293945092851610614221578160200151614223565b835b90508060ff165f03614236575050505050565b5f5b8160ff1681101561430e575f614253845f01518360ff614a09565b6040517faed2ee7300000000000000000000000000000000000000000000000000000000815267ffffffffffffffff8916600482015260ff821660248201529091505f906110009063aed2ee73906044016020604051808303815f875af11580156142c0573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906142e49190616de6565b90508061430457604051633f48ffd960e21b815260040160405180910390fd5b5050600101614238565b50815161431d908260ff614a09565b60ff168252602082018051829190614336908390616e01565b60ff90811690915267ffffffffffffffff9096165f90815260209485526040902083518154959094015187166101000261ffff19909516939096169290921792909217909355505050565b61209f8133615b57565b5f61271061439a600182616e1a565b61ffff166143a88486616d59565b6143b29190616d46565b6119ca9190616d84565b81545f906143cc90600190616caa565b9050808214614509578281815481106143e7576143e7616c18565b905f5260205f200183838154811061440157614401616c18565b5f91825260209091208254910180546bffffffffffffffffffffffff1981166001600160601b0393841690811783558454600160601b908190049094169093027fffffffffffffffff00000000000000000000000000000000000000000000000090911690921791909117808255825464ffffffffff600160c01b9182900416027fffffff0000000000ffffffffffffffffffffffffffffffffffffffffffffffff821681178355925461ffff600160e81b9182900416027fff0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9093167fff00000000000000ffffffffffffffffffffffffffffffffffffffffffffffff909116179190911790555b8280548061451957614519616dd2565b5f8281526020902081015f1990810180547fff00000000000000000000000000000000000000000000000000000000000000169055019055505050565b6001600160a01b038316614598576040517f96c6fd1e0000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6001600160a01b0382166145da576040517fec442f050000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b611f34838383615be3565b6040805160608101825260485461ffff811682526201000081046001600160601b03166020830152600160701b900464ffffffffff16918101829052905f9061462e9042616caa565b90508015612743575f61467083602001516001600160601b031661291e7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace025490565b6001600160601b031690505f6301e1338061468b8484616d59565b6146959190616d84565b90508084602001516001600160601b03166146b09190616d46565b6001600160601b031660208581018290524264ffffffffff16604080880182905287516048805461ffff9092167fffffffffffffffffffffffffffffffffffff000000000000000000000000000090921691909117620100008602177fffffffffffffffffffffffffff0000000000ffffffffffffffffffffffffffff16600160701b90930292909217909155519182527f178c79c1e1bedefddc7aaa1aa24d6c1cee56301d2d4d9aa8cee048cab9552fc19101612a72565b6001600160a01b0382166147ab576040517fec442f050000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6127435f8383615be3565b6001600160a01b038381165f9081527f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0160209081526040808320938616835292905220545f198110156113fc5781811015614856576040517ffb8f41b20000000000000000000000000000000000000000000000000000000081526001600160a01b03841660048201526024810182905260448101839052606401613742565b6113fc84848484035f615a2e565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602081815260408084206001600160a01b038616855290915282205460ff16614927575f848152602082815260408083206001600160a01b03871684529091529020805460ff191660011790556148dd3390565b6001600160a01b0316836001600160a01b0316857f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a460019150506112b1565b5f9150506112b1565b7f902b1971fb3d9217703fb59d9a8bf53ee64da1be6756f20cebc090dd4c37f7d861209f81614381565b5f6119ca8383615d48565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602081815260408084206001600160a01b038616855290915282205460ff1615614927575f848152602082815260408083206001600160a01b0387168085529252808320805460ff1916905551339287917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a460019150506112b1565b5f8160ff168360ff168560ff16614a209190616d46565b614a2a9190616e34565b949350505050565b60605f6119ca83615d94565b614a46615ded565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300805460ff191681557f5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa335b6040516001600160a01b03909116815260200160405180910390a150565b67ffffffffffffffff81165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60160205260409020547fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6009060ff16614b43576040517f78297a8c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040517faed2ee7300000000000000000000000000000000000000000000000000000000815267ffffffffffffffff8316600482015260ff60248201525f906110009063aed2ee73906044016020604051808303815f875af1158015614bab573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190614bcf9190616de6565b905080614bef57604051633f48ffd960e21b815260040160405180910390fd5b5067ffffffffffffffff9091165f908152600190910160205260409020805460ff19169055565b5f5f5f5f614c22615620565b9150915081935080614c3e57614c39846001616d97565b614c49565b614c49846002616d97565b925050509091565b6004545f90808203614c8f576040517f098404de00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6003805480602002602001604051908101604052809291908181526020015f905b82821015614d0e575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b9091041690820152825260019092019101614cb1565b5050505090505f5f614d34838888614d269190616c6c565b6001600160601b0316615096565b9350509250505f8789614d479190616c6c565b6001600160601b031690505f845190505f5b81811015614e64575f856001600160601b0316858381518110614d7e57614d7e616c18565b60200260200101516001600160601b031685614d9a9190616d59565b614da49190616d84565b90506001600160601b03811615614e5b5780878381518110614dc857614dc8616c18565b602002602001015160400151614dde9190616c8b565b60038381548110614df157614df1616c18565b905f5260205f20015f0160146101000a8154816001600160601b0302191690836001600160601b03160217905550614e4e878381518110614e3457614e34616c18565b60200260200101515f0151826001600160601b0316615e48565b614e58818a616c8b565b98505b50600101614d59565b505050505050509392505050565b5f5f6003805480602002602001604051908101604052809291908181526020015f905b82821015614ef2575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b9091041690820152825260019092019101614e95565b5050505090505f5f614f0a838887614d269190616c6c565b5092505091505f8688614f1d9190616c6c565b6001600160601b031690505f845190505f5b8181101561503c575f856001600160601b0316858381518110614f5457614f54616c18565b60200260200101516001600160601b031685614f709190616d59565b614f7a9190616d84565b90506001600160601b038116156150335780878381518110614f9e57614f9e616c18565b602002602001015160400151614fb49190616c6c565b60038381548110614fc757614fc7616c18565b5f91825260209091200180546001600160601b0392909216600160a01b026001600160a01b039092169190911790556150008189616c8b565b975061503187838151811061501757615017616c18565b60200260200101515f0151826001600160601b0316615ef0565b505b50600101614f2f565b5050505050509392505050565b6001600160a01b03821661508b576040517f96c6fd1e0000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b612743825f83615be3565b60045482515f91829160609182918067ffffffffffffffff8111156150bd576150bd61655a565b6040519080825280602002602001820160405280156150e6578160200160208202803683370190505b5093508067ffffffffffffffff8111156151025761510261655a565b60405190808252806020026020018201604052801561512b578160200160208202803683370190505b5092505f5b81811015615269575f89828151811061514b5761514b616c18565b6020026020010151604001516001600160601b031690505f5f8511615170575f6151ad565b848b848151811061518357615183616c18565b6020026020010151602001516001600160601b03168b6151a39190616d59565b6151ad9190616d84565b905080821115615209575f6151c28284616caa565b90506151ce818b616c8b565b9950808885815181106151e3576151e3616c18565b60200260200101906001600160601b031690816001600160601b0316815250505061525f565b8181111561525f575f61521c8383616caa565b9050615228818a616c8b565b98508087858151811061523d5761523d616c18565b60200260200101906001600160601b031690816001600160601b031681525050505b5050600101615130565b50505092959194509250565b306001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016148061530e57507f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166153027f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc546001600160a01b031690565b6001600160a01b031614155b156141b1576040517fe07c8dba00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b861274381614381565b816001600160a01b03166352d1902d6040518163ffffffff1660e01b8152600401602060405180830381865afa9250505080156153c9575060408051601f3d908101601f191682019092526153c691810190616e47565b60015b61540a576040517f4c9c8ce30000000000000000000000000000000000000000000000000000000081526001600160a01b0383166004820152602401613742565b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8114615466576040517faa1d49a400000000000000000000000000000000000000000000000000000000815260048101829052602401613742565b611f34838361600e565b306001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016146141b1576040517fe07c8dba00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b67ffffffffffffffff81165f90815260026020526040812054808203615524576040517f30812d4200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6003615531600183616caa565b8154811061554157615541616c18565b905f5260205f2001915050919050565b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60160205260408120547fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6009060ff16156155e5576040517f500389a000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60ff91506155f4848484616063565b67ffffffffffffffff9093165f908152600193840160205260409020805460ff19169093179092555090565b5f5f6110006001600160a01b031663757991a86040518163ffffffff1660e01b815260040160408051808303815f875af1158015615660573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906156849190616e5e565b915091509091565b5f46608f0361569b5750600190565b4661279f036156aa5750600190565b466175bf036156b95750600190565b50600190565b6156c7614155565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300805460ff191660011781557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a25833614a92565b7fe1777bd22f637fc57eadcf9d877079117b44537a53059b1670036696018f564c61209f81614381565b7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b45161576e81614381565b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6006020526040812054610100900460ff1611156157e6576040517f4d078c7100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed601602052604090205460ff1615612743576040517f4d078c7100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6119ca8383616118565b5f61586c61587c565b5467ffffffffffffffff16919050565b5f807ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a006112b1565b6141b16161f2565b6158b46161f2565b6127438282616230565b7f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b6268005f615917845f9081527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602052604090206001015490565b5f85815260208490526040808220600101869055519192508491839187917fbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff9190a450505050565b6040517fa76e2ca500000000000000000000000000000000000000000000000000000000815267ffffffffffffffff821660048201525f906110009063a76e2ca5906024016020604051808303815f875af11580156159c0573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906159e49190616de6565b90508061274357604051633f48ffd960e21b815260040160405180910390fd5b7fbb12ed6b435a5fce787412ceb233935082e39147d977bc587eb74d0f97f48d2c61209f81614381565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace006001600160a01b038516615a91576040517fe602df050000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6001600160a01b038416615ad3576040517f94280d620000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6001600160a01b038086165f90815260018301602090815260408083209388168352929052208390558115615b5057836001600160a01b0316856001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92585604051615b4791815260200190565b60405180910390a35b5050505050565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602090815260408083206001600160a01b038516845290915290205460ff16612743576040517fe2517d3f0000000000000000000000000000000000000000000000000000000081526001600160a01b038216600482015260248101839052604401613742565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace006001600160a01b038416615c305781816002015f828254615c259190616d46565b90915550615cb99050565b6001600160a01b0384165f9081526020829052604090205482811015615c9b576040517fe450d38c0000000000000000000000000000000000000000000000000000000081526001600160a01b03861660048201526024810182905260448101849052606401613742565b6001600160a01b0385165f9081526020839052604090209083900390555b6001600160a01b038316615cd7576002810180548390039055615cf5565b6001600160a01b0383165f9081526020829052604090208054830190555b826001600160a01b0316846001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef84604051615d3a91815260200190565b60405180910390a350505050565b5f818152600183016020526040812054615d8d57508154600181810184555f8481526020808220909301849055845484825282860190935260409020919091556112b1565b505f6112b1565b6060815f01805480602002602001604051908101604052809291908181526020018280548015615de157602002820191905f5260205f20905b815481526020019060010190808311615dcd575b50505050509050919050565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005460ff166141b1576040517f8dfc202b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040517f84994fec00000000000000000000000000000000000000000000000000000000815267ffffffffffffffff831660048201525f90611000906384994fec90849060240160206040518083038185885af1158015615eab573d5f5f3e3d5ffd5b50505050506040513d601f19601f82011682018060405250810190615ed09190616de6565b905080611f3457604051633f48ffd960e21b815260040160405180910390fd5b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed600602081815260408084208151808301909252805460ff808216845261010090910416928201839052917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0101615fa1576040517f500389a000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b615fb4815f0151826020015160ff614a09565b935080602001516001615fc79190616e8b565b825460ff91909116610100027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff909116178255616005868686616063565b50505092915050565b61601782616293565b6040516001600160a01b038316907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a280511561605b57611f34828261632f565b6127436163a1565b6040517f5cf4151400000000000000000000000000000000000000000000000000000000815267ffffffffffffffff841660048201526024810183905260ff821660448201525f9061100090635cf41514906064016020604051808303815f875af11580156160d4573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906160f89190616de6565b9050806113fc57604051633f48ffd960e21b815260040160405180910390fd5b5f8181526001830160205260408120548015614927575f61613a600183616caa565b85549091505f9061614d90600190616caa565b90508082146161ac575f865f01828154811061616b5761616b616c18565b905f5260205f200154905080875f01848154811061618b5761618b616c18565b5f918252602080832090910192909255918252600188019052604090208390555b85548690806161bd576161bd616dd2565b600190038181905f5260205f20015f90559055856001015f8681526020019081526020015f205f9055600193505050506112b1565b6161fa6163d9565b6141b1576040517fd7e6bcf800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6162386161f2565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace007f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace036162848482616ee8565b50600481016113fc8382616ee8565b806001600160a01b03163b5f036162e1576040517f4c9c8ce30000000000000000000000000000000000000000000000000000000081526001600160a01b0382166004820152602401613742565b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc805473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b0392909216919091179055565b60605f5f846001600160a01b03168460405161634b9190616fa3565b5f60405180830381855af49150503d805f8114616383576040519150601f19603f3d011682016040523d82523d5f602084013e616388565b606091505b50915091506163988583836163f2565b95945050505050565b34156141b1576040517fb398979f00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6163e261587c565b54600160401b900460ff16919050565b6060826164075761640282616467565b6119ca565b815115801561641e57506001600160a01b0384163b155b15616460576040517f9996b3150000000000000000000000000000000000000000000000000000000081526001600160a01b0385166004820152602401613742565b50806119ca565b80511561647657805160208201fd5b6040517fd6bda27500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f602082840312156164b8575f5ffd5b81357fffffffff00000000000000000000000000000000000000000000000000000000811681146119ca575f5ffd5b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b6001600160a01b038116811461209f575f5ffd5b5f5f60408385031215616541575f5ffd5b823561654c8161651c565b946020939093013593505050565b634e487b7160e01b5f52604160045260245ffd5b604051601f8201601f1916810167ffffffffffffffff811182821017156165975761659761655a565b604052919050565b67ffffffffffffffff8116811461209f575f5ffd5b5f82601f8301126165c3575f5ffd5b813567ffffffffffffffff8111156165dd576165dd61655a565b8060051b6165ed6020820161656e565b91825260208185018101929081019086841115616608575f5ffd5b6020860192505b838310156166335782356166228161659f565b82526020928301929091019061660f565b9695505050505050565b5f5f6040838503121561664e575f5ffd5b823567ffffffffffffffff811115616664575f5ffd5b616670858286016165b4565b925050602083013560ff81168114616686575f5ffd5b809150509250929050565b5f602082840312156166a1575f5ffd5b81356119ca8161651c565b602080825282518282018190525f918401906040840190835b818110156167265783516001600160601b0381511684526001600160601b03602082015116602085015264ffffffffff604082015116604085015261ffff6060820151166060850152506080830192506020840193506001810190506166c5565b509095945050505050565b801515811461209f575f5ffd5b5f5f6040838503121561674f575f5ffd5b823561675a8161651c565b9150602083013561668681616731565b5f6020828403121561677a575f5ffd5b5035919050565b80356001600160601b0381168114616797575f5ffd5b919050565b5f5f604083850312156167ad575f5ffd5b6167b683616781565b915060208301356166868161651c565b5f5f5f606084860312156167d8575f5ffd5b83356167e38161651c565b925060208401356167f38161651c565b929592945050506040919091013590565b5f5f60408385031215616815575f5ffd5b61681e83616781565b915061682c60208401616781565b90509250929050565b5f60208284031215616845575f5ffd5b81356119ca8161659f565b5f5f60408385031215616861575f5ffd5b8235915060208301356166868161651c565b602080825282518282018190525f918401906040840190835b8181101561672657835160ff1683526020938401939092019160010161688c565b602080825282518282018190525f918401906040840190835b818110156167265783518352602093840193909201916001016168c6565b5f602082840312156168f4575f5ffd5b813567ffffffffffffffff81111561690a575f5ffd5b614a2a848285016165b4565b5f60208284031215616926575f5ffd5b6119ca82616781565b5f8151808452602084019350602083015f5b828110156169685781516001600160601b0316865260209586019590910190600101616941565b5093949350505050565b6001600160601b03851681526001600160601b0384166020820152608060408201525f6169a2608083018561692f565b82810360608401526169b4818561692f565b979650505050505050565b5f5f604083850312156169d0575f5ffd5b82356169db8161651c565b9150602083013567ffffffffffffffff8111156169f6575f5ffd5b8301601f81018513616a06575f5ffd5b803567ffffffffffffffff811115616a2057616a2061655a565b616a336020601f19601f8401160161656e565b818152866020838501011115616a47575f5ffd5b816020840160208301375f602083830101528093505050509250929050565b606081016112b1828467ffffffffffffffff81511682526001600160601b0360208201511660208301526001600160601b0360408201511660408301525050565b5f5f60408385031215616ab8575f5ffd5b82356167b68161659f565b5f60208284031215616ad3575f5ffd5b813561ffff811681146119ca575f5ffd5b5f5f60208385031215616af5575f5ffd5b823567ffffffffffffffff811115616b0b575f5ffd5b8301601f81018513616b1b575f5ffd5b803567ffffffffffffffff811115616b31575f5ffd5b856020606083028401011115616b45575f5ffd5b6020919091019590945092505050565b5f5f60408385031215616b66575f5ffd5b82356167b68161651c565b602080825282518282018190525f918401906040840190835b8181101561672657616bd083855167ffffffffffffffff81511682526001600160601b0360208201511660208301526001600160601b0360408201511660408301525050565b6020939093019260609290920191600101616b8a565b600181811c90821680616bfa57607f821691505b602082108103613f4a57634e487b7160e01b5f52602260045260245ffd5b634e487b7160e01b5f52603260045260245ffd5b634e487b7160e01b5f52601160045260245ffd5b5f67ffffffffffffffff821667ffffffffffffffff8103616c6357616c63616c2c565b60010192915050565b6001600160601b0382811682821603908111156112b1576112b1616c2c565b6001600160601b0381811683821601908111156112b1576112b1616c2c565b818103818111156112b1576112b1616c2c565b64ffffffffff82811682821603908111156112b1576112b1616c2c565b64ffffffffff81811683821601908111156112b1576112b1616c2c565b5f5f5f5f5f5f5f60e0888a031215616d0d575f5ffd5b5050855160208701516040880151606089015160808a015160a08b015160c0909b0151949c939b50919990985090965094509092509050565b808201808211156112b1576112b1616c2c565b80820281158282048414176112b1576112b1616c2c565b634e487b7160e01b5f52601260045260245ffd5b5f82616d9257616d92616d70565b500490565b67ffffffffffffffff81811683821601908111156112b1576112b1616c2c565b5f60208284031215616dc7575f5ffd5b81356119ca81616731565b634e487b7160e01b5f52603160045260245ffd5b5f60208284031215616df6575f5ffd5b81516119ca81616731565b60ff82811682821603908111156112b1576112b1616c2c565b61ffff82811682821603908111156112b1576112b1616c2c565b5f82616e4257616e42616d70565b500690565b5f60208284031215616e57575f5ffd5b5051919050565b5f5f60408385031215616e6f575f5ffd5b8251616e7a8161659f565b602084015190925061668681616731565b60ff81811683821601908111156112b1576112b1616c2c565b601f821115611f3457805f5260205f20601f840160051c81016020851015616ec95750805b601f840160051c820191505b81811015615b50575f8155600101616ed5565b815167ffffffffffffffff811115616f0257616f0261655a565b616f1681616f108454616be6565b84616ea4565b6020601f821160018114616f48575f8315616f315750848201515b5f19600385901b1c1916600184901b178455615b50565b5f84815260208120601f198516915b82811015616f775787850151825560209485019460019092019101616f57565b5084821015616f9457868401515f19600387901b60f8161c191681555b50505050600190811b01905550565b5f82518060208501845e5f92019182525091905056fea264697066735822122053fc27eb98d4a4c25c052e88af7b8faa94433a1b0197e85f2b025d2f29ab8a3364736f6c634300081e0033",
+    "sourceMap": "1132:33333:58:-:0;;;1171:4:33;1128:48;;5380:67:58;;;;;;;;;-1:-1:-1;5404:36:58;:34;:36::i;:::-;1132:33333;;7709:422:32;3147:66;7898:15;;;;;;;7894:76;;;7936:23;;-1:-1:-1;;;7936:23:32;;;;;;;;;;;7894:76;7983:14;;-1:-1:-1;;;;;7983:14:32;;;:34;7979:146;;8033:33;;-1:-1:-1;;;;;;8033:33:32;-1:-1:-1;;;;;8033:33:32;;;;;8085:29;;158:50:61;;;8085:29:32;;146:2:61;131:18;8085:29:32;;;;;;;7979:146;7758:373;7709:422::o;14:200:61:-;1132:33333:58;;;;;;;;;;;;;;;;;;;;;;",
+    "linkReferences": {}
+  },
+  "deployedBytecode": {
+    "object": "0x608060405260043610610508575f3560e01c80635c975abb1161029f578063a30fefe111610170578063d6531de5116100d1578063e8ce892211610087578063fb9848e41161006d578063fb9848e41461118e578063fd012e34146111ad578063fde73f7d14611207575f5ffd5b8063e8ce89221461113c578063f75b04041461116f575f5ffd5b8063dd62ed3e116100b7578063dd62ed3e14611099578063df235fe6146110fc578063e29581aa1461111b575f5ffd5b8063d6531de51461104c578063d8a9fe501461107a575f5ffd5b8063bf7df8e011610126578063c4d66de81161010c578063c4d66de814610ffb578063cf5e27431461100e578063d547741f1461102d575f5ffd5b8063bf7df8e014610fc0578063c2fab77414610fe7575f5ffd5b8063a9059cbb11610156578063a9059cbb14610f3a578063ad3cb1cc14610f59578063aedf6d5114610fa1575f5ffd5b8063a30fefe114610ee8578063a4b0b5a314610f1b575f5ffd5b80637a6d59d51161021a57806391d14854116101d057806396c82e57116101b657806396c82e5714610ead578063a0e3cdd614610ec2578063a217fddf14610ed5575f5ffd5b806391d1485414610e3657806395d89b4114610e99575f5ffd5b80638456cb59116102005780638456cb5914610de657806386bb1d6e14610dfa5780638dd09af314610e17575f5ffd5b80637a6d59d514610d6b5780637bde82f214610dc7575f5ffd5b80636ec21cc81161026f578063733897b711610255578063733897b714610cac57806377654f3414610ccb57806378f908e114610d0a575f5ffd5b80636ec21cc814610c3a57806370a0823114610c59575f5ffd5b80635c975abb14610b9e578063615bfc4514610bd457806363311d3d14610be857806369ce6d4714610c1b575f5ffd5b80632a7d8acb116103d957806343abcf32116103545780634ff0241a1161030a578063540a26f3116102f0578063540a26f314610aeb578063573c1ce014610b175780635838b2fe14610b6b575f5ffd5b80634ff0241a14610aa457806352d1902d14610ad7575f5ffd5b80634a797bd51161033a5780634a797bd514610a035780634beae6e314610a325780634f1ef28614610a91575f5ffd5b806343abcf32146109d057806346115383146109ef575f5ffd5b806336568abe116103a95780633b5b47651161038f5780633b5b47651461096f5780633e367afa1461099b5780633f4ba83a146109bc575f5ffd5b806336568abe1461093c5780633a98ef391461095b575f5ffd5b80632a7d8acb146108b05780632f2ff15d146108e3578063313ce56714610902578063337b2b6e1461091d575f5ffd5b80631610247b1161048357806322fd4ad511610439578063248a9ca31161041f578063248a9ca3146107ed57806324f67e181461083a5780632584601f14610859575f5ffd5b806322fd4ad51461079b57806323b872dd146107ce575f5ffd5b80631b8e0db6116104695780631b8e0db6146106ee5780631c3477dd146107215780631c53c2801461074c575f5ffd5b80631610247b1461069c57806318160ddd146106bb575f5ffd5b80630a763da1116104d85780630b52f7b1116104be5780630b52f7b1146106235780630bf14d9b1461064f57806315230e801461067d575f5ffd5b80630a763da1146105c85780630a9f9ee214610602575f5ffd5b806301ffc9a71461051357806306c7dbc41461054757806306fdde0314610588578063095ea7b3146105a9575f5ffd5b3661050f57005b5f5ffd5b34801561051e575f5ffd5b5061053261052d3660046164a8565b61121f565b60405190151581526020015b60405180910390f35b348015610552575f5ffd5b5061057a7f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d881565b60405190815260200161053e565b348015610593575f5ffd5b5061059c6112b7565b60405161053e91906164e7565b3480156105b4575f5ffd5b506105326105c3366004616530565b61138a565b3480156105d3575f5ffd5b506046546105ec90600160601b900464ffffffffff1681565b60405164ffffffffff909116815260200161053e565b34801561060d575f5ffd5b5061062161061c36600461663d565b6113a1565b005b34801561062e575f5ffd5b5061064261063d366004616691565b611402565b60405161053e91906166ac565b34801561065a575f5ffd5b50610532610669366004616691565b60496020525f908152604090205460ff1681565b348015610688575f5ffd5b5061062161069736600461673e565b6114b0565b3480156106a7575f5ffd5b506106216106b636600461676a565b611505565b3480156106c6575f5ffd5b507f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace025461057a565b3480156106f9575f5ffd5b5061057a7f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa81565b61073461072f36600461679c565b611794565b6040516001600160601b03909116815260200161053e565b348015610757575f5ffd5b5061076b61076636600461676a565b611968565b6040805167ffffffffffffffff90941684526001600160601b03928316602085015291169082015260600161053e565b3480156107a6575f5ffd5b5061057a7f902b1971fb3d9217703fb59d9a8bf53ee64da1be6756f20cebc090dd4c37f7d881565b3480156107d9575f5ffd5b506105326107e83660046167c6565b6119ac565b3480156107f8575f5ffd5b5061057a61080736600461676a565b5f9081527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602052604090206001015490565b348015610845575f5ffd5b50610734610854366004616804565b6119d1565b348015610864575f5ffd5b50610532610873366004616835565b67ffffffffffffffff165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed601602052604090205460ff1690565b3480156108bb575f5ffd5b5061057a7f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b881565b3480156108ee575f5ffd5b506106216108fd366004616850565b611d50565b34801561090d575f5ffd5b506040516012815260200161053e565b348015610928575f5ffd5b50610621610937366004616835565b611d93565b348015610947575f5ffd5b50610621610956366004616850565b611ee8565b348015610966575f5ffd5b50610734611f39565b34801561097a575f5ffd5b5061098e610989366004616835565b611f73565b60405161053e9190616873565b3480156109a6575f5ffd5b506109af612062565b60405161053e91906168ad565b3480156109c7575f5ffd5b5061062161206d565b3480156109db575f5ffd5b506106216109ea3660046168e4565b6120a2565b3480156109fa575f5ffd5b50610621612173565b348015610a0e575f5ffd5b50610a22610a1d366004616916565b612680565b60405161053e9493929190616972565b348015610a3d575f5ffd5b50610a71610a4c36600461676a565b604c6020525f90815260409020546001600160601b0380821691600160601b90041682565b604080516001600160601b0393841681529290911660208301520161053e565b610621610a9f3660046169bf565b612728565b348015610aaf575f5ffd5b5061057a7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb81565b348015610ae2575f5ffd5b5061057a612747565b348015610af6575f5ffd5b50610b0a610b05366004616835565b612775565b60405161053e9190616a66565b348015610b22575f5ffd5b50610b36610b31366004616aa7565b6127dc565b604080519788526020880196909652948601939093526060850191909152608084015260a083015260c082015260e00161053e565b348015610b76575f5ffd5b5061057a7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b45181565b348015610ba9575f5ffd5b507fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005460ff16610532565b348015610bdf575f5ffd5b50610734612894565b348015610bf3575f5ffd5b5061057a7fe1777bd22f637fc57eadcf9d877079117b44537a53059b1670036696018f564c81565b348015610c26575f5ffd5b50610621610c35366004616691565b61296e565b348015610c45575f5ffd5b50604654610734906001600160601b031681565b348015610c64575f5ffd5b5061057a610c73366004616691565b6001600160a01b03165f9081527f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00602052604090205490565b348015610cb7575f5ffd5b50610621610cc6366004616835565b612a80565b348015610cd6575f5ffd5b50610a71610ce536600461676a565b604b6020525f90815260409020546001600160601b0380821691600160601b90041682565b348015610d15575f5ffd5b50610d4a610d2436600461676a565b604a6020525f908152604090205467ffffffffffffffff80821691600160401b90041682565b6040805167ffffffffffffffff93841681529290911660208301520161053e565b348015610d76575f5ffd5b5061057a610d85366004616835565b67ffffffffffffffff165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6006020526040902054610100900460ff1690565b348015610dd2575f5ffd5b50610734610de1366004616850565b612b51565b348015610df1575f5ffd5b50610621612d98565b348015610e05575f5ffd5b5061057a69010f0cf064dd5920000081565b348015610e22575f5ffd5b50610621610e31366004616ac3565b612dca565b348015610e41575f5ffd5b50610532610e50366004616850565b5f9182527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602090815260408084206001600160a01b0393909316845291905290205460ff1690565b348015610ea4575f5ffd5b5061059c612eb1565b348015610eb8575f5ffd5b5061057a60045481565b610621610ed0366004616691565b612f02565b348015610ee0575f5ffd5b5061057a5f81565b348015610ef3575f5ffd5b5061057a7f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f53881565b348015610f26575f5ffd5b50610621610f35366004616ae4565b61305d565b348015610f45575f5ffd5b50610532610f54366004616530565b61340a565b348015610f64575f5ffd5b5061059c6040518060400160405280600581526020017f352e302e3000000000000000000000000000000000000000000000000000000081525081565b348015610fac575f5ffd5b50610621610fbb366004616835565b613417565b348015610fcb575f5ffd5b5060485461ffff165b60405161ffff909116815260200161053e565b348015610ff2575f5ffd5b506106216136ca565b610621611009366004616691565b613815565b348015611019575f5ffd5b506106216110283660046168e4565b613c4f565b348015611038575f5ffd5b50610621611047366004616850565b613dcf565b348015611057575f5ffd5b50610532611066366004616835565b60056020525f908152604090205460ff1681565b348015611085575f5ffd5b50610621611094366004616835565b613e12565b3480156110a4575f5ffd5b5061057a6110b3366004616b55565b6001600160a01b039182165f9081527f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace016020908152604080832093909416825291909152205490565b348015611107575f5ffd5b50610734611116366004616916565b613efa565b348015611126575f5ffd5b5061112f613f50565b60405161053e9190616b71565b348015611147575f5ffd5b5061057a7fbb12ed6b435a5fce787412ceb233935082e39147d977bc587eb74d0f97f48d2c81565b34801561117a575f5ffd5b50610621611189366004616ac3565b613fd9565b348015611199575f5ffd5b506107346111a8366004616916565b6140b0565b3480156111b8575f5ffd5b506111cc6111c7366004616530565b6140f0565b604080516001600160601b03958616815294909316602085015264ffffffffff9091169183019190915261ffff16606082015260800161053e565b348015611212575f5ffd5b5060475461ffff16610fd4565b5f7fffffffff0000000000000000000000000000000000000000000000000000000082167f7965db0b0000000000000000000000000000000000000000000000000000000014806112b157507f01ffc9a7000000000000000000000000000000000000000000000000000000007fffffffff000000000000000000000000000000000000000000000000000000008316145b92915050565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0380546060917f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace009161130890616be6565b80601f016020809104026020016040519081016040528092919081815260200182805461133490616be6565b801561137f5780601f106113565761010080835404028352916020019161137f565b820191905f5260205f20905b81548152906001019060200180831161136257829003601f168201915b505050505091505090565b5f33611397818585614148565b5060019392505050565b6113a9614155565b81515f5b818167ffffffffffffffff1610156113fc576113ec848267ffffffffffffffff16815181106113de576113de616c18565b6020026020010151846141b3565b6113f581616c40565b90506113ad565b50505050565b6001600160a01b0381165f908152604d60209081526040808320805482518185028101850190935280835260609492939192909184015b828210156114a5575f84815260209081902060408051608081018252918501546001600160601b038082168452600160601b82041683850152600160c01b810464ffffffffff1691830191909152600160e81b900461ffff166060820152825260019092019101611439565b505050509050919050565b7f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f5386114da81614381565b506001600160a01b03919091165f908152604960205260409020805460ff1916911515919091179055565b61150d614155565b335f908152604d60205260408120805490919082908490811061153257611532616c18565b5f9182526020918290206040805160808101825292909101546001600160601b038082168452600160601b80830490911694840194909452600160c01b810464ffffffffff908116928401839052600160e81b90910461ffff16606084015260465492945092909104909116146115d5576040517fdcb958f400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6115f4825f01516001600160601b0316836060015161ffff1661438b565b90505f81835f01516116069190616c6c565b60408085015164ffffffffff165f908152604c6020908152908290208251808401909352546001600160601b03808216808552600160601b909204168383015290860151929350909190829061165d908390616c6c565b6001600160601b031690525060208101805183919061167d908390616c6c565b6001600160601b0390811690915260408087015164ffffffffff165f908152604c602090815291902084518154928601518416600160601b027fffffffffffffffff00000000000000000000000000000000000000000000000090931690841617919091179055841615905061173657604780548491906002906117119084906201000090046001600160601b0316616c6c565b92506101000a8154816001600160601b0302191690836001600160601b031602179055505b61174085876143bc565b6117573033865f01516001600160601b0316614556565b60405186815233907fd1bbb16d648df2dfd0b1b3d88a5bc3f262e0323d3af8fd678115b4f1e7b4b88a9060200160405180910390a2505050505050565b5f61179d614155565b6001600160601b033411156117de576040517f1132981b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6117e66145e5565b6117ef34613efa565b9050806001600160601b03165f0361181a5760405163a88ee57760e01b815260040160405180910390fd5b826001600160601b0316816001600160601b03161015611866576040517fc635a9f200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b61187982826001600160601b0316614769565b604680543491905f906118969084906001600160601b0316616c8b565b82546101009290920a6001600160601b03818102199093169183160217909155604654600160601b900464ffffffffff165f908152604b60205260408120805434945090926118e791859116616c8b565b92506101000a8154816001600160601b0302191690836001600160601b03160217905550816001600160a01b03167f90890809c654f11d6e72a28fa60149770a0d11ec6c92319d6ceb2bb0a4ea1a15823460405161195a9291906001600160601b03929092168252602082015260400190565b60405180910390a292915050565b60038181548110611977575f80fd5b5f9182526020909120015467ffffffffffffffff811691506001600160601b03600160401b8204811691600160a01b90041683565b5f336119b98582856147b6565b6119c4858585614556565b60019150505b9392505050565b5f6119da614155565b6119e26145e5565b335f90815260496020526040812054819060ff16611a195760475461ffff169150611a166001600160601b0386168361438b565b90505b5f611a248287616c6c565b9050611a2f816140b0565b9350836001600160601b03165f03611a5a5760405163a88ee57760e01b815260040160405180910390fd5b846001600160601b0316846001600160601b03161015611aa6576040517f641963a400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b604654335f908152604d6020908152604080832081516080810183526001600160601b03808d1682528a811682860190815264ffffffffff600160601b98899004811684870181815261ffff808f16606088019081528854600181018a55988c528a8c209751979098018054955192519851909116600160e81b027fff0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff98909416600160c01b02979097167fff00000000000000ffffffffffffffffffffffffffffffffffffffffffffffff9186168c027fffffffffffffffff0000000000000000000000000000000000000000000000009095169686169690961793909317929092169390931792909217909255808552604c8452938290208251808401909352548082168084529590041691810191909152909186908290611bea908390616c8b565b6001600160601b0316905250602081018051849190611c0a908390616c8b565b6001600160601b0390811690915264ffffffffff84165f908152604c6020908152604090912084518154928601518416600160601b027fffffffffffffffff000000000000000000000000000000000000000000000000909316908416179190911790558516159050611cc05760478054859190600290611c9b9084906201000090046001600160601b0316616c8b565b92506101000a8154816001600160601b0302191690836001600160601b031602179055505b611cd433308a6001600160601b0316614556565b335f818152604d60205260409020547fef31107568890496c8f16fec1278e709d23f1444e004e7973a9403880c28d91790611d1190600190616caa565b604080519182526001600160601b038088166020840152808b1691830191909152871660608201526080015b60405180910390a2505050505092915050565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b6268006020526040902060010154611d8981614381565b6113fc8383614864565b611d9b614930565b611daf5f67ffffffffffffffff831661495a565b15155f03611de9576040517f0fa1af0e00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b604080516060810182525f602080830182815283850183815267ffffffffffffffff8781168087526003805460018101825581885288517fc2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b9091018054965195519190941673ffffffffffffffffffffffffffffffffffffffff1990961695909517600160401b6001600160601b0395861602176001600160a01b0316600160a01b94909516939093029390931790555481845260028352928590208390558451908152908101829052919290917fdd8aaf98a662995c3720dc78ea3773142e7d32c94f523a7d651e932ba0c44f8a91015b60405180910390a1505050565b6001600160a01b0381163314611f2a576040517f6697b23200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b611f348282614965565b505050565b5f611f42612894565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0254611f6e9190616c8b565b905090565b60605f7fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60067ffffffffffffffff8085165f9081526020838152604080832081518083019092525460ff8082168352610100909104169181018290529394509091811115611fe257611fe261655a565b60405190808252806020026020018201604052801561200b578160200160208202803683370190505b5090505f5b826020015160ff1681101561205957825161202d908260ff614a09565b82828151811061203f5761203f616c18565b60ff90921660209283029190910190910152600101612010565b50949350505050565b6060611f6e5f614a32565b7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb61209781614381565b61209f614a3e565b50565b6120aa614155565b805147905f5b818167ffffffffffffffff1610156120fe576120ee848267ffffffffffffffff16815181106120e1576120e1616c18565b6020026020010151614ab0565b6120f781616c40565b90506120b0565b505f61210a8347616caa565b905080156113fc57604654600160601b900464ffffffffff165f908152604b6020526040812080548392906121499084906001600160601b0316616c8b565b92506101000a8154816001600160601b0302191690836001600160601b0316021790555050505050565b61217b614155565b6121836145e5565b6046546001600160601b03811690600160601b900464ffffffffff165f806121a9614c16565b90925090505f604a816121bd600187616cbd565b64ffffffffff16815260208082019290925260409081015f2081518083019092525467ffffffffffffffff8082168352600160401b90910481169282018390529092508416101561223a576040517f4851faea00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b64ffffffffff84165f818152604b602090815260408083208151808301835290546001600160601b038082168352600160601b91829004811683860152958552604c8452828520835180850190945254808716808552919004861693830193909352805190949193929116111561234a57825182515f916122bb918b614c51565b835185519192505f9183916122cf91616c6c565b6122d99190616c6c565b90506001600160601b038116156123335780604b5f6122f98c6001616cda565b64ffffffffff16815260208101919091526040015f2080546bffffffffffffffffffffffff19166001600160601b03929092169190911790555b505067ffffffffffffffff8516602085015261245e565b825182516001600160601b039182169116111561240a57815183515f91612371918b614e72565b8451845191925082916123849190616c6c565b61238e9190616c6c565b91506001600160601b038216156123f45781604c5f6123ae8b6001616cda565b64ffffffffff16815260208101919091526040015f2080546bffffffffffffffffffffffff19166001600160601b03929092169190911790556123f1828a616c8b565b98505b5067ffffffffffffffff8516602085015261245e565b82516001600160601b03165f0361244d576040517fc2e5347d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b67ffffffffffffffff861660208501525b60208201516001600160601b031615612488576124883083602001516001600160601b0316615049565b81516001600160601b0316156124ca5781516124a49089616c6c565b604680546bffffffffffffffffffffffff19166001600160601b03929092169190911790555b6040805160608101825260475461ffff811682526001600160601b03620100008204811660208401819052600160701b9092041692820192909252901561257f578060200151816040018181516125219190616c8b565b6001600160601b039081169091525f60208401528251604780546040860151909316600160701b027fffffffffffff000000000000000000000000000000000000000000000000000090931661ffff90921691909117919091179055505b67ffffffffffffffff808816865264ffffffffff89165f908152604a6020908152604090912087518154928901518416600160401b027fffffffffffffffffffffffffffffffff000000000000000000000000000000009093169316929092171790556125ed886001616cda565b6046600c6101000a81548164ffffffffff021916908364ffffffffff1602179055507f0d52fcac1f24e16d612d7f4768640d2ec9407f68e8c172ec01887a96b068b9da88846020015184865f01516126459190616c6c565b6040805164ffffffffff90941684526001600160601b03928316602085015291169082015260600160405180910390a1505050505050505050565b5f5f6060806127196003805480602002602001604051908101604052809291908181526020015f905b82821015612706575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b90910416908201528252600190920191016126a9565b50505050866001600160601b0316615096565b93509350935093509193509193565b612730615275565b61273982615345565b612743828261536f565b5050565b5f612750615470565b507f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc90565b604080516060810182525f808252602082018190529181019190915261279a826154d2565b60408051606081018252915467ffffffffffffffff811683526001600160601b03600160401b820481166020850152600160a01b909104169082015292915050565b6040517f573c1ce000000000000000000000000000000000000000000000000000000000815267ffffffffffffffff831660048201526001600160a01b03821660248201525f908190819081908190819081906110009063573c1ce09060440160e0604051808303815f875af1158015612858573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061287c9190616cf7565b959f949e50929c50909a509850965090945092505050565b6040805160608101825260485461ffff811682526201000081046001600160601b031660208301819052600160701b90910464ffffffffff16928201839052915f906128e09042616caa565b90508015612969575f612933846001600160601b031661291e7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace025490565b6129289190616d46565b845161ffff1661438b565b6001600160601b031690505f6301e1338061294e8484616d59565b6129589190616d84565b90506129648186616c8b565b945050505b505090565b612976614155565b7f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d86129a081614381565b6129a86145e5565b6048546201000090046001600160601b031680156129f3576129ca8382614769565b604880547fffffffffffffffffffffffffffffffffffff000000000000000000000000ffff1690555b604754600160701b90046001600160601b03168015612a4057612a17308583614556565b604780547fffffffffffff000000000000000000000000ffffffffffffffffffffffffffff1690555b60408051838152602081018390527fd9787bf70d3926a4a81c52cba8799d18903ce0132aaa4b7de9e92dc893303a7f91015b60405180910390a150505050565b612a88614155565b7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b451612ab281614381565b67ffffffffffffffff82165f9081526005602052604090205460ff16612aeb5760405163194fdc7f60e31b815260040160405180910390fd5b5f612af5836154d2565b8054909150600160a01b90046001600160601b03165f819003612b2b5760405163a88ee57760e01b815260040160405180910390fd5b612b3e84826001600160601b0316615551565b505080546001600160a01b031690555050565b5f612b5a614155565b335f908152604d602052604081208054909190829086908110612b7f57612b7f616c18565b5f91825260208083206040805160808101825293909101546001600160601b038082168552600160601b82041684840152600160c01b810464ffffffffff16848301819052600160e81b90910461ffff1660608501528452604a825280842081518083019092525467ffffffffffffffff808216808452600160401b9092041692820192909252919350909103612c42576040517ffc08f5f200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f612c4b615620565b509050612c5661568c565b60ff168260200151612c689190616d97565b67ffffffffffffffff168167ffffffffffffffff161015612cb5576040517fba9bead700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b612cbf84886143bc565b826020015194505f866001600160a01b0316866001600160601b03166040515f6040518083038185875af1925050503d805f8114612d18576040519150601f19603f3d011682016040523d82523d5f602084013e612d1d565b606091505b5050905080612d58576040517f90b8ec1800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b604080518981526001600160601b038816602082015233917f53a80b7fa2025e3acb298abd7e222b36ce5d6a1425e7a6e53b451aac0c6e5a219101611d3d565b7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb612dc281614381565b61209f6156bf565b7f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa612df481614381565b60c88261ffff161115612e33576040517ffc5bee1200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60485461ffff90811690831603612e5d5760405163a88ee57760e01b815260040160405180910390fd5b612e656145e5565b6048805461ffff191661ffff84169081179091556040519081527f756367c310578acc96b78fcf4141ddb3cf532982d1342ec193f34a3600b9ae65906020015b60405180910390a15050565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0480546060917f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace009161130890616be6565b612f0a614155565b6001600160601b03341115612f4b576040517f1132981b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6046546001600160601b031669010f0cf064dd59200000811015612f9b576040517f500625f400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b612fa53482616c8b565b604680546bffffffffffffffffffffffff19166001600160601b039283161790819055600160601b900464ffffffffff165f908152604b6020526040812080543493919291612ff691859116616c8b565b92506101000a8154816001600160601b0302191690836001600160601b031602179055507f04e75fda068b8e114d7658bdff74280a0fd65586b7e026a034eae29dd5a9e68b3483604051612ea59291909182526001600160a01b0316602082015260400190565b61306561571a565b600454815f5b818110156134015784848281811061308557613085616c18565b905060600201604001602081019061309d9190616db7565b15613238575f6130d38686848181106130b8576130b8616c18565b6130ce9260206060909202019081019150616835565b6154d2565b805467ffffffffffffffff165f9081526005602052604090205490915060ff161561312a576040517f1db1d0c400000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8054600160401b90046001600160601b03165f87878581811061314f5761314f616c18565b90506060020160200160208101906131679190616916565b6131719083616c8b565b835473ffffffffffffffffffffffff00000000000000001916600160401b6001600160601b038381169182029290921786559192506131b290841688616caa565b6131bc9190616d46565b95508787858181106131d0576131d0616c18565b6131e69260206060909202019081019150616835565b6040516001600160601b038316815267ffffffffffffffff91909116907fcfaa637aecf1e60e723842980c95e1f0a7ca0a264e46647e4656b98f7293e33b9060200160405180910390a25050506133f9565b5f60025f87878581811061324e5761324e616c18565b6132649260206060909202019081019150616835565b67ffffffffffffffff1667ffffffffffffffff1681526020019081526020015f20549050805f0361329557506133f9565b5f60036132a3600184616caa565b815481106132b3576132b3616c18565b5f91825260208220018054909250600160401b90046001600160601b0316908181036132e257505050506133f9565b5f8989878181106132f5576132f5616c18565b905060600201602001602081019061330d9190616916565b9050826001600160601b0316816001600160601b03161015613336576133338184616c6c565b91505b83546001600160601b03808416600160401b810273ffffffffffffffffffffffff0000000000000000199093169290921786556133759085168a616caa565b61337f9190616d46565b975089898781811061339357613393616c18565b6133a99260206060909202019081019150616835565b6040516001600160601b038416815267ffffffffffffffff91909116907fcfaa637aecf1e60e723842980c95e1f0a7ca0a264e46647e4656b98f7293e33b9060200160405180910390a250505050505b60010161306b565b50506004555050565b5f33611397818585614556565b61342081615744565b67ffffffffffffffff81165f9081526002602052604081205490819003613473576040517f30812d4200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6003613481600184616caa565b8154811061349157613491616c18565b5f91825260209182902060408051606081018252929091015467ffffffffffffffff811683526001600160601b03600160401b82048116948401859052600160a01b90910416908201529150156134fb5760405163194fdc7f60e31b815260040160405180910390fd5b60408101516001600160601b0316156135275760405163194fdc7f60e31b815260040160405180910390fd5b600380545f919061353a90600190616caa565b8154811061354a5761354a616c18565b5f9182526020808320909101805467ffffffffffffffff168352600290915260409091208490559050806003613581600186616caa565b8154811061359157613591616c18565b5f918252602080832084549201805467ffffffffffffffff9384167fffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000821681178355865473ffffffffffffffffffffffffffffffffffffffff1990921617600160401b918290046001600160601b039081169092021780835595546001600160a01b03909616600160a01b96879004909116909502949094179093558616815260029091526040812055600380548061364c5761364c616dd2565b5f8281526020812082015f199081018290559091019091556136789067ffffffffffffffff8616615858565b5067ffffffffffffffff84165f81815260056020908152604091829020805460ff1916905590519182527f8712d9d347359238729023dc8640e38f0d4f8ad25d0e079c2208a885a51a023f9101612a72565b6001806136d5615863565b67ffffffffffffffff161461374b576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601c60248201527f4578706563746564206120646966666572656e742076657273696f6e0000000060448201526064015b60405180910390fd5b60025f61375661587c565b8054909150600160401b900460ff168061377e5750805467ffffffffffffffff808416911610155b156137b5576040517ff92ee8a900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b805468ffffffffffffffffff191667ffffffffffffffff8316908117600160401b1768ff0000000000000000191682556040519081527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d290602001611edb565b60025f61382061587c565b8054909150600160401b900460ff16806138485750805467ffffffffffffffff808416911610155b1561387f576040517ff92ee8a900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b805468ffffffffffffffffff191667ffffffffffffffff831617600160401b1781556138a96158a4565b6138b16158a4565b6139256040518060400160405280601381526020017f4b696e747375205374616b6564204d6f6e6164000000000000000000000000008152506040518060400160405280600481526020017f734d4f4e000000000000000000000000000000000000000000000000000000008152506158ac565b61392d6158a4565b6139356158a4565b61393f5f84614864565b5061396a7f902b1971fb3d9217703fb59d9a8bf53ee64da1be6756f20cebc090dd4c37f7d884614864565b506139957fe1777bd22f637fc57eadcf9d877079117b44537a53059b1670036696018f564c84614864565b506139c07fbb12ed6b435a5fce787412ceb233935082e39147d977bc587eb74d0f97f48d2c84614864565b506139eb7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b45184614864565b50613a167f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa84614864565b50613a417f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa806158be565b613a6b7f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d884614864565b50613a967f359946d964cb1f92e24841dd25d0e8706f1ab6dd13500522367deddd927658d8806158be565b613ac07f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f53884614864565b50613aeb7f78a7a80e95d53cedc2e84890fb7aaf754249c544050913a3263a2abf9d66f538806158be565b613b157f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b884614864565b50613b407f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b8806158be565b613b6a7ff146182d150a5b368b6d283f87aeae1f25c21b02ff55cf16848704ade176a5cb84614864565b50604680547fffffffffffffffffffffffffffffff0000000000ffffffffffffffffffffffff16600160601b1790556040805160608101825260c88082525f60208301524264ffffffffff1691830182905260488054600160701b9093027fffffffffffffffffffffffffff00000000000000000000000000000000000000909316929092171790556047805461ffff19166005179055815468ff000000000000000019168255517fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d290611edb90849067ffffffffffffffff91909116815260200190565b613c57614155565b80515f904790825b818167ffffffffffffffff161015613d4057613c9d858267ffffffffffffffff1681518110613c9057613c90616c18565b602002602001015161595f565b5f84613ca98547616caa565b613cb39190616caa565b90508015613d2f57613cc58186616d46565b9450858267ffffffffffffffff1681518110613ce357613ce3616c18565b602002602001015167ffffffffffffffff167f8082b0dab6d73a8025e5f15e4fdd54b68197a613e361810d4a2446c634b98ada82604051613d2691815260200190565b60405180910390a25b50613d3981616c40565b9050613c5f565b50825f03613d615760405163a88ee57760e01b815260040160405180910390fd5b604680548491905f90613d7e9084906001600160601b0316616c8b565b82546101009290920a6001600160601b03818102199093169183160217909155604654600160601b900464ffffffffff165f908152604b602052604081208054879450909261214991859116616c8b565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b6268006020526040902060010154613e0881614381565b6113fc8383614965565b613e1a615a04565b67ffffffffffffffff81165f9081526005602052604090205460ff1615613e545760405163a88ee57760e01b815260040160405180910390fd5b5f613e5e826154d2565b805460048054929350600160401b9091046001600160601b0316915f90613e86908490616caa565b9091555050805473ffffffffffffffffffffffff00000000000000001916815567ffffffffffffffff82165f81815260056020908152604091829020805460ff1916600117905590519182527fa46b2e9bd92f27216c46d5a9772c39431f3f381285ee1dacb1f1034fe603b10b9101612ea5565b6046545f906001600160601b0316808203613f1757829150613f4a565b80613f20611f39565b6001600160601b0316846001600160601b0316613f3d9190616d59565b613f479190616d84565b91505b50919050565b60606003805480602002602001604051908101604052809291908181526020015f905b82821015613fd0575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b9091041690820152825260019092019101613f73565b50505050905090565b7f13172b8201242833f26d88301b6e27aa2235ec2d9b2c92a1ed33678f0ee068fa61400381614381565b60328261ffff161115614042576040517ffc5bee1200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60475461ffff9081169083160361406c5760405163a88ee57760e01b815260040160405180910390fd5b6047805461ffff191661ffff84169081179091556040519081527f0531f91c02fe1dc8b306233f5edba5c1b65a79a064d26a40b6082bc9d887ecba90602001612ea5565b5f5f6140ba611f39565b6001600160601b03169050805f036140d457829150613f4a565b6046548190613f3d906001600160601b03908116908616616d59565b604d602052815f5260405f208181548110614109575f80fd5b5f918252602090912001546001600160601b038082169350600160601b8204169150600160c01b810464ffffffffff1690600160e81b900461ffff1684565b611f348383836001615a2e565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005460ff16156141b1576040517fd93c066500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b5f7fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60067ffffffffffffffff84165f9081526020828152604080832081518083019092525460ff8082168352610100909104811692820183905293945092851610614221578160200151614223565b835b90508060ff165f03614236575050505050565b5f5b8160ff1681101561430e575f614253845f01518360ff614a09565b6040517faed2ee7300000000000000000000000000000000000000000000000000000000815267ffffffffffffffff8916600482015260ff821660248201529091505f906110009063aed2ee73906044016020604051808303815f875af11580156142c0573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906142e49190616de6565b90508061430457604051633f48ffd960e21b815260040160405180910390fd5b5050600101614238565b50815161431d908260ff614a09565b60ff168252602082018051829190614336908390616e01565b60ff90811690915267ffffffffffffffff9096165f90815260209485526040902083518154959094015187166101000261ffff19909516939096169290921792909217909355505050565b61209f8133615b57565b5f61271061439a600182616e1a565b61ffff166143a88486616d59565b6143b29190616d46565b6119ca9190616d84565b81545f906143cc90600190616caa565b9050808214614509578281815481106143e7576143e7616c18565b905f5260205f200183838154811061440157614401616c18565b5f91825260209091208254910180546bffffffffffffffffffffffff1981166001600160601b0393841690811783558454600160601b908190049094169093027fffffffffffffffff00000000000000000000000000000000000000000000000090911690921791909117808255825464ffffffffff600160c01b9182900416027fffffff0000000000ffffffffffffffffffffffffffffffffffffffffffffffff821681178355925461ffff600160e81b9182900416027fff0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9093167fff00000000000000ffffffffffffffffffffffffffffffffffffffffffffffff909116179190911790555b8280548061451957614519616dd2565b5f8281526020902081015f1990810180547fff00000000000000000000000000000000000000000000000000000000000000169055019055505050565b6001600160a01b038316614598576040517f96c6fd1e0000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6001600160a01b0382166145da576040517fec442f050000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b611f34838383615be3565b6040805160608101825260485461ffff811682526201000081046001600160601b03166020830152600160701b900464ffffffffff16918101829052905f9061462e9042616caa565b90508015612743575f61467083602001516001600160601b031661291e7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace025490565b6001600160601b031690505f6301e1338061468b8484616d59565b6146959190616d84565b90508084602001516001600160601b03166146b09190616d46565b6001600160601b031660208581018290524264ffffffffff16604080880182905287516048805461ffff9092167fffffffffffffffffffffffffffffffffffff000000000000000000000000000090921691909117620100008602177fffffffffffffffffffffffffff0000000000ffffffffffffffffffffffffffff16600160701b90930292909217909155519182527f178c79c1e1bedefddc7aaa1aa24d6c1cee56301d2d4d9aa8cee048cab9552fc19101612a72565b6001600160a01b0382166147ab576040517fec442f050000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6127435f8383615be3565b6001600160a01b038381165f9081527f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace0160209081526040808320938616835292905220545f198110156113fc5781811015614856576040517ffb8f41b20000000000000000000000000000000000000000000000000000000081526001600160a01b03841660048201526024810182905260448101839052606401613742565b6113fc84848484035f615a2e565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602081815260408084206001600160a01b038616855290915282205460ff16614927575f848152602082815260408083206001600160a01b03871684529091529020805460ff191660011790556148dd3390565b6001600160a01b0316836001600160a01b0316857f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d60405160405180910390a460019150506112b1565b5f9150506112b1565b7f902b1971fb3d9217703fb59d9a8bf53ee64da1be6756f20cebc090dd4c37f7d861209f81614381565b5f6119ca8383615d48565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602081815260408084206001600160a01b038616855290915282205460ff1615614927575f848152602082815260408083206001600160a01b0387168085529252808320805460ff1916905551339287917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a460019150506112b1565b5f8160ff168360ff168560ff16614a209190616d46565b614a2a9190616e34565b949350505050565b60605f6119ca83615d94565b614a46615ded565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300805460ff191681557f5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa335b6040516001600160a01b03909116815260200160405180910390a150565b67ffffffffffffffff81165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60160205260409020547fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6009060ff16614b43576040517f78297a8c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040517faed2ee7300000000000000000000000000000000000000000000000000000000815267ffffffffffffffff8316600482015260ff60248201525f906110009063aed2ee73906044016020604051808303815f875af1158015614bab573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190614bcf9190616de6565b905080614bef57604051633f48ffd960e21b815260040160405180910390fd5b5067ffffffffffffffff9091165f908152600190910160205260409020805460ff19169055565b5f5f5f5f614c22615620565b9150915081935080614c3e57614c39846001616d97565b614c49565b614c49846002616d97565b925050509091565b6004545f90808203614c8f576040517f098404de00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6003805480602002602001604051908101604052809291908181526020015f905b82821015614d0e575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b9091041690820152825260019092019101614cb1565b5050505090505f5f614d34838888614d269190616c6c565b6001600160601b0316615096565b9350509250505f8789614d479190616c6c565b6001600160601b031690505f845190505f5b81811015614e64575f856001600160601b0316858381518110614d7e57614d7e616c18565b60200260200101516001600160601b031685614d9a9190616d59565b614da49190616d84565b90506001600160601b03811615614e5b5780878381518110614dc857614dc8616c18565b602002602001015160400151614dde9190616c8b565b60038381548110614df157614df1616c18565b905f5260205f20015f0160146101000a8154816001600160601b0302191690836001600160601b03160217905550614e4e878381518110614e3457614e34616c18565b60200260200101515f0151826001600160601b0316615e48565b614e58818a616c8b565b98505b50600101614d59565b505050505050509392505050565b5f5f6003805480602002602001604051908101604052809291908181526020015f905b82821015614ef2575f848152602090819020604080516060810182529185015467ffffffffffffffff811683526001600160601b03600160401b8204811684860152600160a01b9091041690820152825260019092019101614e95565b5050505090505f5f614f0a838887614d269190616c6c565b5092505091505f8688614f1d9190616c6c565b6001600160601b031690505f845190505f5b8181101561503c575f856001600160601b0316858381518110614f5457614f54616c18565b60200260200101516001600160601b031685614f709190616d59565b614f7a9190616d84565b90506001600160601b038116156150335780878381518110614f9e57614f9e616c18565b602002602001015160400151614fb49190616c6c565b60038381548110614fc757614fc7616c18565b5f91825260209091200180546001600160601b0392909216600160a01b026001600160a01b039092169190911790556150008189616c8b565b975061503187838151811061501757615017616c18565b60200260200101515f0151826001600160601b0316615ef0565b505b50600101614f2f565b5050505050509392505050565b6001600160a01b03821661508b576040517f96c6fd1e0000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b612743825f83615be3565b60045482515f91829160609182918067ffffffffffffffff8111156150bd576150bd61655a565b6040519080825280602002602001820160405280156150e6578160200160208202803683370190505b5093508067ffffffffffffffff8111156151025761510261655a565b60405190808252806020026020018201604052801561512b578160200160208202803683370190505b5092505f5b81811015615269575f89828151811061514b5761514b616c18565b6020026020010151604001516001600160601b031690505f5f8511615170575f6151ad565b848b848151811061518357615183616c18565b6020026020010151602001516001600160601b03168b6151a39190616d59565b6151ad9190616d84565b905080821115615209575f6151c28284616caa565b90506151ce818b616c8b565b9950808885815181106151e3576151e3616c18565b60200260200101906001600160601b031690816001600160601b0316815250505061525f565b8181111561525f575f61521c8383616caa565b9050615228818a616c8b565b98508087858151811061523d5761523d616c18565b60200260200101906001600160601b031690816001600160601b031681525050505b5050600101615130565b50505092959194509250565b306001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016148061530e57507f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166153027f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc546001600160a01b031690565b6001600160a01b031614155b156141b1576040517fe07c8dba00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7f1ea2b19b7ab22acb68ebeb58b5cb9eab43e3e119ebbd3159fdcddfc5b8c538b861274381614381565b816001600160a01b03166352d1902d6040518163ffffffff1660e01b8152600401602060405180830381865afa9250505080156153c9575060408051601f3d908101601f191682019092526153c691810190616e47565b60015b61540a576040517f4c9c8ce30000000000000000000000000000000000000000000000000000000081526001600160a01b0383166004820152602401613742565b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8114615466576040517faa1d49a400000000000000000000000000000000000000000000000000000000815260048101829052602401613742565b611f34838361600e565b306001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016146141b1576040517fe07c8dba00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b67ffffffffffffffff81165f90815260026020526040812054808203615524576040517f30812d4200000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6003615531600183616caa565b8154811061554157615541616c18565b905f5260205f2001915050919050565b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed60160205260408120547fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6009060ff16156155e5576040517f500389a000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60ff91506155f4848484616063565b67ffffffffffffffff9093165f908152600193840160205260409020805460ff19169093179092555090565b5f5f6110006001600160a01b031663757991a86040518163ffffffff1660e01b815260040160408051808303815f875af1158015615660573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906156849190616e5e565b915091509091565b5f46608f0361569b5750600190565b4661279f036156aa5750600190565b466175bf036156b95750600190565b50600190565b6156c7614155565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300805460ff191660011781557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a25833614a92565b7fe1777bd22f637fc57eadcf9d877079117b44537a53059b1670036696018f564c61209f81614381565b7f1d770361ad1ba5c90793f5d8711778cd963118207b8b46db0f36c72a65b0b45161576e81614381565b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed6006020526040812054610100900460ff1611156157e6576040517f4d078c7100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed601602052604090205460ff1615612743576040517f4d078c7100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6119ca8383616118565b5f61586c61587c565b5467ffffffffffffffff16919050565b5f807ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a006112b1565b6141b16161f2565b6158b46161f2565b6127438282616230565b7f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b6268005f615917845f9081527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602052604090206001015490565b5f85815260208490526040808220600101869055519192508491839187917fbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff9190a450505050565b6040517fa76e2ca500000000000000000000000000000000000000000000000000000000815267ffffffffffffffff821660048201525f906110009063a76e2ca5906024016020604051808303815f875af11580156159c0573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906159e49190616de6565b90508061274357604051633f48ffd960e21b815260040160405180910390fd5b7fbb12ed6b435a5fce787412ceb233935082e39147d977bc587eb74d0f97f48d2c61209f81614381565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace006001600160a01b038516615a91576040517fe602df050000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6001600160a01b038416615ad3576040517f94280d620000000000000000000000000000000000000000000000000000000081525f6004820152602401613742565b6001600160a01b038086165f90815260018301602090815260408083209388168352929052208390558115615b5057836001600160a01b0316856001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92585604051615b4791815260200190565b60405180910390a35b5050505050565b5f8281527f02dd7bc7dec4dceedda775e58dd541e08a116c6c53815c0bd028192f7b626800602090815260408083206001600160a01b038516845290915290205460ff16612743576040517fe2517d3f0000000000000000000000000000000000000000000000000000000081526001600160a01b038216600482015260248101839052604401613742565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace006001600160a01b038416615c305781816002015f828254615c259190616d46565b90915550615cb99050565b6001600160a01b0384165f9081526020829052604090205482811015615c9b576040517fe450d38c0000000000000000000000000000000000000000000000000000000081526001600160a01b03861660048201526024810182905260448101849052606401613742565b6001600160a01b0385165f9081526020839052604090209083900390555b6001600160a01b038316615cd7576002810180548390039055615cf5565b6001600160a01b0383165f9081526020829052604090208054830190555b826001600160a01b0316846001600160a01b03167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef84604051615d3a91815260200190565b60405180910390a350505050565b5f818152600183016020526040812054615d8d57508154600181810184555f8481526020808220909301849055845484825282860190935260409020919091556112b1565b505f6112b1565b6060815f01805480602002602001604051908101604052809291908181526020018280548015615de157602002820191905f5260205f20905b815481526020019060010190808311615dcd575b50505050509050919050565b7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f033005460ff166141b1576040517f8dfc202b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040517f84994fec00000000000000000000000000000000000000000000000000000000815267ffffffffffffffff831660048201525f90611000906384994fec90849060240160206040518083038185885af1158015615eab573d5f5f3e3d5ffd5b50505050506040513d601f19601f82011682018060405250810190615ed09190616de6565b905080611f3457604051633f48ffd960e21b815260040160405180910390fd5b67ffffffffffffffff82165f9081527fd5d321e774be746819c1749e69f27b3f3e063f791b56826404d788d5a63ed600602081815260408084208151808301909252805460ff808216845261010090910416928201839052917fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0101615fa1576040517f500389a000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b615fb4815f0151826020015160ff614a09565b935080602001516001615fc79190616e8b565b825460ff91909116610100027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff909116178255616005868686616063565b50505092915050565b61601782616293565b6040516001600160a01b038316907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a280511561605b57611f34828261632f565b6127436163a1565b6040517f5cf4151400000000000000000000000000000000000000000000000000000000815267ffffffffffffffff841660048201526024810183905260ff821660448201525f9061100090635cf41514906064016020604051808303815f875af11580156160d4573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906160f89190616de6565b9050806113fc57604051633f48ffd960e21b815260040160405180910390fd5b5f8181526001830160205260408120548015614927575f61613a600183616caa565b85549091505f9061614d90600190616caa565b90508082146161ac575f865f01828154811061616b5761616b616c18565b905f5260205f200154905080875f01848154811061618b5761618b616c18565b5f918252602080832090910192909255918252600188019052604090208390555b85548690806161bd576161bd616dd2565b600190038181905f5260205f20015f90559055856001015f8681526020019081526020015f205f9055600193505050506112b1565b6161fa6163d9565b6141b1576040517fd7e6bcf800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6162386161f2565b7f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace007f52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace036162848482616ee8565b50600481016113fc8382616ee8565b806001600160a01b03163b5f036162e1576040517f4c9c8ce30000000000000000000000000000000000000000000000000000000081526001600160a01b0382166004820152602401613742565b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc805473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b0392909216919091179055565b60605f5f846001600160a01b03168460405161634b9190616fa3565b5f60405180830381855af49150503d805f8114616383576040519150601f19603f3d011682016040523d82523d5f602084013e616388565b606091505b50915091506163988583836163f2565b95945050505050565b34156141b1576040517fb398979f00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f6163e261587c565b54600160401b900460ff16919050565b6060826164075761640282616467565b6119ca565b815115801561641e57506001600160a01b0384163b155b15616460576040517f9996b3150000000000000000000000000000000000000000000000000000000081526001600160a01b0385166004820152602401613742565b50806119ca565b80511561647657805160208201fd5b6040517fd6bda27500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f602082840312156164b8575f5ffd5b81357fffffffff00000000000000000000000000000000000000000000000000000000811681146119ca575f5ffd5b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b6001600160a01b038116811461209f575f5ffd5b5f5f60408385031215616541575f5ffd5b823561654c8161651c565b946020939093013593505050565b634e487b7160e01b5f52604160045260245ffd5b604051601f8201601f1916810167ffffffffffffffff811182821017156165975761659761655a565b604052919050565b67ffffffffffffffff8116811461209f575f5ffd5b5f82601f8301126165c3575f5ffd5b813567ffffffffffffffff8111156165dd576165dd61655a565b8060051b6165ed6020820161656e565b91825260208185018101929081019086841115616608575f5ffd5b6020860192505b838310156166335782356166228161659f565b82526020928301929091019061660f565b9695505050505050565b5f5f6040838503121561664e575f5ffd5b823567ffffffffffffffff811115616664575f5ffd5b616670858286016165b4565b925050602083013560ff81168114616686575f5ffd5b809150509250929050565b5f602082840312156166a1575f5ffd5b81356119ca8161651c565b602080825282518282018190525f918401906040840190835b818110156167265783516001600160601b0381511684526001600160601b03602082015116602085015264ffffffffff604082015116604085015261ffff6060820151166060850152506080830192506020840193506001810190506166c5565b509095945050505050565b801515811461209f575f5ffd5b5f5f6040838503121561674f575f5ffd5b823561675a8161651c565b9150602083013561668681616731565b5f6020828403121561677a575f5ffd5b5035919050565b80356001600160601b0381168114616797575f5ffd5b919050565b5f5f604083850312156167ad575f5ffd5b6167b683616781565b915060208301356166868161651c565b5f5f5f606084860312156167d8575f5ffd5b83356167e38161651c565b925060208401356167f38161651c565b929592945050506040919091013590565b5f5f60408385031215616815575f5ffd5b61681e83616781565b915061682c60208401616781565b90509250929050565b5f60208284031215616845575f5ffd5b81356119ca8161659f565b5f5f60408385031215616861575f5ffd5b8235915060208301356166868161651c565b602080825282518282018190525f918401906040840190835b8181101561672657835160ff1683526020938401939092019160010161688c565b602080825282518282018190525f918401906040840190835b818110156167265783518352602093840193909201916001016168c6565b5f602082840312156168f4575f5ffd5b813567ffffffffffffffff81111561690a575f5ffd5b614a2a848285016165b4565b5f60208284031215616926575f5ffd5b6119ca82616781565b5f8151808452602084019350602083015f5b828110156169685781516001600160601b0316865260209586019590910190600101616941565b5093949350505050565b6001600160601b03851681526001600160601b0384166020820152608060408201525f6169a2608083018561692f565b82810360608401526169b4818561692f565b979650505050505050565b5f5f604083850312156169d0575f5ffd5b82356169db8161651c565b9150602083013567ffffffffffffffff8111156169f6575f5ffd5b8301601f81018513616a06575f5ffd5b803567ffffffffffffffff811115616a2057616a2061655a565b616a336020601f19601f8401160161656e565b818152866020838501011115616a47575f5ffd5b816020840160208301375f602083830101528093505050509250929050565b606081016112b1828467ffffffffffffffff81511682526001600160601b0360208201511660208301526001600160601b0360408201511660408301525050565b5f5f60408385031215616ab8575f5ffd5b82356167b68161659f565b5f60208284031215616ad3575f5ffd5b813561ffff811681146119ca575f5ffd5b5f5f60208385031215616af5575f5ffd5b823567ffffffffffffffff811115616b0b575f5ffd5b8301601f81018513616b1b575f5ffd5b803567ffffffffffffffff811115616b31575f5ffd5b856020606083028401011115616b45575f5ffd5b6020919091019590945092505050565b5f5f60408385031215616b66575f5ffd5b82356167b68161651c565b602080825282518282018190525f918401906040840190835b8181101561672657616bd083855167ffffffffffffffff81511682526001600160601b0360208201511660208301526001600160601b0360408201511660408301525050565b6020939093019260609290920191600101616b8a565b600181811c90821680616bfa57607f821691505b602082108103613f4a57634e487b7160e01b5f52602260045260245ffd5b634e487b7160e01b5f52603260045260245ffd5b634e487b7160e01b5f52601160045260245ffd5b5f67ffffffffffffffff821667ffffffffffffffff8103616c6357616c63616c2c565b60010192915050565b6001600160601b0382811682821603908111156112b1576112b1616c2c565b6001600160601b0381811683821601908111156112b1576112b1616c2c565b818103818111156112b1576112b1616c2c565b64ffffffffff82811682821603908111156112b1576112b1616c2c565b64ffffffffff81811683821601908111156112b1576112b1616c2c565b5f5f5f5f5f5f5f60e0888a031215616d0d575f5ffd5b5050855160208701516040880151606089015160808a015160a08b015160c0909b0151949c939b50919990985090965094509092509050565b808201808211156112b1576112b1616c2c565b80820281158282048414176112b1576112b1616c2c565b634e487b7160e01b5f52601260045260245ffd5b5f82616d9257616d92616d70565b500490565b67ffffffffffffffff81811683821601908111156112b1576112b1616c2c565b5f60208284031215616dc7575f5ffd5b81356119ca81616731565b634e487b7160e01b5f52603160045260245ffd5b5f60208284031215616df6575f5ffd5b81516119ca81616731565b60ff82811682821603908111156112b1576112b1616c2c565b61ffff82811682821603908111156112b1576112b1616c2c565b5f82616e4257616e42616d70565b500690565b5f60208284031215616e57575f5ffd5b5051919050565b5f5f60408385031215616e6f575f5ffd5b8251616e7a8161659f565b602084015190925061668681616731565b60ff81811683821601908111156112b1576112b1616c2c565b601f821115611f3457805f5260205f20601f840160051c81016020851015616ec95750805b601f840160051c820191505b81811015615b50575f8155600101616ed5565b815167ffffffffffffffff811115616f0257616f0261655a565b616f1681616f108454616be6565b84616ea4565b6020601f821160018114616f48575f8315616f315750848201515b5f19600385901b1c1916600184901b178455615b50565b5f84815260208120601f198516915b82811015616f775787850151825560209485019460019092019101616f57565b5084821015616f9457868401515f19600387901b60f8161c191681555b50505050600190811b01905550565b5f82518060208501845e5f92019182525091905056fea264697066735822122053fc27eb98d4a4c25c052e88af7b8faa94433a1b0197e85f2b025d2f29ab8a3364736f6c634300081e0033",
+    "sourceMap": "1132:33333:58:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;3491:202:31;;;;;;;;;;-1:-1:-1;3491:202:31;;;;;:::i;:::-;;:::i;:::-;;;516:14:61;;509:22;491:41;;479:2;464:18;3491:202:31;;;;;;;;4090:72:58;;;;;;;;;;;;4133:29;4090:72;;;;;689:25:61;;;677:2;662:18;4090:72:58;543:177:61;2697:144:34;;;;;;;;;;;;;:::i;:::-;;;;;;;:::i;5114:186::-;;;;;;;;;;-1:-1:-1;5114:186:34;;;;;:::i;:::-;;:::i;4716:28:58:-;;;;;;;;;;-1:-1:-1;4716:28:58;;;;-1:-1:-1;;;4716:28:58;;;;;;;;;1912:12:61;1900:25;;;1882:44;;1870:2;1855:18;4716:28:58;1738:194:61;22695:257:58;;;;;;;;;;-1:-1:-1;22695:257:58;;;;;:::i;:::-;;:::i;:::-;;9912:143;;;;;;;;;;-1:-1:-1;9912:143:58;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;4822:47::-;;;;;;;;;;-1:-1:-1;4822:47:58;;;;;:::i;:::-;;;;;;;;;;;;;;;;26774:145;;;;;;;;;;-1:-1:-1;26774:145:58;;;;;:::i;:::-;;:::i;14506:1548::-;;;;;;;;;;-1:-1:-1;14506:1548:58;;;;;:::i;:::-;;:::i;3850:152:34:-;;;;;;;;;;-1:-1:-1;3981:14:34;;3850:152;;4014:70:58;;;;;;;;;;;;4056:28;4014:70;;11598:583;;;;;;:::i;:::-;;:::i;:::-;;;-1:-1:-1;;;;;6726:39:61;;;6708:58;;6696:2;6681:18;11598:583:58;6564:208:61;1023:19:56;;;;;;;;;;-1:-1:-1;1023:19:56;;;;;:::i;:::-;;:::i;:::-;;;;7003:18:61;6991:31;;;6973:50;;-1:-1:-1;;;;;7059:39:61;;;7054:2;7039:18;;7032:67;7135:39;;7115:18;;;7108:67;6961:2;6946:18;1023:19:56;6777:404:61;3674:66:58;;;;;;;;;;;;3714:26;3674:66;;5892:244:34;;;;;;;;;;-1:-1:-1;5892:244:34;;;;;:::i;:::-;;:::i;4807:191:31:-;;;;;;;;;;-1:-1:-1;4807:191:31;;;;;:::i;:::-;4872:7;4967:14;;;3001:28;4967:14;;;;;:24;;;;4807:191;12421:1742:58;;;;;;;;;;-1:-1:-1;12421:1742:58;;;;;:::i;:::-;;:::i;11455:185:60:-;;;;;;;;;;-1:-1:-1;11455:185:60;;;;;:::i;:::-;11601:32;;11523:4;11601:32;;;:24;:32;;;;;;;;;11455:185;4280:64:58;;;;;;;;;;;;4319:25;4280:64;;5294:136:31;;;;;;;;;;-1:-1:-1;5294:136:31;;;;;:::i;:::-;;:::i;3735:82:34:-;;;;;;;;;;-1:-1:-1;3735:82:34;;3808:2;8955:36:61;;8943:2;8928:18;3735:82:34;8813:184:61;2429:482:56;;;;;;;;;;-1:-1:-1;2429:482:56;;;;;:::i;:::-;;:::i;6396:245:31:-;;;;;;;;;;-1:-1:-1;6396:245:31;;;;;:::i;:::-;;:::i;9762:144:58:-;;;;;;;;;;;;;:::i;10772:493:60:-;;;;;;;;;;-1:-1:-1;10772:493:60;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;1802:104:56:-;;;;;;;;;;;;;:::i;:::-;;;;;;;:::i;27023:96:58:-;;;;;;;;;;;;;:::i;23278:484::-;;;;;;;;;;-1:-1:-1;23278:484:58;;;;;:::i;:::-;;:::i;18283:3165::-;;;;;;;;;;;;;:::i;10924:292::-;;;;;;;;;;-1:-1:-1;10924:292:58;;;;;:::i;:::-;;:::i;:::-;;;;;;;;;;:::i;4999:54::-;;;;;;;;;;-1:-1:-1;4999:54:58;;;;;:::i;:::-;;;;;;;;;;;;-1:-1:-1;;;;;4999:54:58;;;;-1:-1:-1;;;4999:54:58;;;;;;;;;-1:-1:-1;;;;;12096:39:61;;;12078:58;;12172:39;;;;12167:2;12152:18;;12145:67;12051:18;4999:54:58;11908:310:61;4161:214:33;;;;;;:::i;:::-;;:::i;4378:60:58:-;;;;;;;;;;;;4415:23;4378:60;;3708:134:33;;;;;;;;;;;;;:::i;2197:129:56:-;;;;;;;;;;-1:-1:-1;2197:129:56;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;10225:369:60:-;;;;;;;;;;-1:-1:-1;10225:369:60;;;;;:::i;:::-;;:::i;:::-;;;;14434:25:61;;;14490:2;14475:18;;14468:34;;;;14518:18;;;14511:34;;;;14576:2;14561:18;;14554:34;;;;14619:3;14604:19;;14597:35;14663:3;14648:19;;14641:35;14707:3;14692:19;;14685:35;14421:3;14406:19;10225:369:60;14119:607:61;3910:72:58;;;;;;;;;;;;3953:29;3910:72;;2496:145:36;;;;;;;;;;-1:-1:-1;1270:23:36;2625:9;;;2496:145;;10362:556:58;;;;;;;;;;;;;:::i;3746:78::-;;;;;;;;;;;;3792:32;3746:78;;25574:637;;;;;;;;;;-1:-1:-1;25574:637:58;;;;;:::i;:::-;;:::i;4612:25::-;;;;;;;;;;-1:-1:-1;4612:25:58;;;;-1:-1:-1;;;;;4612:25:58;;;4035:171:34;;;;;;;;;;-1:-1:-1;4035:171:34;;;;;:::i;:::-;-1:-1:-1;;;;;4179:20:34;4100:7;4179:20;;;2064;4179;;;;;;;4035:171;21873:517:58;;;;;;;;;;-1:-1:-1;21873:517:58;;;;;:::i;:::-;;:::i;4940:53::-;;;;;;;;;;-1:-1:-1;4940:53:58;;;;;:::i;:::-;;;;;;;;;;;;-1:-1:-1;;;;;4940:53:58;;;;-1:-1:-1;;;4940:53:58;;;;;4875:59;;;;;;;;;;-1:-1:-1;4875:59:58;;;;;:::i;:::-;;;;;;;;;;;;;;;;;-1:-1:-1;;;4875:59:58;;;;;;;;;14931:18:61;14919:31;;;14901:50;;14987:31;;;;14982:2;14967:18;;14960:59;14874:18;4875:59:58;14731:294:61;11271:178:60;;;;;;;;;;-1:-1:-1;11271:178:60;;;;;:::i;:::-;11416:21;;11335:7;11416:21;;;2359;11416;;;;;:26;;;;;;;11271:178;16344:1071:58;;;;;;;;;;-1:-1:-1;16344:1071:58;;;;;:::i;:::-;;:::i;26925:92::-;;;;;;;;;;;;;:::i;4445:66::-;;;;;;;;;;;;4500:11;4445:66;;26217:297;;;;;;;;;;-1:-1:-1;26217:297:58;;;;;:::i;:::-;;:::i;3780:207:31:-;;;;;;;;;;-1:-1:-1;3780:207:31;;;;;:::i;:::-;3857:4;3949:14;;;3001:28;3949:14;;;;;;;;-1:-1:-1;;;;;3949:31:31;;;;;;;;;;;;;;;3780:207;2954:148:34;;;;;;;;;;;;;:::i;1094:26:56:-;;;;;;;;;;;;;;;;24935:479:58;;;;;;:::i;:::-;;:::i;2398:49:31:-;;;;;;;;;;-1:-1:-1;2398:49:31;2443:4;2398:49;;4168:76:58;;;;;;;;;;;;4213:31;4168:76;;3310:1726:56;;;;;;;;;;-1:-1:-1;3310:1726:56;;;;;:::i;:::-;;:::i;4401:178:34:-;;;;;;;;;;-1:-1:-1;4401:178:34;;;;;:::i;:::-;;:::i;1819:58:33:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5688:877:56;;;;;;;;;;-1:-1:-1;5688:877:56;;;;;:::i;:::-;;:::i;10160:105:58:-;;;;;;;;;;-1:-1:-1;10240:13:58;:18;;;10160:105;;;16511:6:61;16499:19;;;16481:38;;16469:2;16454:18;10160:105:58;16337:188:61;7682:84:58;;;;;;;;;;;;;:::i;5826:1850::-;;;;;;:::i;:::-;;:::i;23914:732::-;;;;;;;;;;-1:-1:-1;23914:732:58;;;;;:::i;:::-;;:::i;5710:138:31:-;;;;;;;;;;-1:-1:-1;5710:138:31;;;;;:::i;:::-;;:::i;1175:45:56:-;;;;;;;;;;-1:-1:-1;1175:45:56;;;;;:::i;:::-;;;;;;;;;;;;;;;;5245:332;;;;;;;;;;-1:-1:-1;5245:332:56;;;;;:::i;:::-;;:::i;4612:195:34:-;;;;;;;;;;-1:-1:-1;4612:195:34;;;;;:::i;:::-;-1:-1:-1;;;;;4771:20:34;;;4692:7;4771:20;;;:13;:20;;;;;;;;:29;;;;;;;;;;;;;4612:195;8597:409:58;;;;;;;;;;-1:-1:-1;8597:409:58;;;;;:::i;:::-;;:::i;2054:87:56:-;;;;;;;;;;;;;:::i;:::-;;;;;;;:::i;3830:74:58:-;;;;;;;;;;;;3874:30;3830:74;;26520:248;;;;;;;;;;-1:-1:-1;26520:248:58;;;;;:::i;:::-;;:::i;9215:399::-;;;;;;;;;;-1:-1:-1;9215:399:58;;;;;:::i;:::-;;:::i;5059:61::-;;;;;;;;;;-1:-1:-1;5059:61:58;;;;;:::i;:::-;;:::i;:::-;;;;-1:-1:-1;;;;;17844:39:61;;;17826:58;;17920:39;;;;17915:2;17900:18;;17893:67;18008:12;17996:25;;;17976:18;;;17969:53;;;;18070:6;18058:19;18053:2;18038:18;;18031:47;17813:3;17798:19;5059:61:58;17603:481:61;10061:93:58;;;;;;;;;;-1:-1:-1;10135:7:58;:12;;;10061:93;;3491:202:31;3576:4;3599:47;;;3614:32;3599:47;;:87;;-1:-1:-1;1116:25:37;1101:40;;;;3650:36:31;3592:94;3491:202;-1:-1:-1;;3491:202:31:o;2697:144:34:-;2827:7;2820:14;;2742:13;;2064:20;;2820:14;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2697:144;:::o;5114:186::-;5187:4;966:10:35;5241:31:34;966:10:35;5257:7:34;5266:5;5241:8;:31::i;:::-;-1:-1:-1;5289:4:34;;5114:186;-1:-1:-1;;;5114:186:34:o;22695:257:58:-;1979:19:36;:17;:19::i;:::-;22809:14:58;;22795:11:::1;22833:113;22852:3;22848:1;:7;;;22833:113;;;22876:59;22903:7;22911:1;22903:10;;;;;;;;;;:::i;:::-;;;;;;;22915:19;22876:26;:59::i;:::-;22857:3;::::0;::::1;:::i;:::-;;;22833:113;;;;22785:167;22695:257:::0;;:::o;9912:143::-;-1:-1:-1;;;;;10024:24:58;;;;;;:18;:24;;;;;;;;10017:31;;;;;;;;;;;;;;;;;9983:22;;10017:31;;10024:24;;10017:31;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;10017:31:58;;;;;-1:-1:-1;;;10017:31:58;;;;;;;-1:-1:-1;;;10017:31:58;;;;;;;;;;;-1:-1:-1;;;10017:31:58;;;;;;;;;;;;;;;;;;;;;;;;;9912:143;;;:::o;26774:145::-;4213:31;3272:16:31;3283:4;3272:10;:16::i;:::-;-1:-1:-1;;;;;;26880:21:58;;;::::1;;::::0;;;:15:::1;:21;::::0;;;;:32;;-1:-1:-1;;26880:32:58::1;::::0;::::1;;::::0;;;::::1;::::0;;26774:145::o;14506:1548::-;1979:19:36;:17;:19::i;:::-;14768:10:58::1;14700:46;14749:30:::0;;;:18:::1;:30;::::0;;;;14830:35;;14749:30;;14700:46;14749:30;;14853:11;;14830:35;::::1;;;;;:::i;:::-;;::::0;;;::::1;::::0;;;;14789:76:::1;::::0;;::::1;::::0;::::1;::::0;;14830:35;;;::::1;14789:76:::0;-1:-1:-1;;;;;14789:76:58;;::::1;::::0;;-1:-1:-1;;;14789:76:58;;::::1;::::0;;::::1;::::0;;::::1;::::0;;;;-1:-1:-1;;;14789:76:58;::::1;;::::0;;::::1;::::0;;;;;;-1:-1:-1;;;14789:76:58;;::::1;;;::::0;;;;14933:14:::1;::::0;14789:76;;-1:-1:-1;14933:14:58;;;::::1;::::0;;::::1;14904:43;14900:82;;14956:26;;;;;;;;;;;;;;14900:82;15068:18;15089:72;15103:17;:24;;;-1:-1:-1::0;;;;;15089:72:58::1;15129:17;:31;;;15089:72;;:13;:72::i;:::-;15068:93;;15171:21;15222:11;15195:17;:24;;;:38;;;;:::i;:::-;15362:25;::::0;;::::1;::::0;15340:48:::1;;15303:34;15340:48:::0;;;:21:::1;:48;::::0;;;;;;;15303:85;;;;::::1;::::0;;;;-1:-1:-1;;;;;15303:85:58;;::::1;::::0;;;-1:-1:-1;;;15303:85:58;;::::1;;::::0;;::::1;::::0;15455:27;;::::1;::::0;15171:62;;-1:-1:-1;15303:85:58;;15455:27;15303:85;;15423:59:::1;::::0;15455:27;;15423:59:::1;:::i;:::-;-1:-1:-1::0;;;;;15423:59:58::1;::::0;;-1:-1:-1;15492:28:58::1;::::0;::::1;:46:::0;;15524:14;;15492:28;:46:::1;::::0;15524:14;;15492:46:::1;:::i;:::-;-1:-1:-1::0;;;;;15492:46:58;;::::1;::::0;;;15570:25:::1;::::0;;::::1;::::0;15548:48:::1;;;::::0;;;:21:::1;:48;::::0;;;;;;:72;;;;;;::::1;::::0;;::::1;-1:-1:-1::0;;;15548:72:58::1;::::0;;;;;;::::1;::::0;;;;::::1;::::0;;15672:15;::::1;::::0;;-1:-1:-1;15668:81:58::1;;15703:7;:35:::0;;15727:11;;15703:7;:20:::1;::::0;:35:::1;::::0;15727:11;;15703:35;;::::1;-1:-1:-1::0;;;;;15703:35:58::1;;:::i;:::-;;;;;;;;-1:-1:-1::0;;;;;15703:35:58::1;;;;;-1:-1:-1::0;;;;;15703:35:58::1;;;;;;15668:81;15809:57;15830:22;15854:11;15809:20;:57::i;:::-;15912:79;15947:4;15954:10;15966:17;:24;;;-1:-1:-1::0;;;;;15912:79:58::1;:26;:79::i;:::-;16007:40;::::0;689:25:61;;;16023:10:58::1;::::0;16007:40:::1;::::0;677:2:61;662:18;16007:40:58::1;;;;;;;14579:1475;;;;;14506:1548:::0;:::o;11598:583::-;11691:13;1979:19:36;:17;:19::i;:::-;-1:-1:-1;;;;;11720:9:58::1;:28;11716:58;;;11757:17;;;;;;;;;;;;;;11716:58;11785:13;:11;:13::i;:::-;11818:34;11841:9;11818:15;:34::i;:::-;11809:43;;11866:6;-1:-1:-1::0;;;;;11866:11:58::1;11876:1;11866:11:::0;11862:34:::1;;11886:10;;-1:-1:-1::0;;;11886:10:58::1;;;;;;;;;;;11862:34;11919:9;-1:-1:-1::0;;;;;11910:18:58::1;:6;-1:-1:-1::0;;;;;11910:18:58::1;;11906:47;;;11937:16;;;;;;;;;;;;;;11906:47;11964:40;11987:8;11997:6;-1:-1:-1::0;;;;;11964:40:58::1;:22;:40::i;:::-;12015:11;:32:::0;;12037:9:::1;::::0;12015:11;::::1;::::0;:32:::1;::::0;12037:9;;-1:-1:-1;;;;;12015:32:58::1;;:::i;:::-;::::0;;::::1;::::0;;;::::1;-1:-1:-1::0;;;;;12015:32:58;;::::1;;::::0;;::::1;::::0;;::::1;;;::::0;;;12079:14:::1;::::0;-1:-1:-1;;;12079:14:58;::::1;;;-1:-1:-1::0;12058:36:58;;;:20:::1;:36;::::0;;;;:64;;12112:9:::1;::::0;-1:-1:-1;12058:36:58;;:64:::1;::::0;12112:9;;12058:64:::1;;:::i;:::-;;;;;;;;-1:-1:-1::0;;;;;12058:64:58::1;;;;;-1:-1:-1::0;;;;;12058:64:58::1;;;;;;12146:8;-1:-1:-1::0;;;;;12138:36:58::1;;12156:6;12164:9;12138:36;;;;;;-1:-1:-1::0;;;;;19752:39:61;;;;19734:58;;19823:2;19808:18;;19801:34;19722:2;19707:18;;19561:280;12138:36:58::1;;;;;;;;11598:583:::0;;;;:::o;1023:19:56:-;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;;1023:19:56;;;;;-1:-1:-1;;;1023:19:56;;;;:::o;5892:244:34:-;5979:4;966:10:35;6035:37:34;6051:4;966:10:35;6066:5:34;6035:15;:37::i;:::-;6082:26;6092:4;6098:2;6102:5;6082:9;:26::i;:::-;6125:4;6118:11;;;5892:244;;;;;;:::o;12421:1742:58:-;12512:16;1979:19:36;:17;:19::i;:::-;12540:13:58::1;:11;:13::i;:::-;12683:10;12604:20;12667:27:::0;;;:15:::1;:27;::::0;;;;;12604:20;;12667:27:::1;;12662:151;;12726:7;:12:::0;::::1;;::::0;-1:-1:-1;12766:36:58::1;-1:-1:-1::0;;;;;12766:36:58;::::1;12726:12:::0;12766:13:::1;:36::i;:::-;12752:50;;12662:151;12823:21;12847:20;12856:11:::0;12847:6;:20:::1;:::i;:::-;12823:44;;12889:31;12905:14;12889:15;:31::i;:::-;12877:43;;12934:9;-1:-1:-1::0;;;;;12934:14:58::1;12947:1;12934:14:::0;12930:37:::1;;12957:10;;-1:-1:-1::0;;;12957:10:58::1;;;;;;;;;;;12930:37;12993:12;-1:-1:-1::0;;;;;12981:24:58::1;:9;-1:-1:-1::0;;;;;12981:24:58::1;;12977:52;;;13014:15;;;;;;;;;;;;;;12977:52;13065:14;::::0;13160:10:::1;13040:22;13141:30:::0;;;:18:::1;:30;::::0;;;;;;;13177:167;;::::1;::::0;::::1;::::0;;-1:-1:-1;;;;;13177:167:58;;::::1;::::0;;;;::::1;::::0;;::::1;::::0;;;13065:14:::1;-1:-1:-1::0;;;13065:14:58;;;::::1;::::0;::::1;13177:167:::0;;;;;;::::1;::::0;;::::1;::::0;;;;;;13141:204;;::::1;::::0;::::1;::::0;;;;;;;;;;;;;::::1;::::0;;;;;;;;;;::::1;-1:-1:-1::0;;;13141:204:58::1;::::0;;;;::::1;-1:-1:-1::0;;;13141:204:58::1;::::0;;;;;;;::::1;::::0;::::1;::::0;;;;;;::::1;::::0;;;;;;;::::1;::::0;;;;;;;;;;;::::1;::::0;;;13425:38;;;:21:::1;:38:::0;;;;;;13388:75;;;;::::1;::::0;;;;;;::::1;::::0;;;;;::::1;;::::0;;::::1;::::0;;;;13065:14;;13244:9;;13388:75;;13498:41:::1;::::0;13244:9;;13498:41:::1;:::i;:::-;-1:-1:-1::0;;;;;13498:41:58::1;::::0;;-1:-1:-1;13549:28:58::1;::::0;::::1;:46:::0;;13581:14;;13549:28;:46:::1;::::0;13581:14;;13549:46:::1;:::i;:::-;-1:-1:-1::0;;;;;13549:46:58;;::::1;::::0;;;13605:38:::1;::::0;::::1;;::::0;;;:21:::1;:38;::::0;;;;;;;:62;;;;;;::::1;::::0;;::::1;-1:-1:-1::0;;;13605:62:58::1;::::0;;;;;;::::1;::::0;;;;::::1;::::0;;13714:15;::::1;::::0;;-1:-1:-1;13710:81:58::1;;13745:7;:35:::0;;13769:11;;13745:7;:20:::1;::::0;:35:::1;::::0;13769:11;;13745:35;;::::1;-1:-1:-1::0;;;;;13745:35:58::1;;:::i;:::-;;;;;;;;-1:-1:-1::0;;;;;13745:35:58::1;;;;;-1:-1:-1::0;;;;;13745:35:58::1;;;;;;13710:81;13899:61;13926:10;13946:4;13953:6;-1:-1:-1::0;;;;;13899:61:58::1;:26;:61::i;:::-;14005:10;14029:30;::::0;;;:18:::1;:30;::::0;;;;:37;13976:180:::1;::::0;14029:41:::1;::::0;14069:1:::1;::::0;14029:41:::1;:::i;:::-;13976:180;::::0;;20207:25:61;;;-1:-1:-1;;;;;20268:39:61;;;20263:2;20248:18;;20241:67;20344:39;;;20324:18;;;20317:67;;;;20420:39;;20415:2;20400:18;;20393:67;20194:3;20179:19;13976:180:58::1;;;;;;;;12530:1633;;;;;12421:1742:::0;;;;:::o;5294:136:31:-;4872:7;4967:14;;;3001:28;4967:14;;;;;:24;;;3272:16;3283:4;3272:10;:16::i;:::-;5398:25:::1;5409:4;5415:7;5398:10;:25::i;2429:482:56:-:0;2480:19;:17;:19::i;:::-;2514:20;:8;:20;;;:12;:20::i;:::-;:29;;2538:5;2514:29;2510:57;;2552:15;;;;;;;;;;;;;;2510:57;-1:-1:-1;;;;;;;;;;;;;;;;;;;;;;2630:19:56;;;;;;;2659:5;:19;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;2659:19:56;;;;;;;-1:-1:-1;;;;;;;;2659:19:56;;;;;-1:-1:-1;;;;;2659:19:56;-1:-1:-1;;;2659:19:56;;;;;;;;;;;;;;2771:12;2816:28;;;:20;:28;;;;;;:42;;;2874:30;;20643:50:61;;;20709:18;;;20702:34;;;-1:-1:-1;;2771:12:56;;2874:30;;20616:18:61;2874:30:56;;;;;;;;2470:441;;2429:482;:::o;6396:245:31:-;-1:-1:-1;;;;;6489:34:31;;966:10:35;6489:34:31;6485:102;;6546:30;;;;;;;;;;;;;;6485:102;6597:37;6609:4;6615:18;6597:11;:37::i;:::-;;6396:245;;:::o;9762:144:58:-;9806:6;9872:27;:25;:27::i;:::-;3981:14:34;;9831:68:58;;;;:::i;:::-;9824:75;;9762:144;:::o;10772:493:60:-;10832:14;10858:23;2359:21;10958;;;;10913:42;10958:21;;;;;;;;;;;10913:66;;;;;;;;;;;;;;;;;;;;;;;;;;10858:45;;-1:-1:-1;10913:42:60;;11018:35;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;11018:35:60;;10989:64;;11068:9;11063:168;11083:17;:22;;;11079:26;;:1;:26;11063:168;;;11155:24;;11143:77;;11187:1;1720:3;11143:11;:77::i;:::-;11126:11;11138:1;11126:14;;;;;;;;:::i;:::-;:94;;;;:14;;;;;;;;;;;:94;11107:3;;11063:168;;;-1:-1:-1;11247:11:60;10772:493;-1:-1:-1;;;;10772:493:60:o;1802:104:56:-;1847:16;1882:17;:8;:15;:17::i;27023:96:58:-;4415:23;3272:16:31;3283:4;3272:10;:16::i;:::-;27082:30:58::1;:28;:30::i;:::-;27023:96:::0;:::o;23278:484::-;1979:19:36;:17;:19::i;:::-;23429:14:58;;23383:21:::1;::::0;23357:23:::1;23453:98;23472:3;23468:1;:7;;;23453:98;;;23496:44;23529:7;23537:1;23529:10;;;;;;;;;;:::i;:::-;;;;;;;23496:32;:44::i;:::-;23477:3;::::0;::::1;:::i;:::-;;;23453:98;;;-1:-1:-1::0;23561:23:58::1;23587:39;23611:15:::0;23587:21:::1;:39;:::i;:::-;23561:65:::0;-1:-1:-1;23640:19:58;;23636:120:::1;;23696:14;::::0;-1:-1:-1;;;23696:14:58;::::1;;;23675:36;::::0;;;:20:::1;:36;::::0;;;;:70;;23729:15;;23675:36;:70:::1;::::0;23729:15;;-1:-1:-1;;;;;23675:70:58::1;;:::i;:::-;;;;;;;;-1:-1:-1::0;;;;;23675:70:58::1;;;;;-1:-1:-1::0;;;;;23675:70:58::1;;;;;;23347:415;;;23278:484:::0;:::o;18283:3165::-;1979:19:36;:17;:19::i;:::-;18339:13:58::1;:11;:13::i;:::-;18385:11;::::0;-1:-1:-1;;;;;18385:11:58;::::1;::::0;-1:-1:-1;;;18441:14:58;::::1;;;18363:19;::::0;18522::::1;:17;:19::i;:::-;18476:65:::0;;-1:-1:-1;18476:65:58;-1:-1:-1;18719:38:58::1;18760:16;18719:38:::0;18777:19:::1;18795:1;18777:15:::0;:19:::1;:::i;:::-;18760:37;;::::0;;::::1;::::0;;::::1;::::0;;;;;;;;-1:-1:-1;18760:37:58;18719:78;;;;::::1;::::0;;;;::::1;::::0;;::::1;::::0;;-1:-1:-1;;;18719:78:58;;::::1;::::0;::::1;::::0;;::::1;::::0;;;;;-1:-1:-1;18812:46:58;::::1;;18808:78;;;18867:19;;;;;;;;;;;;;;18808:78;18932:37;::::0;::::1;18897:32;18932:37:::0;;;:20:::1;:37;::::0;;;;;;;18897:72;;;;::::1;::::0;;;;-1:-1:-1;;;;;18897:72:58;;::::1;::::0;;-1:-1:-1;;;18897:72:58;;;::::1;::::0;::::1;::::0;;::::1;::::0;19015:38;;;:21:::1;:38:::0;;;;;18979:74;;;;::::1;::::0;;;;;;::::1;::::0;;;;;::::1;::::0;::::1;::::0;;::::1;::::0;;;;19095:26;;18897:72;;18979:74;;18897:32;19095:56;::::1;;19091:1263;;;19230:26:::0;;19258:27;;19194:22:::1;::::0;19219:81:::1;::::0;19287:12;19219:10:::1;:81::i;:::-;19357:27:::0;;19328:26;;19194:106;;-1:-1:-1;19314:11:58::1;::::0;19194:106;;19328:56:::1;::::0;::::1;:::i;:::-;:74;;;;:::i;:::-;19314:88:::0;-1:-1:-1;;;;;;19420:8:58;::::1;::::0;19416:102:::1;;19499:4:::0;19448:20:::1;:41;19469:19;:15:::0;19487:1:::1;19469:19;:::i;:::-;19448:41;;::::0;;::::1;::::0;::::1;::::0;;;;;;-1:-1:-1;19448:41:58;:55;;-1:-1:-1;;19448:55:58::1;-1:-1:-1::0;;;;;19448:55:58;;;::::1;::::0;;;::::1;::::0;;19416:102:::1;-1:-1:-1::0;;19531:47:58::1;::::0;::::1;:31;::::0;::::1;:47:::0;19091:1263:::1;;;19629:26:::0;;19599:27;;-1:-1:-1;;;;;19599:56:58;;::::1;::::0;::::1;;19595:759;;;19737:27:::0;;19766:26;;19697:24:::1;::::0;19724:83:::1;::::0;19794:12;19724::::1;:83::i;:::-;19864:26:::0;;19834:27;;19697:110;;-1:-1:-1;19697:110:58;;19834:56:::1;::::0;19864:26;19834:56:::1;:::i;:::-;:76;;;;:::i;:::-;19821:89:::0;-1:-1:-1;;;;;;19928:14:58;::::1;::::0;19924:159:::1;;20014:10:::0;19962:21:::1;:42;19984:19;:15:::0;20002:1:::1;19984:19;:::i;:::-;19962:42;;::::0;;::::1;::::0;::::1;::::0;;;;;;-1:-1:-1;19962:42:58;:62;;-1:-1:-1;;19962:62:58::1;-1:-1:-1::0;;;;;19962:62:58;;;::::1;::::0;;;::::1;::::0;;20042:26:::1;20058:10:::0;20042:26;::::1;:::i;:::-;;;19924:159;-1:-1:-1::0;20096:47:58::1;::::0;::::1;:31;::::0;::::1;:47:::0;19595:759:::1;;;20231:26:::0;;-1:-1:-1;;;;;20231:31:58::1;:26;:31:::0;20227:56:::1;;20271:12;;;;;;;;;;;;;;20227:56;20297:46;::::0;::::1;:31;::::0;::::1;:46:::0;19595:759:::1;20368:27;::::0;::::1;::::0;-1:-1:-1;;;;;20368:31:58::1;::::0;20364:128:::1;;20415:66;20446:4;20453:20;:27;;;-1:-1:-1::0;;;;;20415:66:58::1;:22;:66::i;:::-;20506:27:::0;;-1:-1:-1;;;;;20506:31:58::1;::::0;20502:275:::1;;20739:27:::0;;20724:42:::1;::::0;:12;:42:::1;:::i;:::-;20710:11;:56:::0;;-1:-1:-1;;20710:56:58::1;-1:-1:-1::0;;;;;20710:56:58;;;::::1;::::0;;;::::1;::::0;;20502:275:::1;20841:33;::::0;;::::1;::::0;::::1;::::0;;20867:7:::1;20841:33:::0;::::1;::::0;::::1;::::0;;-1:-1:-1;;;;;20841:33:58;;::::1;::::0;::::1;;::::0;::::1;::::0;;;-1:-1:-1;;;20841:33:58;;::::1;;::::0;;;;;;;;20913:25;20909:175:::1;;20981:8;:21;;;20954:8;:23;;:48;;;;;;;:::i;:::-;-1:-1:-1::0;;;;;20954:48:58;;::::1;::::0;;;21040:1:::1;21016:21;::::0;::::1;:25:::0;21055:18;;:7:::1;:18:::0;;::::1;::::0;::::1;::::0;;;::::1;-1:-1:-1::0;;;21055:18:58::1;::::0;;;;::::1;::::0;;::::1;::::0;;;;;;;::::1;::::0;;-1:-1:-1;20909:175:58::1;21144:46;::::0;;::::1;::::0;;21200:33:::1;::::0;::::1;21144:31;21200:33:::0;;;:16:::1;:33;::::0;;;;;;;:51;;;;;;::::1;::::0;;::::1;-1:-1:-1::0;;;21200:51:58::1;::::0;;;;;::::1;::::0;;;;::::1;::::0;;21309:19:::1;21217:15:::0;21200:51;21309:19:::1;:::i;:::-;21292:14;;:36;;;;;;;;;;;;;;;;;;21344:97;21354:15;21371:20;:27;;;21430:10;21400:20;:27;;;:40;;;;:::i;:::-;21344:97;::::0;;21335:12:61;21323:25;;;21305:44;;-1:-1:-1;;;;;21385:39:61;;;21380:2;21365:18;;21358:67;21461:39;;21441:18;;;21434:67;21293:2;21278:18;21344:97:58::1;;;;;;;18329:3119;;;;;;;;;18283:3165::o:0;10924:292::-;11009:18;11037:19;11066:28;11104;11156:53;11178:14;11156:53;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;11156:53:58;;;;;;;;-1:-1:-1;;;11156:53:58;;;;;;;;;;;;;;;;;;;;;;;11194:14;-1:-1:-1;;;;;11156:53:58;:21;:53::i;:::-;11149:60;;;;;;;;10924:292;;;;;:::o;4161:214:33:-;2655:13;:11;:13::i;:::-;4276:36:::1;4294:17;4276;:36::i;:::-;4322:46;4344:17;4363:4;4322:21;:46::i;:::-;4161:214:::0;;:::o;3708:134::-;3777:7;2926:20;:18;:20::i;:::-;-1:-1:-1;811:66:10::1;3708:134:33::0;:::o;2197:129:56:-;-1:-1:-1;;;;;;;;;;;;;;;;;;;;;;;;;2296:23:56;2312:6;2296:15;:23::i;:::-;2289:30;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;2289:30:56;;;;;;;;-1:-1:-1;;;2289:30:56;;;;;;;;;2197:129;-1:-1:-1;;2197:129:56:o;10225:369:60:-;10532:55;;;;;21714:18:61;21702:31;;10532:55:60;;;21684:50:61;-1:-1:-1;;;;;21770:55:61;;21750:18;;;21743:83;10306:13:60;;;;;;;;;;;;;;1617:42;;10532:36;;21657:18:61;;10532:55:60;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;10525:62;;;;-1:-1:-1;10525:62:60;;-1:-1:-1;10525:62:60;;-1:-1:-1;10525:62:60;-1:-1:-1;10525:62:60;-1:-1:-1;10525:62:60;;-1:-1:-1;10225:369:60;-1:-1:-1;;;10225:369:60:o;10362:556:58:-;10445:51;;;;;;;;10483:13;10445:51;;;;;;;;;-1:-1:-1;;;;;10445:51:58;;;;;;;-1:-1:-1;;;10445:51:58;;;;;;;;;;;;-1:-1:-1;;10603:43:58;;:15;:43;:::i;:::-;10588:58;-1:-1:-1;10660:8:58;;10656:256;;10684:17;10704:75;10751:6;-1:-1:-1;;;;;10718:39:58;:30;3981:14:34;;;3850:152;10718:30:58;:39;;;;:::i;:::-;10759:19;;10704:75;;:13;:75::i;:::-;-1:-1:-1;;;;;10684:95:58;;-1:-1:-1;10793:29:58;1362:8;10825:16;10837:4;10684:95;10825:16;:::i;:::-;:23;;;;:::i;:::-;10793:55;-1:-1:-1;10862:39:58;10793:55;10862:39;;:::i;:::-;;;10670:242;;10656:256;10435:483;;10362:556;:::o;25574:637::-;1979:19:36;:17;:19::i;:::-;4133:29:58::1;3272:16:31;3283:4;3272:10;:16::i;:::-;25673:13:58::2;:11;:13::i;:::-;25727;:35:::0;;;::::2;-1:-1:-1::0;;;;;25727:35:58::2;25776:23:::0;;25772:154:::2;;25815:47;25838:2;25842:19;25815:22;:47::i;:::-;25876:13;:39:::0;;;::::2;::::0;;25772:154:::2;25960:7;:22:::0;-1:-1:-1;;;25960:22:58;::::2;-1:-1:-1::0;;;;;25960:22:58::2;25996:17:::0;;25992:148:::2;;26029:60;26064:4;26071:2;26075:13;26029:26;:60::i;:::-;26103:7;:26:::0;;;::::2;::::0;;25992:148:::2;26155:49;::::0;;23545:25:61;;;23601:2;23586:18;;23579:34;;;26155:49:58::2;::::0;23518:18:61;26155:49:58::2;;;;;;;;25663:548;;2008:1:36::1;25574:637:58::0;:::o;21873:517::-;1979:19:36;:17;:19::i;:::-;3953:29:58::1;3272:16:31;3283:4;3272:10;:16::i;:::-;21980:22:58::2;::::0;::::2;;::::0;;;:14:::2;:22;::::0;;;;;::::2;;21975:48;;22011:12;;-1:-1:-1::0;;;22011:12:58::2;;;;;;;;;;;21975:48;22034:17;22054:32;22079:6;22054:24;:32::i;:::-;22113:11:::0;;;;-1:-1:-1;;;;22113:11:58;::::2;-1:-1:-1::0;;;;;22113:11:58::2;22096:14;22138:12:::0;;;22134:35:::2;;22159:10;;-1:-1:-1::0;;;22159:10:58::2;;;;;;;;;;;22134:35;22242:51;22277:6;22285:7;-1:-1:-1::0;;;;;22242:51:58::2;:34;:51::i;:::-;-1:-1:-1::0;;22368:15:58;;-1:-1:-1;;;;;22368:15:58::2;::::0;;-1:-1:-1;;21873:517:58:o;16344:1071::-;16439:13;1979:19:36;:17;:19::i;:::-;16532:10:58::1;16464:46;16513:30:::0;;;:18:::1;:30;::::0;;;;16594:35;;16513:30;;16464:46;16513:30;;16617:11;;16594:35;::::1;;;;;:::i;:::-;;::::0;;;::::1;::::0;;;16553:76:::1;::::0;;::::1;::::0;::::1;::::0;;16594:35;;;::::1;16553:76:::0;-1:-1:-1;;;;;16553:76:58;;::::1;::::0;;-1:-1:-1;;;16553:76:58;::::1;;::::0;;::::1;::::0;-1:-1:-1;;;16553:76:58;::::1;;;::::0;;;;;;-1:-1:-1;;;16553:76:58;;::::1;;;::::0;;;;16705:43;;:16:::1;:43:::0;;;;;16664:84;;;;::::1;::::0;;;;::::1;::::0;;::::1;::::0;;;-1:-1:-1;;;16664:84:58;;::::1;;::::0;;::::1;::::0;;;;16553:76;;-1:-1:-1;16664:84:58;;16787:36;16783:68:::1;;16832:19;;;;;;;;;;;;;;16783:68;16863:19;16887:28;:26;:28::i;:::-;16862:53;;;16978:36;:34;:36::i;:::-;16944:70;;:15;:31;;;:70;;;;:::i;:::-;16929:85;;:12;:85;;;16925:113;;;17023:15;;;;;;;;;;;;;;16925:113;17097:57;17118:22;17142:11;17097:20;:57::i;:::-;17211:17;:27;;;17202:36;;17249:12;17266:8;-1:-1:-1::0;;;;;17266:13:58::1;17287:6;-1:-1:-1::0;;;;;17266:32:58::1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;17248:50;;;17313:7;17308:37;;17329:16;;;;;;;;;;;;;;17308:37;17361:47;::::0;;24203:25:61;;;-1:-1:-1;;;;;24264:39:61;;24259:2;24244:18;;24237:67;17376:10:58::1;::::0;17361:47:::1;::::0;24176:18:61;17361:47:58::1;24030:280:61::0;26925:92:58;4415:23;3272:16:31;3283:4;3272:10;:16::i;:::-;26982:28:58::1;:26;:28::i;26217:297::-:0;4056:28;3272:16:31;3283:4;3272:10;:16::i;:::-;26316:4:58::1;26307:6;:13;;;26303:39;;;26329:13;;;;;;;;;;;;;;26303:39;26366:13;:18:::0;::::1;::::0;;::::1;26356:28:::0;;::::1;::::0;26352:51:::1;;26393:10;;-1:-1:-1::0;;;26393:10:58::1;;;;;;;;;;;26352:51;26413:13;:11;:13::i;:::-;26436;:27:::0;;-1:-1:-1;;26436:27:58::1;;::::0;::::1;::::0;;::::1;::::0;;;26478:29:::1;::::0;16481:38:61;;;26478:29:58::1;::::0;16469:2:61;16454:18;26478:29:58::1;;;;;;;;26217:297:::0;;:::o;2954:148:34:-;3086:9;3079:16;;3001:13;;2064:20;;3079:16;;;:::i;24935:479:58:-;1979:19:36;:17;:19::i;:::-;-1:-1:-1;;;;;25026:9:58::1;:28;25022:58;;;25063:17;;;;;;;;;;;;;;25022:58;25112:11;::::0;-1:-1:-1;;;;;25112:11:58::1;4500;25147:43:::0;::::1;25143:84;;;25199:28;;;;;;;;;;;;;;25143:84;25251:32;25273:9;25251:12:::0;:32:::1;:::i;:::-;25237:11;:46:::0;;-1:-1:-1;;25237:46:58::1;-1:-1:-1::0;;;;;25237:46:58;;::::1;;::::0;;;;-1:-1:-1;;;25314:14:58;::::1;;;-1:-1:-1::0;25293:36:58;;;:20:::1;:36;::::0;;;;:64;;25347:9:::1;::::0;25293:36;;-1:-1:-1;25293:64:58::1;::::0;25347:9;;25293:64:::1;;:::i;:::-;;;;;;;;-1:-1:-1::0;;;;;25293:64:58::1;;;;;-1:-1:-1::0;;;;;25293:64:58::1;;;;;;25372:35;25385:9;25396:10;25372:35;;;;;;24683:25:61::0;;;-1:-1:-1;;;;;24744:55:61;24739:2;24724:18;;24717:83;24671:2;24656:18;;24509:297;3310:1726:56;3389:24;:22;:24::i;:::-;3447:11;;3493:12;3424:20;3522:1471;3542:3;3538:1;:7;3522:1471;;;3570:12;;3583:1;3570:15;;;;;;;:::i;:::-;;;;;;:28;;;;;;;;;;:::i;:::-;3566:1417;;;3618:17;3638:39;3654:12;;3667:1;3654:15;;;;;;;:::i;:::-;:22;;;:15;;;;;:22;;;;-1:-1:-1;3654:22:56;:::i;:::-;3638:15;:39::i;:::-;3714:7;;;;3699:23;;;;:14;:23;;;;;;3618:59;;-1:-1:-1;3699:23:56;;3695:50;;;3731:14;;;;;;;;;;;;;;3695:50;3782:11;;-1:-1:-1;;;3782:11:56;;-1:-1:-1;;;;;3782:11:56;3763:16;3842:12;;3855:1;3842:15;;;;;;;:::i;:::-;;;;;;:21;;;;;;;;;;:::i;:::-;3830:33;;:9;:33;:::i;:::-;3882:23;;-1:-1:-1;;3882:23:56;-1:-1:-1;;;;;;;;3882:23:56;;;;;;;;;;;;;;-1:-1:-1;3938:24:56;;;;:12;:24;:::i;:::-;:36;;;;:::i;:::-;3923:51;;4009:12;;4022:1;4009:15;;;;;;;:::i;:::-;:22;;;:15;;;;;:22;;;;-1:-1:-1;4009:22:56;:::i;:::-;3997:46;;-1:-1:-1;;;;;6726:39:61;;6708:58;;3997:46:56;;;;;;;;6696:2:61;6681:18;3997:46:56;;;;;;;3600:458;;;3566:1417;;;4141:19;4163:20;:44;4184:12;;4197:1;4184:15;;;;;;;:::i;:::-;:22;;;:15;;;;;:22;;;;-1:-1:-1;4184:22:56;:::i;:::-;4163:44;;;;;;;;;;;;;;;;4141:66;;4229:11;4244:1;4229:16;4225:30;;4247:8;;;4225:30;4303:17;4323:5;4329:15;4343:1;4329:11;:15;:::i;:::-;4323:22;;;;;;;;:::i;:::-;;;;;;;;;4382:11;;4323:22;;-1:-1:-1;;;;4382:11:56;;-1:-1:-1;;;;;4382:11:56;;4460:14;;;4456:28;;4476:8;;;;;;4456:28;4549:18;4570:12;;4583:1;4570:15;;;;;;;:::i;:::-;;;;;;:21;;;;;;;;;;:::i;:::-;4549:42;;4702:9;-1:-1:-1;;;;;4688:23:56;:11;-1:-1:-1;;;;;4688:23:56;;4684:105;;;4747:23;4759:11;4747:9;:23;:::i;:::-;4735:35;;4684:105;4807:23;;-1:-1:-1;;;;;4807:23:56;;;-1:-1:-1;;;4807:23:56;;-1:-1:-1;;4807:23:56;;;;;;;;;4863:24;;;;:12;:24;:::i;:::-;:36;;;;:::i;:::-;4848:51;;4934:12;;4947:1;4934:15;;;;;;;:::i;:::-;:22;;;:15;;;;;:22;;;;-1:-1:-1;4934:22:56;:::i;:::-;4922:46;;-1:-1:-1;;;;;6726:39:61;;6708:58;;4922:46:56;;;;;;;;6696:2:61;6681:18;4922:46:56;;;;;;;4064:919;;;;;3566:1417;3547:3;;3522:1471;;;-1:-1:-1;;5003:11:56;:26;-1:-1:-1;;3310:1726:56:o;4401:178:34:-;4470:4;966:10:35;4524:27:34;966:10:35;4541:2:34;4545:5;4524:9;:27::i;5688:877:56:-;5742:28;5763:6;5742:20;:28::i;:::-;5803;;;5781:19;5803:28;;;:20;:28;;;;;;;5845:16;;;5841:42;;5870:13;;;;;;;;;;;;;;5841:42;5894:16;5913:5;5919:15;5933:1;5919:11;:15;:::i;:::-;5913:22;;;;;;;;:::i;:::-;;;;;;;;;;5894:41;;;;;;;;5913:22;;;;5894:41;;;;;;-1:-1:-1;;;;;;;;5894:41:56;;;;;;;;;;-1:-1:-1;;;5894:41:56;;;;;;;;;-1:-1:-1;5974:15:56;5970:40;;5998:12;;-1:-1:-1;;;5998:12:56;;;;;;;;;;;5970:40;6024:11;;;;-1:-1:-1;;;;;6024:15:56;;6020:40;;6048:12;;-1:-1:-1;;;6048:12:56;;;;;;;;;;;6020:40;6095:5;6101:12;;6071:21;;6095:5;6101:16;;6116:1;;6101:16;:::i;:::-;6095:23;;;;;;;;:::i;:::-;;;;;;;;;;;;6217:11;;;;6196:33;;:20;:33;;;;;;;:47;;;6095:23;-1:-1:-1;6095:23:56;6253:5;6259:15;6217:11;6232;6259:15;:::i;:::-;6253:22;;;;;;;;:::i;:::-;;;;;;;;;:33;;:22;;:33;;;;;;;;;;;;;;;-1:-1:-1;;6253:33:56;;;;-1:-1:-1;;;6253:33:56;;;;-1:-1:-1;;;;;6253:33:56;;;;;;;;;;;;-1:-1:-1;;;;;6253:33:56;;;-1:-1:-1;;;6253:33:56;;;;;;;;;;;;;;;;;6339:28;;;;:20;:28;;;;;;6332:35;6377:5;:11;;;;;;;:::i;:::-;;;;;;;;;;-1:-1:-1;;6377:11:56;;;;;;;;;;;;6460:23;;6377:11;6460:23;;:15;:23::i;:::-;-1:-1:-1;6493:22:56;;;6518:5;6493:22;;;:14;:22;;;;;;;;;:30;;-1:-1:-1;;6493:30:56;;;6539:19;;25604:50:61;;;6539:19:56;;25577:18:61;6539:19:56;25460:200:61;7682:84:58;7744:1;;5267:38;:36;:38::i;:::-;:49;;;5263:93;;5318:38;;;;;25867:2:61;5318:38:58;;;25849:21:61;25906:2;25886:18;;;25879:30;25945;25925:18;;;25918:58;25993:18;;5318:38:58;;;;;;;;5263:93;7761:1:::1;6355:30:32;6388:26;:24;:26::i;:::-;6429:15:::0;;;;-1:-1:-1;;;;6429:15:32;::::1;;;::::0;:44:::1;;-1:-1:-1::0;6448:14:32;;:25:::1;::::0;;::::1;:14:::0;::::1;:25;;6429:44;6425:105;;;6496:23;;;;;;;;;;;;;;6425:105;6539:24:::0;;-1:-1:-1;;6573:22:32;6539:24:::1;::::0;::::1;6573:22:::0;;;-1:-1:-1;;;6573:22:32::1;-1:-1:-1::0;;6616:23:32::1;::::0;;6654:20:::1;::::0;25604:50:61;;;6654:20:32::1;::::0;25592:2:61;25577:18;6654:20:32::1;25460:200:61::0;5826:1850:58;5892:1;6355:30:32;6388:26;:24;:26::i;:::-;6429:15;;;;-1:-1:-1;;;;6429:15:32;;;;;:44;;-1:-1:-1;6448:14:32;;:25;;;;:14;;:25;;6429:44;6425:105;;;6496:23;;;;;;;;;;;;;;6425:105;6539:24;;-1:-1:-1;;6573:22:32;6539:24;;;6573:22;-1:-1:-1;;;6573:22:32;;;5905:40:58::1;:38;:40::i;:::-;5955:33;:31;:33::i;:::-;5998:60;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;;;;::::0;:29:::1;:60::i;:::-;6068:47;:45;:47::i;:::-;6125:37;:35;:37::i;:::-;6173:87;2443:4:31;6254:5:58::0;6173:35:::1;:87::i;:::-;;6329:57;3714:26;6380:5;6329:35;:57::i;:::-;;6396:63;3792:32;6453:5;6396:35;:63::i;:::-;;6469:61;3874:30;6524:5;6469:35;:61::i;:::-;;6540:60;3953:29;6594:5;6540:35;:60::i;:::-;;6647:59;4056:28;6700:5;6647:35;:59::i;:::-;;6716:72;4056:28;::::0;6716:38:::1;:72::i;:::-;6798:60;4133:29;6852:5;6798:35;:60::i;:::-;;6868:74;4133:29;::::0;6868:38:::1;:74::i;:::-;6952:62;4213:31;7008:5;6952:35;:62::i;:::-;;7024:78;4213:31;::::0;7024:38:::1;:78::i;:::-;7153:56;4319:25;7203:5;7153:35;:56::i;:::-;;7219:66;4319:25;::::0;7219:38:::1;:66::i;:::-;7349:54;4415:23;7397:5;7349:35;:54::i;:::-;-1:-1:-1::0;7414:14:58::1;:18:::0;;;::::1;-1:-1:-1::0;;;7414:18:58::1;::::0;;7459:160:::1;::::0;;::::1;::::0;::::1;::::0;;7493:4:::1;7459:160:::0;;;-1:-1:-1;7459:160:58::1;::::0;::::1;::::0;7592:15:::1;7414:18;7459:160;::::0;;;;;;7443:13:::1;:176:::0;;-1:-1:-1;;;7443:176:58;;::::1;::::0;;;;;;;;;;;7629:7:::1;:16:::0;;-1:-1:-1;;7629:16:58::1;7644:1;7629:16;::::0;;6616:23:32;;-1:-1:-1;;6616:23:32;;;6654:20;;;;;6666:7;;25634:18:61;25622:31;;;;25604:50;;25592:2;25577:18;;25460:200;23914:732:58;1979:19:36;:17;:19::i;:::-;24094:14:58;;23990:22:::1;::::0;24048:21:::1;::::0;23990:22;24118:342:::1;24137:3;24133:1;:7;;;24118:342;;;24161:42;24192:7;24200:1;24192:10;;;;;;;;;;:::i;:::-;;;;;;;24161:30;:42::i;:::-;24217:19;24281:14:::0;24239:39:::1;24263:15:::0;24239:21:::1;:39;:::i;:::-;:56;;;;:::i;:::-;24217:78:::0;-1:-1:-1;24313:15:58;;24309:141:::1;;24348:29;24366:11:::0;24348:29;::::1;:::i;:::-;;;24411:7;24419:1;24411:10;;;;;;;;;;:::i;:::-;;;;;;;24400:35;;;24423:11;24400:35;;;;689:25:61::0;;677:2;662:18;;543:177;24400:35:58::1;;;;;;;;24309:141;-1:-1:-1::0;24142:3:58::1;::::0;::::1;:::i;:::-;;;24118:342;;;;24474:14;24492:1;24474:19:::0;24470:42:::1;;24502:10;;-1:-1:-1::0;;;24502:10:58::1;;;;;;;;;;;24470:42;24523:11;:37:::0;;24545:14;;24523:11;::::1;::::0;:37:::1;::::0;24545:14;;-1:-1:-1;;;;;24523:37:58::1;;:::i;:::-;::::0;;::::1;::::0;;;::::1;-1:-1:-1::0;;;;;24523:37:58;;::::1;;::::0;;::::1;::::0;;::::1;;;::::0;;;24591:14:::1;::::0;-1:-1:-1;;;24591:14:58;::::1;;;-1:-1:-1::0;24570:36:58;;;:20:::1;:36;::::0;;;;:69;;24624:14;;-1:-1:-1;24570:36:58;;:69:::1;::::0;24624:14;;24570:69:::1;;:::i;5710:138:31:-:0;4872:7;4967:14;;;3001:28;4967:14;;;;;:24;;;3272:16;3283:4;3272:10;:16::i;:::-;5815:26:::1;5827:4;5833:7;5815:11;:26::i;5245:332:56:-:0;5300:23;:21;:23::i;:::-;5338:22;;;;;;;:14;:22;;;;;;;;5334:45;;;5369:10;;-1:-1:-1;;;5369:10:56;;;;;;;;;;;5334:45;5390:17;5410:23;5426:6;5410:15;:23::i;:::-;5458:11;;5443;:26;;5458:11;;-1:-1:-1;;;;5458:11:56;;;-1:-1:-1;;;;;5458:11:56;;;;5443:26;;5458:11;;5443:26;:::i;:::-;;;;-1:-1:-1;;5479:15:56;;-1:-1:-1;;5479:15:56;;;5505:22;;;-1:-1:-1;5505:22:56;;;:14;:22;;;;;;;;;:29;;-1:-1:-1;;5505:29:56;-1:-1:-1;5505:29:56;;;5550:20;;25604:50:61;;;5550:20:56;;25577:18:61;5550:20:56;25460:200:61;8597:409:58;8706:11;;8658:13;;-1:-1:-1;;;;;8706:11:58;8741:17;;;8737:263;;8880:6;8871:15;;8737:263;;;8976:12;8959:13;:11;:13::i;:::-;-1:-1:-1;;;;;8951:22:58;8941:6;-1:-1:-1;;;;;8933:15:58;:40;;;;:::i;:::-;:55;;;;:::i;:::-;8917:72;;8737:263;8673:333;8597:409;;;:::o;2054:87:56:-;2097:13;2129:5;2122:12;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;2122:12:56;;;;;;;;-1:-1:-1;;;2122:12:56;;;;;;;;;;;;;;;;;;;;;;;;;2054:87;:::o;26520:248:58:-;4056:28;3272:16:31;3283:4;3272:10;:16::i;:::-;26613:2:58::1;26604:6;:11;;;26600:37;;;26624:13;;;;;;;;;;;;;;26600:37;26661:7;:12:::0;::::1;::::0;;::::1;26651:22:::0;;::::1;::::0;26647:45:::1;;26682:10;;-1:-1:-1::0;;;26682:10:58::1;;;;;;;;;;;26647:45;26702:7;:21:::0;;-1:-1:-1;;26702:21:58::1;;::::0;::::1;::::0;;::::1;::::0;;;26738:23:::1;::::0;16481:38:61;;;26738:23:58::1;::::0;16469:2:61;16454:18;26738:23:58::1;16337:188:61::0;9215:399:58;9276:13;9301:20;9324:13;:11;:13::i;:::-;-1:-1:-1;;;;;9301:36:58;;;9351:12;9367:1;9351:17;9347:261;;9490:6;9481:15;;9347:261;;;9569:11;;9584:12;;9543:38;;-1:-1:-1;;;;;9569:11:58;;;;9543:15;;:38;:::i;5059:61::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;5059:61:58;;;;-1:-1:-1;;;;5059:61:58;;;;-1:-1:-1;;;;5059:61:58;;;;;-1:-1:-1;;;5059:61:58;;;;;:::o;9905:128:34:-;9989:37;9998:5;10005:7;10014:5;10021:4;9989:8;:37::i;2709:128:36:-;1270:23;2625:9;;;2770:61;;;2805:15;;;;;;;;;;;;;;2770:61;2709:128::o;7980:978:60:-;8052:23;2359:21;8152;;;8107:42;8152:21;;;;;;;;;;;8107:66;;;;;;;;;;;;;;;;;;;;;;;;;;;8052:45;;-1:-1:-1;8107:66:60;8230:37;;-1:-1:-1;8230:77:60;;8285:17;:22;;;8230:77;;;8270:12;8230:77;8208:99;;8396:13;:18;;8413:1;8396:18;8392:31;;8416:7;;;7980:978;;:::o;8392:31::-;8438:9;8433:299;8453:13;8449:17;;:1;:17;8433:299;;;8487:16;8506:77;8518:17;:24;;;8550:1;1720:3;8506:11;:77::i;:::-;8612:52;;;;;26220:18:61;26208:31;;8612:52:60;;;26190:50:61;26288:4;26276:17;;26256:18;;;26249:45;8487:96:60;;-1:-1:-1;8597:12:60;;1617:42;;8612:32;;26163:18:61;;8612:52:60;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;8597:67;;8683:7;8678:43;;8699:22;;-1:-1:-1;;;8699:22:60;;;;;;;;;;;8678:43;-1:-1:-1;;8468:3:60;;8433:299;;;-1:-1:-1;8781:24:60;;8769:82;;8807:13;1720:3;8769:11;:82::i;:::-;8742:109;;;;8861:22;;;:39;;8887:13;;8861:22;:39;;8887:13;;8861:39;:::i;:::-;;;;;;;;8910:21;;;;:13;:21;;;;;;;;;;:41;;;;;;;;;;;;;-1:-1:-1;;8910:41:60;;;;;;;;;;;;;;;;;;-1:-1:-1;;;7980:978:60:o;4196:103:31:-;4262:30;4273:4;966:10:35;4262::31;:30::i;27649:172:58:-;27729:6;1319;27784:8;27791:1;1319:6;27784:8;:::i;:::-;27762:31;;:18;27771:9;27762:6;:18;:::i;:::-;:31;;;;:::i;:::-;27761:40;;;;:::i;33034:431::-;33149:12;;33128:18;;33149:16;;33164:1;;33149:16;:::i;:::-;33128:37;;33188:10;33179:5;:19;33175:228;;33375:5;33381:10;33375:17;;;;;;;;:::i;:::-;;;;;;;;33360:5;33366;33360:12;;;;;;;;:::i;:::-;;;;;;;;;:32;;:12;;:32;;-1:-1:-1;;33360:32:58;;-1:-1:-1;;;;;33360:32:58;;;;;;;;;;-1:-1:-1;;;33360:32:58;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;33360:32:58;;;;;;;;;;;;;;;;-1:-1:-1;;;33360:32:58;;;;;;;;;;;;;;;;;;;;;33175:228;33447:5;:11;;;;;;;:::i;:::-;;;;;;;;;;-1:-1:-1;;33447:11:58;;;;;;;;;;;;-1:-1:-1;;;33034:431:58:o;6509:300:34:-;-1:-1:-1;;;;;6592:18:34;;6588:86;;6633:30;;;;;6660:1;6633:30;;;27020:74:61;26993:18;;6633:30:34;26874:226:61;6588:86:34;-1:-1:-1;;;;;6687:16:34;;6683:86;;6726:32;;;;;6755:1;6726:32;;;27020:74:61;26993:18;;6726:32:34;26874:226:61;6683:86:34;6778:24;6786:4;6792:2;6796:5;6778:7;:24::i;33720:743:58:-;33761:51;;;;;;;;33799:13;33761:51;;;;;;;;;-1:-1:-1;;;;;33761:51:58;;;;;-1:-1:-1;;;33761:51:58;;;;;;;;;;;-1:-1:-1;;33862:43:58;;:15;:43;:::i;:::-;33847:58;-1:-1:-1;33919:8:58;;33915:542;;33943:17;33963:105;34010:14;:36;;;-1:-1:-1;;;;;33977:69:58;:30;3981:14:34;;;3850:152;33963:105:58;-1:-1:-1;;;;;33943:125:58;;-1:-1:-1;34082:29:58;1362:8;34114:16;34126:4;33943:125;34114:16;:::i;:::-;:23;;;;:::i;:::-;34082:55;;34236:21;34197:14;:36;;;-1:-1:-1;;;;;34197:60:58;;;;;:::i;:::-;-1:-1:-1;;;;;34151:107:58;:36;;;;:107;;;34307:15;34272:51;;:25;;;;:51;;;34337:30;;:13;:30;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;34337:30:58;;;;;;;;;;34387:59;6708:58:61;;;34387:59:58;;6681:18:61;34387:59:58;6564:208:61;8637::34;-1:-1:-1;;;;;8707:21:34;;8703:91;;8751:32;;;;;8780:1;8751:32;;;27020:74:61;26993:18;;8751:32:34;26874:226:61;8703:91:34;8803:35;8819:1;8823:7;8832:5;8803:7;:35::i;11649:476::-;-1:-1:-1;;;;;4771:20:34;;;11748:24;4771:20;;;:13;:20;;;;;;;;:29;;;;;;;;;;-1:-1:-1;;11814:36:34;;11810:309;;;11889:5;11870:16;:24;11866:130;;;11921:60;;;;;-1:-1:-1;;;;;27325:55:61;;11921:60:34;;;27307:74:61;27397:18;;;27390:34;;;27440:18;;;27433:34;;;27280:18;;11921:60:34;27105:368:61;11866:130:34;12037:57;12046:5;12053:7;12081:5;12062:16;:24;12088:5;12037:8;:57::i;7318:387:31:-;7395:4;3949:14;;;3001:28;3949:14;;;;;;;;-1:-1:-1;;;;;3949:31:31;;;;;;;;;;;;7480:219;;7523:8;:14;;;;;;;;;;;-1:-1:-1;;;;;7523:31:31;;;;;;;;;:38;;-1:-1:-1;;7523:38:31;7557:4;7523:38;;;7607:12;966:10:35;;887:96;7607:12:31;-1:-1:-1;;;;;7580:40:31;7598:7;-1:-1:-1;;;;;7580:40:31;7592:4;7580:40;;;;;;;;;;7641:4;7634:11;;;;;7480:219;7683:5;7676:12;;;;;7875:78:58;3714:26;3272:16:31;3283:4;3272:10;:16::i;15133:129:30:-;15200:4;15223:32;15228:3;15248:5;15223:4;:32::i;7942:388:31:-;8020:4;3949:14;;;3001:28;3949:14;;;;;;;;-1:-1:-1;;;;;3949:31:31;;;;;;;;;;;;8105:219;;;8181:5;8147:14;;;;;;;;;;;-1:-1:-1;;;;;8147:31:31;;;;;;;;;;:39;;-1:-1:-1;;8147:39:31;;;8205:40;966:10:35;;8147:14:31;;8205:40;;8181:5;8205:40;8266:4;8259:11;;;;;11646:150:60;11718:5;11784:3;11776:12;;11770:1;11762:10;;11757:1;11749:10;;:23;;;;:::i;:::-;11748:40;;;;:::i;:::-;11735:54;11646:150;-1:-1:-1;;;;11646:150:60:o;17394:270:30:-;17454:16;17482:22;17507:19;17515:3;17507:7;:19::i;3478:178:36:-;2226:16;:14;:16::i;:::-;1270:23;3595:17;;-1:-1:-1;;3595:17:36::1;::::0;;3627:22:::1;966:10:35::0;3636:12:36::1;3627:22;::::0;-1:-1:-1;;;;;27038:55:61;;;27020:74;;27008:2;26993:18;3627:22:36::1;;;;;;;3526:130;3478:178::o:0;9144:388:60:-;9262:32;;;9202:23;9262:32;;;:24;:32;;;;;;2359:21;;9262:32;;9257:78;;9303:32;;;;;;;;;;;;;;9257:78;9361:60;;;;;26220:18:61;26208:31;;9361:60:60;;;26190:50:61;1785:3:60;26256:18:61;;;26249:45;9346:12:60;;1617:42;;9361:32;;26163:18:61;;9361:60:60;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;9346:75;;9436:7;9431:43;;9452:22;;-1:-1:-1;;;9452:22:60;;;;;;;;;;;9431:43;-1:-1:-1;9485:32:60;;;;9520:5;9485:32;;;:24;;;;:32;;;;;:40;;-1:-1:-1;;9485:40:60;;;9144:388::o;27125:310:58:-;27171:19;27192:20;27225;27247:26;27277:28;:26;:28::i;:::-;27224:81;;;;27330:13;27315:28;;27369:21;:59;;27412:16;:12;27427:1;27412:16;:::i;:::-;27369:59;;;27393:16;:12;27408:1;27393:16;:::i;:::-;27353:75;;27214:221;;27125:310;;:::o;30274:1006::-;30434:20;;30379;;30478:17;;;30474:47;;30504:17;;;;;;;;;;;;;;30474:47;30532:20;30555:14;30532:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;30532:37:58;;;;;;;;-1:-1:-1;;;30532:37:58;;;;;;;;;;;;;;;;;;;;;;;;;30614:19;30636:28;30668:122;30703:6;30738:16;30723:12;:31;;;;:::i;:::-;-1:-1:-1;;;;;30668:122:58;:21;:122::i;:::-;30611:179;;;;;;30801:24;30844:16;30828:13;:32;;;;:::i;:::-;-1:-1:-1;;;;;30801:59:58;;;30871:9;30883:6;:13;30871:25;;30911:9;30906:368;30926:1;30922;:5;30906:368;;;30948:17;31012:12;-1:-1:-1;;;;;30975:49:58;30994:12;31007:1;30994:15;;;;;;;;:::i;:::-;;;;;;;-1:-1:-1;;;;;30975:34:58;:16;:34;;;;:::i;:::-;:49;;;;:::i;:::-;30948:77;-1:-1:-1;;;;;;31044:14:58;;;31040:224;;31124:10;31105:6;31112:1;31105:9;;;;;;;;:::i;:::-;;;;;;;:16;;;:29;;;;:::i;:::-;31078:14;31093:1;31078:17;;;;;;;;:::i;:::-;;;;;;;;:24;;;:56;;;;;-1:-1:-1;;;;;31078:56:58;;;;;-1:-1:-1;;;;;31078:56:58;;;;;;31152:52;31179:6;31186:1;31179:9;;;;;;;;:::i;:::-;;;;;;;:12;;;31193:10;-1:-1:-1;;;;;31152:52:58;:26;:52::i;:::-;31222:27;31239:10;31222:27;;:::i;:::-;;;31040:224;-1:-1:-1;30929:3:58;;30906:368;;;;30401:879;;;;;;30274:1006;;;;;:::o;31981:904::-;32088:22;32122:20;32145:14;32122:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;32122:37:58;;;;;;;;-1:-1:-1;;;32122:37:58;;;;;;;;;;;;;;;;;;;;;;;;;32202:18;32223:28;32256:122;32291:6;32326:16;32311:12;:31;;;;:::i;32256:122::-;32201:177;;;;;;32389:26;32437:13;32418:16;:32;;;;:::i;:::-;-1:-1:-1;;;;;32389:61:58;;;32461:9;32473:6;:13;32461:25;;32501:9;32496:383;32516:1;32512;:5;32496:383;;;32538:19;32606:11;-1:-1:-1;;;;;32567:50:58;32588:12;32601:1;32588:15;;;;;;;;:::i;:::-;;;;;;;-1:-1:-1;;;;;32567:36:58;:18;:36;;;;:::i;:::-;:50;;;;:::i;:::-;32538:80;-1:-1:-1;;;;;;32637:16:58;;;32633:236;;32719:12;32700:6;32707:1;32700:9;;;;;;;;:::i;:::-;;;;;;;:16;;;:31;;;;:::i;:::-;32673:14;32688:1;32673:17;;;;;;;;:::i;:::-;;;;;;;;;;:58;;-1:-1:-1;;;;;32673:58:58;;;;-1:-1:-1;;;32673:58:58;-1:-1:-1;;;;;32673:58:58;;;;;;;;;32749:31;32768:12;32749:31;;:::i;:::-;;;32798:56;32827:6;32834:1;32827:9;;;;;;;;:::i;:::-;;;;;;;:12;;;32841;-1:-1:-1;;;;;32798:56:58;:28;:56::i;:::-;;32633:236;-1:-1:-1;32519:3:58;;32496:383;;;;32112:773;;;;;31981:904;;;;;:::o;9163:206:34:-;-1:-1:-1;;;;;9233:21:34;;9229:89;;9277:30;;;;;9304:1;9277:30;;;27020:74:61;26993:18;;9277:30:34;26874:226:61;9229:89:34;9327:35;9335:7;9352:1;9356:5;9327:7;:35::i;28323:1258:58:-;28618:20;;28673:12;;28455:18;;;;28512:28;;;;28673:12;28710:17;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;28710:17:58;;28695:32;;28765:3;28752:17;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;28752:17:58;;28737:32;;28785:9;28780:795;28800:3;28796:1;:7;28780:795;;;28824:27;28854:5;28860:1;28854:8;;;;;;;;:::i;:::-;;;;;;;:15;;;-1:-1:-1;;;;;28824:45:58;;;28883:27;28928:1;28913:12;:16;:82;;28994:1;28913:82;;;28979:12;28960:5;28966:1;28960:8;;;;;;;;:::i;:::-;;;;;;;:15;;;-1:-1:-1;;;;;28952:24:58;28932:17;:44;;;;:::i;:::-;:59;;;;:::i;:::-;28883:112;;29036:19;29014;:41;29010:555;;;29119:12;29134:41;29156:19;29134;:41;:::i;:::-;29119:56;-1:-1:-1;29193:27:58;29119:56;29193:27;;:::i;:::-;;;29263:4;29238:12;29251:1;29238:15;;;;;;;;:::i;:::-;;;;;;:30;-1:-1:-1;;;;;29238:30:58;;;-1:-1:-1;;;;;29238:30:58;;;;;29057:226;29010:555;;;29315:19;29293;:41;29289:276;;;29400:12;29415:41;29437:19;29415;:41;:::i;:::-;29400:56;-1:-1:-1;29474:28:58;29400:56;29474:28;;:::i;:::-;;;29545:4;29520:12;29533:1;29520:15;;;;;;;;:::i;:::-;;;;;;:30;-1:-1:-1;;;;;29520:30:58;;;-1:-1:-1;;;;;29520:30:58;;;;;29336:229;29289:276;-1:-1:-1;;28805:3:58;;28780:795;;;;28585:996;;28323:1258;;;;;;;:::o;4578:312:33:-;4658:4;-1:-1:-1;;;;;4667:6:33;4650:23;;;:120;;;4764:6;-1:-1:-1;;;;;4728:42:33;:32;811:66:10;1519:53;-1:-1:-1;;;;;1519:53:10;;1441:138;4728:32:33;-1:-1:-1;;;;;4728:42:33;;;4650:120;4633:251;;;4844:29;;;;;;;;;;;;;;7772:97:58;4319:25;3272:16:31;3283:4;3272:10;:16::i;6032:538:33:-;6149:17;-1:-1:-1;;;;;6131:50:33;;:52;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;6131:52:33;;;;;;;;-1:-1:-1;;6131:52:33;;;;;;;;;;;;:::i;:::-;;;6127:437;;6493:60;;;;;-1:-1:-1;;;;;27038:55:61;;6493:60:33;;;27020:74:61;26993:18;;6493:60:33;26874:226:61;6127:437:33;811:66:10;6225:40:33;;6221:120;;6292:34;;;;;;;;689:25:61;;;662:18;;6292:34:33;543:177:61;6221:120:33;6354:54;6384:17;6403:4;6354:29;:54::i;5007:213::-;5081:4;-1:-1:-1;;;;;5090:6:33;5073:23;;5069:145;;5174:29;;;;;;;;;;;;;;6722:210:56;6826:28;;;6785:17;6826:28;;;:20;:28;;;;;;6868:6;;;6864:32;;6883:13;;;;;;;;;;;;;;6864:32;6913:5;6919;6923:1;6919;:5;:::i;:::-;6913:12;;;;;;;;:::i;:::-;;;;;;;;6906:19;;6804:128;6722:210;;;:::o;5865:372:60:-;6027:32;;;5940:16;6027:32;;;:24;:32;;;;;;2359:21;;6027:32;;6023:68;;;6068:23;;;;;;;;;;;;;;6023:68;1785:3;6101:31;;6142:39;6154:6;6162;6170:10;6142:11;:39::i;:::-;6191:32;;;;;;;;6226:4;6191:24;;;:32;;;;;:39;;-1:-1:-1;;6191:39:60;;;;;;;-1:-1:-1;5865:372:60;:::o;3132:138::-;3170:12;3184:26;1617:42;-1:-1:-1;;;;;3229:32:60;;:34;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;3222:41;;;;3132:138;;:::o;3499:304::-;3550:5;3596:13;3613:3;3596:20;3592:34;;-1:-1:-1;3625:1:60;;3499:304::o;3592:34::-;3672:13;3689:5;3672:22;3668:36;;-1:-1:-1;3703:1:60;;3499:304::o;3668:36::-;3745:13;3762:5;3745:22;3741:36;;-1:-1:-1;3776:1:60;;3499:304::o;3741:36::-;-1:-1:-1;3795:1:60;;3499:304::o;3170:176:36:-;1979:19;:17;:19::i;:::-;1270:23;3288:16;;-1:-1:-1;;3288:16:36::1;3300:4;3288:16;::::0;;3319:20:::1;966:10:35::0;3326:12:36::1;887:96:35::0;7958:89:58;3792:32;3272:16:31;3283:4;3272:10;:16::i;8143:284:58:-;3953:29;3272:16:31;3283:4;3272:10;:16::i;:::-;11416:21:60;;;8299:1:58::1;11416:21:60::0;;;2359;11416;;;;;:26;;;;;;8252:48:58::1;8248:81;;;8309:20;;;;;;;;;;;;;;8248:81;11601:32:60::0;;;11523:4;11601:32;;;:24;:32;;;;;;;;8339:81:58::1;;;8400:20;;;;;;;;;;;;;;15430:135:30::0;15500:4;15523:35;15531:3;15551:5;15523:7;:35::i;8241:128:32:-;8298:6;8323:26;:24;:26::i;:::-;:39;;;;8241:128;-1:-1:-1;8241:128:32:o;9071:205::-;9129:30;;3147:66;9186:27;8819:122;2970:67:33;6929:20:32;:18;:20::i;2263:147:34:-;6929:20:32;:18;:20::i;:::-;2365:38:34::1;2388:5;2395:7;2365:22;:38::i;6766:318:31:-:0;3001:28;6849:30;6946:18;6959:4;4872:7;4967:14;;;3001:28;4967:14;;;;;:24;;;;4807:191;6946:18;6974:8;:14;;;;;;;;;;;:24;;:36;;;7025:52;6918:46;;-1:-1:-1;7001:9:31;;6918:46;;6983:4;;7025:52;;6974:8;7025:52;6839:245;;6766:318;;:::o;9919:175:60:-;9990:44;;;;;25634:18:61;25622:31;;9990:44:60;;;25604:50:61;9975:12:60;;1617:42;;9990:36;;25577:18:61;;9990:44:60;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;9975:59;;10049:7;10044:43;;10065:22;;-1:-1:-1;;;10065:22:60;;;;;;;;;;;8052:86:58;3874:30;3272:16:31;3283:4;3272:10;:16::i;10880:487:34:-;2064:20;-1:-1:-1;;;;;11045:19:34;;11041:89;;11087:32;;;;;11116:1;11087:32;;;27020:74:61;26993:18;;11087:32:34;26874:226:61;11041:89:34;-1:-1:-1;;;;;11143:21:34;;11139:90;;11187:31;;;;;11215:1;11187:31;;;27020:74:61;26993:18;;11187:31:34;26874:226:61;11139:90:34;-1:-1:-1;;;;;11238:20:34;;;;;;;:13;;;:20;;;;;;;;:29;;;;;;;;;:37;;;11285:76;;;;11335:7;-1:-1:-1;;;;;11319:31:34;11328:5;-1:-1:-1;;;;;11319:31:34;;11344:5;11319:31;;;;689:25:61;;677:2;662:18;;543:177;11319:31:34;;;;;;;;11285:76;10978:389;10880:487;;;;:::o;4429:197:31:-;3857:4;3949:14;;;3001:28;3949:14;;;;;;;;-1:-1:-1;;;;;3949:31:31;;;;;;;;;;;;4512:108;;4562:47;;;;;-1:-1:-1;;;;;28358:55:61;;4562:47:31;;;28340:74:61;28430:18;;;28423:34;;;28313:18;;4562:47:31;28166:297:61;7124:1170:34;2064:20;-1:-1:-1;;;;;7266:18:34;;7262:546;;7420:5;7402:1;:14;;;:23;;;;;;;:::i;:::-;;;;-1:-1:-1;7262:546:34;;-1:-1:-1;7262:546:34;;-1:-1:-1;;;;;7478:17:34;;7456:19;7478:17;;;;;;;;;;;7513:19;;;7509:115;;;7559:50;;;;;-1:-1:-1;;;;;27325:55:61;;7559:50:34;;;27307:74:61;27397:18;;;27390:34;;;27440:18;;;27433:34;;;27280:18;;7559:50:34;27105:368:61;7509:115:34;-1:-1:-1;;;;;7744:17:34;;:11;:17;;;;;;;;;;7764:19;;;;7744:39;;7262:546;-1:-1:-1;;;;;7822:16:34;;7818:429;;7985:14;;;:23;;;;;;;7818:429;;;-1:-1:-1;;;;;8198:15:34;;:11;:15;;;;;;;;;;:24;;;;;;7818:429;8277:2;-1:-1:-1;;;;;8262:25:34;8271:4;-1:-1:-1;;;;;8262:25:34;;8281:5;8262:25;;;;689::61;;677:2;662:18;;543:177;8262:25:34;;;;;;;;7199:1095;7124:1170;;;:::o;2497:406:30:-;2560:4;5197:21;;;:14;;;:21;;;;;;2576:321;;-1:-1:-1;2618:23:30;;;;;;;;:11;:23;;;;;;;;;;;;;2800:18;;2776:21;;;:14;;;:21;;;;;;:42;;;;2832:11;;2576:321;-1:-1:-1;2881:5:30;2874:12;;6418:109;6474:16;6509:3;:11;;6502:18;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;6418:109;;;:::o;2909:126:36:-;1270:23;2625:9;;;2967:62;;3003:15;;;;;;;;;;;;;;4214:198:60;4297:55;;;;;25634:18:61;25622:31;;4297:55:60;;;25604:50:61;4282:12:60;;1617:42;;4297:32;;4337:6;;25577:18:61;;4297:55:60;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;4282:70;;4367:7;4362:43;;4383:22;;-1:-1:-1;;;4383:22:60;;;;;;;;;;;4792:770;4990:21;;;4861:16;4990:21;;;2359;4990;;;;;;;;5021:63;;;;;;;;;;;;;;;;;;;;;;;;;;;4990:21;5124:55;;5120:91;;5188:23;;;;;;;;;;;;;;5120:91;5315:93;5327:18;:25;;;5354:18;:23;;;1720:3;5315:11;:93::i;:::-;5302:106;;5478:18;:23;;;5504:1;5478:27;;;;:::i;:::-;5453:52;;;;;;;;;;;;;;;;5516:39;5528:6;5536;5544:10;5516:11;:39::i;:::-;4879:683;;;4792:770;;;;:::o;2264:344:10:-;2355:37;2374:17;2355:18;:37::i;:::-;2407:36;;-1:-1:-1;;;;;2407:36:10;;;;;;;;2458:11;;:15;2454:148;;2489:53;2518:17;2537:4;2489:28;:53::i;2454:148::-;2573:18;:16;:18::i;6995:225:60:-;7098:62;;;;;28847:18:61;28835:31;;7098:62:60;;;28817:50:61;28883:18;;;28876:34;;;28958:4;28946:17;;28926:18;;;28919:45;7083:12:60;;1617:42;;7098:34;;28790:18:61;;7098:62:60;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;7083:77;;7175:7;7170:43;;7191:22;;-1:-1:-1;;;7191:22:60;;;;;;;;;;;3071:1368:30;3137:4;3266:21;;;:14;;;:21;;;;;;3302:13;;3298:1135;;3669:18;3690:12;3701:1;3690:8;:12;:::i;:::-;3736:18;;3669:33;;-1:-1:-1;3716:17:30;;3736:22;;3757:1;;3736:22;:::i;:::-;3716:42;;3791:9;3777:10;:23;3773:378;;3820:17;3840:3;:11;;3852:9;3840:22;;;;;;;;:::i;:::-;;;;;;;;;3820:42;;3987:9;3961:3;:11;;3973:10;3961:23;;;;;;;;:::i;:::-;;;;;;;;;;;;:35;;;;4100:25;;;:14;;;:25;;;;;:36;;;3773:378;4229:17;;:3;;:17;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;4332:3;:14;;:21;4347:5;4332:21;;;;;;;;;;;4325:28;;;4375:4;4368:11;;;;;;;7082:141:32;7149:17;:15;:17::i;:::-;7144:73;;7189:17;;;;;;;;;;;;;;2416:216:34;6929:20:32;:18;:20::i;:::-;2064::34;2581:7;:15:::1;2591:5:::0;2581:7;:15:::1;:::i;:::-;-1:-1:-1::0;2606:9:34::1;::::0;::::1;:19;2618:7:::0;2606:9;:19:::1;:::i;1671:281:10:-:0;1748:17;-1:-1:-1;;;;;1748:29:10;;1781:1;1748:34;1744:119;;1805:47;;;;;-1:-1:-1;;;;;27038:55:61;;1805:47:10;;;27020:74:61;26993:18;;1805:47:10;26874:226:61;1744:119:10;811:66;1872:73;;-1:-1:-1;;1872:73:10;-1:-1:-1;;;;;1872:73:10;;;;;;;;;;1671:281::o;3916:253:18:-;3999:12;4024;4038:23;4065:6;-1:-1:-1;;;;;4065:19:18;4085:4;4065:25;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4023:67;;;;4107:55;4134:6;4142:7;4151:10;4107:26;:55::i;:::-;4100:62;3916:253;-1:-1:-1;;;;;3916:253:18:o;6113:122:10:-;6163:9;:13;6159:70;;6199:19;;;;;;;;;;;;;;8485:120:32;8535:4;8558:26;:24;:26::i;:::-;:40;-1:-1:-1;;;8558:40:32;;;;;;-1:-1:-1;8485:120:32:o;4437:582:18:-;4581:12;4610:7;4605:408;;4633:19;4641:10;4633:7;:19::i;:::-;4605:408;;;4857:17;;:22;:49;;;;-1:-1:-1;;;;;;4883:18:18;;;:23;4857:49;4853:119;;;4933:24;;;;;-1:-1:-1;;;;;27038:55:61;;4933:24:18;;;27020:74:61;26993:18;;4933:24:18;26874:226:61;4853:119:18;-1:-1:-1;4992:10:18;4985:17;;5559:434;5690:17;;:21;5686:301;;5894:10;5888:17;5881:4;5869:10;5865:21;5858:48;5686:301;5957:19;;;;;;;;;;;;;;14:332:61;72:6;125:2;113:9;104:7;100:23;96:32;93:52;;;141:1;138;131:12;93:52;180:9;167:23;230:66;223:5;219:78;212:5;209:89;199:117;;312:1;309;302:12;725:477;874:2;863:9;856:21;837:4;906:6;900:13;949:6;944:2;933:9;929:18;922:34;1008:6;1003:2;995:6;991:15;986:2;975:9;971:18;965:50;1064:1;1059:2;1050:6;1039:9;1035:22;1031:31;1024:42;1193:2;-1:-1:-1;;1118:2:61;1110:6;1106:15;1102:88;1091:9;1087:104;1083:113;1075:121;;;725:477;;;;:::o;1207:154::-;-1:-1:-1;;;;;1286:5:61;1282:54;1275:5;1272:65;1262:93;;1351:1;1348;1341:12;1366:367;1434:6;1442;1495:2;1483:9;1474:7;1470:23;1466:32;1463:52;;;1511:1;1508;1501:12;1463:52;1550:9;1537:23;1569:31;1594:5;1569:31;:::i;:::-;1619:5;1697:2;1682:18;;;;1669:32;;-1:-1:-1;;;1366:367:61:o;1937:184::-;-1:-1:-1;;;1986:1:61;1979:88;2086:4;2083:1;2076:15;2110:4;2107:1;2100:15;2126:334;2197:2;2191:9;2253:2;2243:13;;-1:-1:-1;;2239:86:61;2227:99;;2356:18;2341:34;;2377:22;;;2338:62;2335:88;;;2403:18;;:::i;:::-;2439:2;2432:22;2126:334;;-1:-1:-1;2126:334:61:o;2465:129::-;2550:18;2543:5;2539:30;2532:5;2529:41;2519:69;;2584:1;2581;2574:12;2599:794;2652:5;2705:3;2698:4;2690:6;2686:17;2682:27;2672:55;;2723:1;2720;2713:12;2672:55;2763:6;2750:20;2793:18;2785:6;2782:30;2779:56;;;2815:18;;:::i;:::-;2861:6;2858:1;2854:14;2888:30;2912:4;2908:2;2904:13;2888:30;:::i;:::-;2954:19;;;2998:4;3030:15;;;3026:26;;;2989:14;;;;3064:15;;;3061:35;;;3092:1;3089;3082:12;3061:35;3128:4;3120:6;3116:17;3105:28;;3142:220;3158:6;3153:3;3150:15;3142:220;;;3240:3;3227:17;3257:30;3281:5;3257:30;:::i;:::-;3300:18;;3347:4;3175:14;;;;3338;;;;3142:220;;;3380:7;2599:794;-1:-1:-1;;;;;;2599:794:61:o;3398:503::-;3488:6;3496;3549:2;3537:9;3528:7;3524:23;3520:32;3517:52;;;3565:1;3562;3555:12;3517:52;3605:9;3592:23;3638:18;3630:6;3627:30;3624:50;;;3670:1;3667;3660:12;3624:50;3693:60;3745:7;3736:6;3725:9;3721:22;3693:60;:::i;:::-;3683:70;;;3803:2;3792:9;3788:18;3775:32;3847:4;3840:5;3836:16;3829:5;3826:27;3816:55;;3867:1;3864;3857:12;3816:55;3890:5;3880:15;;;3398:503;;;;;:::o;3906:247::-;3965:6;4018:2;4006:9;3997:7;3993:23;3989:32;3986:52;;;4034:1;4031;4024:12;3986:52;4073:9;4060:23;4092:31;4117:5;4092:31;:::i;4158:970::-;4412:2;4424:21;;;4494:13;;4397:18;;;4516:22;;;4364:4;;4595:15;;;4569:2;4554:18;;;4364:4;4638:464;4652:6;4649:1;4646:13;4638:464;;;4717:6;4711:13;-1:-1:-1;;;;;4759:2:61;4753:9;4749:42;4744:3;4737:55;-1:-1:-1;;;;;4844:2:61;4840;4836:11;4830:18;4826:51;4821:2;4816:3;4812:12;4805:73;4936:12;4930:2;4926;4922:11;4916:18;4912:37;4907:2;4902:3;4898:12;4891:59;5012:6;5004:4;5000:2;4996:13;4990:20;4986:33;4979:4;4974:3;4970:14;4963:57;;5049:4;5044:3;5040:14;5033:21;;5089:2;5081:6;5077:15;5067:25;;4674:1;4671;4667:9;4662:14;;4638:464;;;-1:-1:-1;5119:3:61;;4158:970;-1:-1:-1;;;;;4158:970:61:o;5133:118::-;5219:5;5212:13;5205:21;5198:5;5195:32;5185:60;;5241:1;5238;5231:12;5256:382;5321:6;5329;5382:2;5370:9;5361:7;5357:23;5353:32;5350:52;;;5398:1;5395;5388:12;5350:52;5437:9;5424:23;5456:31;5481:5;5456:31;:::i;:::-;5506:5;-1:-1:-1;5563:2:61;5548:18;;5535:32;5576:30;5535:32;5576:30;:::i;5643:226::-;5702:6;5755:2;5743:9;5734:7;5730:23;5726:32;5723:52;;;5771:1;5768;5761:12;5723:52;-1:-1:-1;5816:23:61;;5643:226;-1:-1:-1;5643:226:61:o;6056:179::-;6123:20;;-1:-1:-1;;;;;6172:38:61;;6162:49;;6152:77;;6225:1;6222;6215:12;6152:77;6056:179;;;:::o;6240:319::-;6307:6;6315;6368:2;6356:9;6347:7;6343:23;6339:32;6336:52;;;6384:1;6381;6374:12;6336:52;6407:28;6425:9;6407:28;:::i;:::-;6397:38;;6485:2;6474:9;6470:18;6457:32;6498:31;6523:5;6498:31;:::i;7186:508::-;7263:6;7271;7279;7332:2;7320:9;7311:7;7307:23;7303:32;7300:52;;;7348:1;7345;7338:12;7300:52;7387:9;7374:23;7406:31;7431:5;7406:31;:::i;:::-;7456:5;-1:-1:-1;7513:2:61;7498:18;;7485:32;7526:33;7485:32;7526:33;:::i;:::-;7186:508;;7578:7;;-1:-1:-1;;;7658:2:61;7643:18;;;;7630:32;;7186:508::o;7930:256::-;7996:6;8004;8057:2;8045:9;8036:7;8032:23;8028:32;8025:52;;;8073:1;8070;8063:12;8025:52;8096:28;8114:9;8096:28;:::i;:::-;8086:38;;8143:37;8176:2;8165:9;8161:18;8143:37;:::i;:::-;8133:47;;7930:256;;;;;:::o;8191:245::-;8249:6;8302:2;8290:9;8281:7;8277:23;8273:32;8270:52;;;8318:1;8315;8308:12;8270:52;8357:9;8344:23;8376:30;8400:5;8376:30;:::i;8441:367::-;8509:6;8517;8570:2;8558:9;8549:7;8545:23;8541:32;8538:52;;;8586:1;8583;8576:12;8538:52;8631:23;;;-1:-1:-1;8730:2:61;8715:18;;8702:32;8743:33;8702:32;8743:33;:::i;9002:618::-;9188:2;9200:21;;;9270:13;;9173:18;;;9292:22;;;9140:4;;9371:15;;;9345:2;9330:18;;;9140:4;9414:180;9428:6;9425:1;9422:13;9414:180;;;9493:13;;9508:4;9489:24;9477:37;;9543:2;9569:15;;;;9534:12;;;;9450:1;9443:9;9414:180;;9625:611;9815:2;9827:21;;;9897:13;;9800:18;;;9919:22;;;9767:4;;9998:15;;;9972:2;9957:18;;;9767:4;10041:169;10055:6;10052:1;10049:13;10041:169;;;10116:13;;10104:26;;10159:2;10185:15;;;;10150:12;;;;10077:1;10070:9;10041:169;;10241:346;10324:6;10377:2;10365:9;10356:7;10352:23;10348:32;10345:52;;;10393:1;10390;10383:12;10345:52;10433:9;10420:23;10466:18;10458:6;10455:30;10452:50;;;10498:1;10495;10488:12;10452:50;10521:60;10573:7;10564:6;10553:9;10549:22;10521:60;:::i;10592:184::-;10650:6;10703:2;10691:9;10682:7;10678:23;10674:32;10671:52;;;10719:1;10716;10709:12;10671:52;10742:28;10760:9;10742:28;:::i;10781:452::-;10833:3;10871:5;10865:12;10898:6;10893:3;10886:19;10930:4;10925:3;10921:14;10914:21;;10969:4;10962:5;10958:16;10992:1;11002:206;11016:6;11013:1;11010:13;11002:206;;;11081:13;;-1:-1:-1;;;;;11077:46:61;11065:59;;11153:4;11144:14;;;;11181:17;;;;11038:1;11031:9;11002:206;;;-1:-1:-1;11224:3:61;;10781:452;-1:-1:-1;;;;10781:452:61:o;11238:665::-;-1:-1:-1;;;;;11547:6:61;11543:39;11532:9;11525:58;-1:-1:-1;;;;;11623:6:61;11619:39;11614:2;11603:9;11599:18;11592:67;11695:3;11690:2;11679:9;11675:18;11668:31;11506:4;11722:56;11773:3;11762:9;11758:19;11750:6;11722:56;:::i;:::-;11826:9;11818:6;11814:22;11809:2;11798:9;11794:18;11787:50;11854:43;11890:6;11882;11854:43;:::i;:::-;11846:51;11238:665;-1:-1:-1;;;;;;;11238:665:61:o;12223:959::-;12300:6;12308;12361:2;12349:9;12340:7;12336:23;12332:32;12329:52;;;12377:1;12374;12367:12;12329:52;12416:9;12403:23;12435:31;12460:5;12435:31;:::i;:::-;12485:5;-1:-1:-1;12541:2:61;12526:18;;12513:32;12568:18;12557:30;;12554:50;;;12600:1;12597;12590:12;12554:50;12623:22;;12676:4;12668:13;;12664:27;-1:-1:-1;12654:55:61;;12705:1;12702;12695:12;12654:55;12745:2;12732:16;12771:18;12763:6;12760:30;12757:56;;;12793:18;;:::i;:::-;12835:116;12947:2;-1:-1:-1;;12871:4:61;12863:6;12859:17;12855:90;12851:99;12835:116;:::i;:::-;12974:6;12967:5;12960:21;13022:7;13017:2;13008:6;13004:2;13000:15;12996:24;12993:37;12990:57;;;13043:1;13040;13033:12;12990:57;13098:6;13093:2;13089;13085:11;13080:2;13073:5;13069:14;13056:49;13150:1;13145:2;13136:6;13129:5;13125:18;13121:27;13114:38;13171:5;13161:15;;;;;12223:959;;;;;:::o;13484:239::-;13664:2;13649:18;;13676:41;13653:9;13699:6;13275:18;13267:5;13261:12;13257:37;13252:3;13245:50;-1:-1:-1;;;;;13348:4:61;13341:5;13337:16;13331:23;13327:56;13320:4;13315:3;13311:14;13304:80;-1:-1:-1;;;;;13437:4:61;13430:5;13426:16;13420:23;13416:56;13409:4;13404:3;13400:14;13393:80;;;13187:292;13728:386;13795:6;13803;13856:2;13844:9;13835:7;13831:23;13827:32;13824:52;;;13872:1;13869;13862:12;13824:52;13911:9;13898:23;13930:30;13954:5;13930:30;:::i;15410:272::-;15468:6;15521:2;15509:9;15500:7;15496:23;15492:32;15489:52;;;15537:1;15534;15527:12;15489:52;15576:9;15563:23;15626:6;15619:5;15615:18;15608:5;15605:29;15595:57;;15648:1;15645;15638:12;15687:645;15805:6;15813;15866:2;15854:9;15845:7;15841:23;15837:32;15834:52;;;15882:1;15879;15872:12;15834:52;15922:9;15909:23;15955:18;15947:6;15944:30;15941:50;;;15987:1;15984;15977:12;15941:50;16010:22;;16063:4;16055:13;;16051:27;-1:-1:-1;16041:55:61;;16092:1;16089;16082:12;16041:55;16132:2;16119:16;16158:18;16150:6;16147:30;16144:50;;;16190:1;16187;16180:12;16144:50;16246:7;16241:2;16233:4;16225:6;16221:17;16217:2;16213:26;16209:35;16206:48;16203:68;;;16267:1;16264;16257:12;16203:68;16298:2;16290:11;;;;;16320:6;;-1:-1:-1;15687:645:61;-1:-1:-1;;;15687:645:61:o;16530:388::-;16598:6;16606;16659:2;16647:9;16638:7;16634:23;16630:32;16627:52;;;16675:1;16672;16665:12;16627:52;16714:9;16701:23;16733:31;16758:5;16733:31;:::i;16923:675::-;17159:2;17171:21;;;17241:13;;17144:18;;;17263:22;;;17111:4;;17342:15;;;17316:2;17301:18;;;17111:4;17385:187;17399:6;17396:1;17393:13;17385:187;;;17448:42;17486:3;17477:6;17471:13;13275:18;13267:5;13261:12;13257:37;13252:3;13245:50;-1:-1:-1;;;;;13348:4:61;13341:5;13337:16;13331:23;13327:56;13320:4;13315:3;13311:14;13304:80;-1:-1:-1;;;;;13437:4:61;13430:5;13426:16;13420:23;13416:56;13409:4;13404:3;13400:14;13393:80;;;13187:292;17448:42;17559:2;17547:15;;;;;17519:4;17510:14;;;;;17421:1;17414:9;17385:187;;18089:437;18168:1;18164:12;;;;18211;;;18232:61;;18286:4;18278:6;18274:17;18264:27;;18232:61;18339:2;18331:6;18328:14;18308:18;18305:38;18302:218;;-1:-1:-1;;;18373:1:61;18366:88;18477:4;18474:1;18467:15;18505:4;18502:1;18495:15;18531:184;-1:-1:-1;;;18580:1:61;18573:88;18680:4;18677:1;18670:15;18704:4;18701:1;18694:15;18720:184;-1:-1:-1;;;18769:1:61;18762:88;18869:4;18866:1;18859:15;18893:4;18890:1;18883:15;18909:204;18947:3;18991:18;18984:5;18980:30;19034:18;19025:7;19022:31;19019:57;;19056:18;;:::i;:::-;19105:1;19092:15;;18909:204;-1:-1:-1;;18909:204:61:o;19118:218::-;-1:-1:-1;;;;;19224:34:61;;;19188;;;19184:75;;19271:36;;19268:62;;;19310:18;;:::i;19341:215::-;-1:-1:-1;;;;;19409:34:61;;;19445;;;19405:75;;19492:35;;19489:61;;;19530:18;;:::i;19846:128::-;19913:9;;;19934:11;;;19931:37;;;19948:18;;:::i;20747:176::-;20846:12;20839:20;;;20817;;;20813:47;;20872:22;;20869:48;;;20897:18;;:::i;20928:173::-;21025:12;20996:20;;;21018;;;20992:47;;21051:21;;21048:47;;;21075:18;;:::i;21837:912::-;21961:6;21969;21977;21985;21993;22001;22009;22062:3;22050:9;22041:7;22037:23;22033:33;22030:53;;;22079:1;22076;22069:12;22030:53;-1:-1:-1;;22124:16:61;;22230:2;22215:18;;22209:25;22326:2;22311:18;;22305:25;22422:2;22407:18;;22401:25;22518:3;22503:19;;22497:26;22615:3;22600:19;;22594:26;22712:3;22697:19;;;22691:26;22124:16;;22209:25;;-1:-1:-1;22305:25:61;;22401;;-1:-1:-1;22497:26:61;;-1:-1:-1;22594:26:61;-1:-1:-1;22691:26:61;;-1:-1:-1;21837:912:61;-1:-1:-1;21837:912:61:o;22754:125::-;22819:9;;;22840:10;;;22837:36;;;22853:18;;:::i;22884:168::-;22957:9;;;22988;;23005:15;;;22999:22;;22985:37;22975:71;;23026:18;;:::i;23057:184::-;-1:-1:-1;;;23106:1:61;23099:88;23206:4;23203:1;23196:15;23230:4;23227:1;23220:15;23246:120;23286:1;23312;23302:35;;23317:18;;:::i;:::-;-1:-1:-1;23351:9:61;;23246:120::o;23624:191::-;23727:18;23692:26;;;23720;;;23688:59;;23759:27;;23756:53;;;23789:18;;:::i;24811:241::-;24867:6;24920:2;24908:9;24899:7;24895:23;24891:32;24888:52;;;24936:1;24933;24926:12;24888:52;24975:9;24962:23;24994:28;25016:5;24994:28;:::i;25271:184::-;-1:-1:-1;;;25320:1:61;25313:88;25420:4;25417:1;25410:15;25444:4;25441:1;25434:15;26305:245;26372:6;26425:2;26413:9;26404:7;26400:23;26396:32;26393:52;;;26441:1;26438;26431:12;26393:52;26473:9;26467:16;26492:28;26514:5;26492:28;:::i;26555:151::-;26645:4;26638:12;;;26624;;;26620:31;;26663:14;;26660:40;;;26680:18;;:::i;26711:158::-;26804:6;26797:14;;;26781;;;26777:35;;26824:16;;26821:42;;;26843:18;;:::i;27478:112::-;27510:1;27536;27526:35;;27541:18;;:::i;:::-;-1:-1:-1;27575:9:61;;27478:112::o;27595:184::-;27665:6;27718:2;27706:9;27697:7;27693:23;27689:32;27686:52;;;27734:1;27731;27724:12;27686:52;-1:-1:-1;27757:16:61;;27595:184;-1:-1:-1;27595:184:61:o;27784:377::-;27859:6;27867;27920:2;27908:9;27899:7;27895:23;27891:32;27888:52;;;27936:1;27933;27926:12;27888:52;27968:9;27962:16;27987:30;28011:5;27987:30;:::i;:::-;28086:2;28071:18;;28065:25;28036:5;;-1:-1:-1;28099:30:61;28065:25;28099:30;:::i;28468:148::-;28556:4;28535:12;;;28549;;;28531:31;;28574:13;;28571:39;;;28590:18;;:::i;29101:518::-;29203:2;29198:3;29195:11;29192:421;;;29239:5;29236:1;29229:16;29283:4;29280:1;29270:18;29353:2;29341:10;29337:19;29334:1;29330:27;29324:4;29320:38;29389:4;29377:10;29374:20;29371:47;;;-1:-1:-1;29412:4:61;29371:47;29467:2;29462:3;29458:12;29455:1;29451:20;29445:4;29441:31;29431:41;;29522:81;29540:2;29533:5;29530:13;29522:81;;;29599:1;29585:16;;29566:1;29555:13;29522:81;;29795:1358;29921:3;29915:10;29948:18;29940:6;29937:30;29934:56;;;29970:18;;:::i;:::-;29999:97;30089:6;30049:38;30081:4;30075:11;30049:38;:::i;:::-;30043:4;29999:97;:::i;:::-;30145:4;30176:2;30165:14;;30193:1;30188:708;;;;30940:1;30957:6;30954:89;;;-1:-1:-1;31009:19:61;;;31003:26;30954:89;-1:-1:-1;;29752:1:61;29748:11;;;29744:24;29740:29;29730:40;29776:1;29772:11;;;29727:57;31056:81;;30158:989;;30188:708;29048:1;29041:14;;;29085:4;29072:18;;-1:-1:-1;;30224:79:61;;;30401:222;30415:7;30412:1;30409:14;30401:222;;;30497:19;;;30491:26;30476:42;;30604:4;30589:20;;;;30557:1;30545:14;;;;30431:12;30401:222;;;30405:3;30651:6;30642:7;30639:19;30636:201;;;30712:19;;;30706:26;-1:-1:-1;;30795:1:61;30791:14;;;30807:3;30787:24;30783:37;30779:42;30764:58;30749:74;;30636:201;-1:-1:-1;;;;30883:1:61;30867:14;;;30863:22;30850:36;;-1:-1:-1;29795:1358:61:o;31158:301::-;31287:3;31325:6;31319:13;31371:6;31364:4;31356:6;31352:17;31347:3;31341:37;31433:1;31397:16;;31422:13;;;-1:-1:-1;31397:16:61;31158:301;-1:-1:-1;31158:301:61:o",
+    "linkReferences": {},
+    "immutableReferences": {
+      "10191": [
+        {
+          "start": 21120,
+          "length": 32
+        },
+        {
+          "start": 21161,
+          "length": 32
+        },
+        {
+          "start": 21627,
+          "length": 32
+        }
+      ]
+    }
+  },
+  "methodIdentifiers": {
+    "DEFAULT_ADMIN_ROLE()": "a217fddf",
+    "MINIMUM_CONTRIBUTE_THRESHOLD()": "86bb1d6e",
+    "ROLE_ADD_NODE()": "22fd4ad5",
+    "ROLE_DISABLE_NODE()": "e8ce8922",
+    "ROLE_FEE_CLAIMER()": "06c7dbc4",
+    "ROLE_FEE_EXEMPTION()": "a30fefe1",
+    "ROLE_FEE_SETTER()": "1b8e0db6",
+    "ROLE_PAUSE()": "4ff0241a",
+    "ROLE_REMOVE_NODE()": "5838b2fe",
+    "ROLE_UPDATE_WEIGHTS()": "63311d3d",
+    "ROLE_UPGRADE()": "2a7d8acb",
+    "UPGRADE_INTERFACE_VERSION()": "ad3cb1cc",
+    "addNode(uint64)": "337b2b6e",
+    "allowance(address,address)": "dd62ed3e",
+    "approve(address,uint256)": "095ea7b3",
+    "balanceOf(address)": "70a08231",
+    "batchDepositRequests(uint256)": "77654f34",
+    "batchSubmissions(uint256)": "78f908e1",
+    "batchWithdrawRequests(uint256)": "4beae6e3",
+    "calculateStakeDeltas(uint96)": "4a797bd5",
+    "cancelUnlockRequest(uint256)": "1610247b",
+    "claimProtocolFees(address)": "69ce6d47",
+    "compound(uint64[])": "cf5e2743",
+    "contributeToPool(address)": "a0e3cdd6",
+    "convertToAssets(uint96)": "fb9848e4",
+    "convertToShares(uint96)": "df235fe6",
+    "currentBatchId()": "0a763da1",
+    "decimals()": "313ce567",
+    "deposit(uint96,address)": "1c3477dd",
+    "disableNode(uint64)": "d8a9fe50",
+    "getAllUserUnlockRequests(address)": "0b52f7b1",
+    "getDelegator(uint64,address)": "573c1ce0",
+    "getExitFeeBips()": "fde73f7d",
+    "getManagementFeeBips()": "bf7df8e0",
+    "getMintableProtocolShares()": "615bfc45",
+    "getNodeIds()": "3e367afa",
+    "getNodes()": "e29581aa",
+    "getRoleAdmin(bytes32)": "248a9ca3",
+    "getWithdrawIds(uint64)": "3b5b4765",
+    "getWithdrawIdsSize(uint64)": "7a6d59d5",
+    "grantRole(bytes32,address)": "2f2ff15d",
+    "hasRole(bytes32,address)": "91d14854",
+    "initialize(address)": "c4d66de8",
+    "initializeFromV1()": "c2fab774",
+    "isExitFeeExempt(address)": "0bf14d9b",
+    "isForceWithdrawPending(uint64)": "2584601f",
+    "isNodeDisabled(uint64)": "d6531de5",
+    "name()": "06fdde03",
+    "nodes(uint256)": "1c53c280",
+    "pause()": "8456cb59",
+    "paused()": "5c975abb",
+    "proxiableUUID()": "52d1902d",
+    "redeem(uint256,address)": "7bde82f2",
+    "removeNode(uint64)": "aedf6d51",
+    "renounceRole(bytes32,address)": "36568abe",
+    "requestUnlock(uint96,uint96)": "24f67e18",
+    "revokeRole(bytes32,address)": "d547741f",
+    "setExitFee(uint16)": "f75b0404",
+    "setExitFeeExemption(address,bool)": "15230e80",
+    "setManagementFee(uint16)": "8dd09af3",
+    "submitBatch()": "46115383",
+    "supportsInterface(bytes4)": "01ffc9a7",
+    "sweep(uint64[],uint8)": "0a9f9ee2",
+    "sweepForced(uint64[])": "43abcf32",
+    "symbol()": "95d89b41",
+    "totalPooled()": "6ec21cc8",
+    "totalShares()": "3a98ef39",
+    "totalSupply()": "18160ddd",
+    "totalWeight()": "96c82e57",
+    "transfer(address,uint256)": "a9059cbb",
+    "transferFrom(address,address,uint256)": "23b872dd",
+    "unbondDisableNode(uint64)": "733897b7",
+    "unpause()": "3f4ba83a",
+    "updateWeights((uint64,uint96,bool)[])": "a4b0b5a3",
+    "upgradeToAndCall(address,bytes)": "4f1ef286",
+    "userUnlockRequests(address,uint256)": "fd012e34",
+    "viewNodeByNodeId(uint64)": "540a26f3"
+  },
+  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.30+commit.73712a01\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"AccessControlBadConfirmation\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"neededRole\",\"type\":\"bytes32\"}],\"name\":\"AccessControlUnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ActiveNode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"AddressEmptyCode\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"BatchNotSubmitted\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"CancellationWindowClosed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"DepositOverflow\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"DisabledNode\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"DuplicateNode\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"ERC1967InvalidImplementation\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ERC1967NonPayable\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientAllowance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"needed\",\"type\":\"uint256\"}],\"name\":\"ERC20InsufficientBalance\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"approver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidApprover\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"ERC20InvalidReceiver\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSender\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"ERC20InvalidSpender\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EmptyBatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EnforcedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ExpectedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FailedCall\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FeeTooLarge\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InsufficientPendingWithdrawals\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidNode\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MaxPendingWithdrawals\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MinimumBatchDelay\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MinimumContributeThreshold\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MinimumDeposit\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MinimumUnlock\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NoChange\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"PendingWithdrawals\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"PrecompileCallFailed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"TransferFailed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"UUPSUnauthorizedCallContext\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"slot\",\"type\":\"bytes32\"}],\"name\":\"UUPSUnsupportedProxiableUUID\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"WithdrawDelay\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroTotalWeight\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"batchId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"sharesBurnt\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"unstakeValue\",\"type\":\"uint256\"}],\"name\":\"BatchSent\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"nodeId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Compounded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"benefactor\",\"type\":\"address\"}],\"name\":\"Contribution\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"staker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Deposit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newFee\",\"type\":\"uint256\"}],\"name\":\"ExitFeeAdjusted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"managementFeeShares\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"exitFeeShares\",\"type\":\"uint256\"}],\"name\":\"FeesWithdrawn\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newFee\",\"type\":\"uint256\"}],\"name\":\"ManagementFeeAdjusted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"name\":\"NodeAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"}],\"name\":\"NodeDisabled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"}],\"name\":\"NodeRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newWeight\",\"type\":\"uint256\"}],\"name\":\"NodeUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Paused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"staker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"unlockId\",\"type\":\"uint256\"}],\"name\":\"UnlockCancelled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"staker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"unlockId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"UnlockRedeemed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"staker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"unlockId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"spotValue\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"toll\",\"type\":\"uint256\"}],\"name\":\"UnlockRequested\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Unpaused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"shares\",\"type\":\"uint256\"}],\"name\":\"VirtualSharesSnapshot\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DEFAULT_ADMIN_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"MINIMUM_CONTRIBUTE_THRESHOLD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_ADD_NODE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_DISABLE_NODE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_FEE_CLAIMER\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_FEE_EXEMPTION\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_FEE_SETTER\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_PAUSE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_REMOVE_NODE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_UPDATE_WEIGHTS\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ROLE_UPGRADE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"UPGRADE_INTERFACE_VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"}],\"name\":\"addNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"batchDepositRequests\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"assets\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"batchSubmissions\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"submissionEpoch\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"activationEpoch\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"batchWithdrawRequests\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"assets\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint96\",\"name\":\"newTotalStaked\",\"type\":\"uint96\"}],\"name\":\"calculateStakeDeltas\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"totalExcess\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"totalDeficit\",\"type\":\"uint96\"},{\"internalType\":\"uint96[]\",\"name\":\"nodeExcesses\",\"type\":\"uint96[]\"},{\"internalType\":\"uint96[]\",\"name\":\"nodeDeficits\",\"type\":\"uint96[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"unlockIndex\",\"type\":\"uint256\"}],\"name\":\"cancelUnlockRequest\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"claimProtocolFees\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64[]\",\"name\":\"nodeIds\",\"type\":\"uint64[]\"}],\"name\":\"compound\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"benefactor\",\"type\":\"address\"}],\"name\":\"contributeToPool\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"}],\"name\":\"convertToAssets\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"assets\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint96\",\"name\":\"assets\",\"type\":\"uint96\"}],\"name\":\"convertToShares\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"currentBatchId\",\"outputs\":[{\"internalType\":\"uint40\",\"name\":\"\",\"type\":\"uint40\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint96\",\"name\":\"minShares\",\"type\":\"uint96\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"deposit\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"}],\"name\":\"disableNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"user\",\"type\":\"address\"}],\"name\":\"getAllUserUnlockRequests\",\"outputs\":[{\"components\":[{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"spotValue\",\"type\":\"uint96\"},{\"internalType\":\"uint40\",\"name\":\"batchId\",\"type\":\"uint40\"},{\"internalType\":\"uint16\",\"name\":\"exitFeeInBips\",\"type\":\"uint16\"}],\"internalType\":\"struct StakedMonadV2.UnlockRequest[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"val_id\",\"type\":\"uint64\"},{\"internalType\":\"address\",\"name\":\"delegator\",\"type\":\"address\"}],\"name\":\"getDelegator\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"stake\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"acc_reward_per_token\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"rewards\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delta_stake\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"next_delta_stake\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"delta_epoch\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"next_delta_epoch\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getExitFeeBips\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getManagementFeeBips\",\"outputs\":[{\"internalType\":\"uint16\",\"name\":\"\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getMintableProtocolShares\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getNodeIds\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getNodes\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"id\",\"type\":\"uint64\"},{\"internalType\":\"uint96\",\"name\":\"weight\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"staked\",\"type\":\"uint96\"}],\"internalType\":\"struct Registry.Node[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"}],\"name\":\"getRoleAdmin\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"val_id\",\"type\":\"uint64\"}],\"name\":\"getWithdrawIds\",\"outputs\":[{\"internalType\":\"uint8[]\",\"name\":\"\",\"type\":\"uint8[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"val_id\",\"type\":\"uint64\"}],\"name\":\"getWithdrawIdsSize\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"hasRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"admin\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"initializeFromV1\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isExitFeeExempt\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"val_id\",\"type\":\"uint64\"}],\"name\":\"isForceWithdrawPending\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"name\":\"isNodeDisabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"nodes\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"id\",\"type\":\"uint64\"},{\"internalType\":\"uint96\",\"name\":\"weight\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"staked\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"paused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"proxiableUUID\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"unlockIndex\",\"type\":\"uint256\"},{\"internalType\":\"address payable\",\"name\":\"receiver\",\"type\":\"address\"}],\"name\":\"redeem\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"assets\",\"type\":\"uint96\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"}],\"name\":\"removeNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"callerConfirmation\",\"type\":\"address\"}],\"name\":\"renounceRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"minSpotValue\",\"type\":\"uint96\"}],\"name\":\"requestUnlock\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"spotValue\",\"type\":\"uint96\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"newFee\",\"type\":\"uint16\"}],\"name\":\"setExitFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"user\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isExempt\",\"type\":\"bool\"}],\"name\":\"setExitFeeExemption\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"newFee\",\"type\":\"uint16\"}],\"name\":\"setManagementFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"submitBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64[]\",\"name\":\"nodeIds\",\"type\":\"uint64[]\"},{\"internalType\":\"uint8\",\"name\":\"maxWithdrawsPerNode\",\"type\":\"uint8\"}],\"name\":\"sweep\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64[]\",\"name\":\"nodeIds\",\"type\":\"uint64[]\"}],\"name\":\"sweepForced\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalPooled\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalShares\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"\",\"type\":\"uint96\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalWeight\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"}],\"name\":\"unbondDisableNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unpause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"},{\"internalType\":\"uint96\",\"name\":\"delta\",\"type\":\"uint96\"},{\"internalType\":\"bool\",\"name\":\"isIncreasing\",\"type\":\"bool\"}],\"internalType\":\"struct Registry.WeightDelta[]\",\"name\":\"weightDeltas\",\"type\":\"tuple[]\"}],\"name\":\"updateWeights\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"userUnlockRequests\",\"outputs\":[{\"internalType\":\"uint96\",\"name\":\"shares\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"spotValue\",\"type\":\"uint96\"},{\"internalType\":\"uint40\",\"name\":\"batchId\",\"type\":\"uint40\"},{\"internalType\":\"uint16\",\"name\":\"exitFeeInBips\",\"type\":\"uint16\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"nodeId\",\"type\":\"uint64\"}],\"name\":\"viewNodeByNodeId\",\"outputs\":[{\"components\":[{\"internalType\":\"uint64\",\"name\":\"id\",\"type\":\"uint64\"},{\"internalType\":\"uint96\",\"name\":\"weight\",\"type\":\"uint96\"},{\"internalType\":\"uint96\",\"name\":\"staked\",\"type\":\"uint96\"}],\"internalType\":\"struct Registry.Node\",\"name\":\"node\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}],\"devdoc\":{\"author\":\"Brandon Mino <https://github.com/bmino>\",\"errors\":{\"AccessControlBadConfirmation()\":[{\"details\":\"The caller of a function is not the expected one. NOTE: Don't confuse with {AccessControlUnauthorizedAccount}.\"}],\"AccessControlUnauthorizedAccount(address,bytes32)\":[{\"details\":\"The `account` is missing a role.\"}],\"AddressEmptyCode(address)\":[{\"details\":\"There's no code at `target` (it is not a contract).\"}],\"ERC1967InvalidImplementation(address)\":[{\"details\":\"The `implementation` of the proxy is invalid.\"}],\"ERC1967NonPayable()\":[{\"details\":\"An upgrade function sees `msg.value > 0` that may be lost.\"}],\"ERC20InsufficientAllowance(address,uint256,uint256)\":[{\"details\":\"Indicates a failure with the `spender`\\u2019s `allowance`. Used in transfers.\",\"params\":{\"allowance\":\"Amount of tokens a `spender` is allowed to operate with.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"ERC20InsufficientBalance(address,uint256,uint256)\":[{\"details\":\"Indicates an error related to the current `balance` of a `sender`. Used in transfers.\",\"params\":{\"balance\":\"Current balance for the interacting account.\",\"needed\":\"Minimum amount required to perform a transfer.\",\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidApprover(address)\":[{\"details\":\"Indicates a failure with the `approver` of a token to be approved. Used in approvals.\",\"params\":{\"approver\":\"Address initiating an approval operation.\"}}],\"ERC20InvalidReceiver(address)\":[{\"details\":\"Indicates a failure with the token `receiver`. Used in transfers.\",\"params\":{\"receiver\":\"Address to which tokens are being transferred.\"}}],\"ERC20InvalidSender(address)\":[{\"details\":\"Indicates a failure with the token `sender`. Used in transfers.\",\"params\":{\"sender\":\"Address whose tokens are being transferred.\"}}],\"ERC20InvalidSpender(address)\":[{\"details\":\"Indicates a failure with the `spender` to be approved. Used in approvals.\",\"params\":{\"spender\":\"Address that may be allowed to operate on tokens without being their owner.\"}}],\"EnforcedPause()\":[{\"details\":\"The operation failed because the contract is paused.\"}],\"ExpectedPause()\":[{\"details\":\"The operation failed because the contract is not paused.\"}],\"FailedCall()\":[{\"details\":\"A call to an address target failed. The target may have reverted.\"}],\"InvalidInitialization()\":[{\"details\":\"The contract is already initialized.\"}],\"NotInitializing()\":[{\"details\":\"The contract is not initializing.\"}],\"UUPSUnauthorizedCallContext()\":[{\"details\":\"The call is from an unauthorized context.\"}],\"UUPSUnsupportedProxiableUUID(bytes32)\":[{\"details\":\"The storage `slot` is unsupported as a UUID.\"}]},\"events\":{\"Approval(address,address,uint256)\":{\"details\":\"Emitted when the allowance of a `spender` for an `owner` is set by a call to {approve}. `value` is the new allowance.\"},\"Initialized(uint64)\":{\"details\":\"Triggered when the contract has been initialized or reinitialized.\"},\"Paused(address)\":{\"details\":\"Emitted when the pause is triggered by `account`.\"},\"RoleAdminChanged(bytes32,bytes32,bytes32)\":{\"details\":\"Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole` `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite {RoleAdminChanged} not being emitted to signal this.\"},\"RoleGranted(bytes32,address,address)\":{\"details\":\"Emitted when `account` is granted `role`. `sender` is the account that originated the contract call. This account bears the admin role (for the granted role). Expected in cases where the role was granted using the internal {AccessControl-_grantRole}.\"},\"RoleRevoked(bytes32,address,address)\":{\"details\":\"Emitted when `account` is revoked `role`. `sender` is the account that originated the contract call:   - if using `revokeRole`, it is the admin role bearer   - if using `renounceRole`, it is the role bearer (i.e. `account`)\"},\"Transfer(address,address,uint256)\":{\"details\":\"Emitted when `value` tokens are moved from one account (`from`) to another (`to`). Note that `value` may be zero.\"},\"Unpaused(address)\":{\"details\":\"Emitted when the pause is lifted by `account`.\"},\"Upgraded(address)\":{\"details\":\"Emitted when the implementation is upgraded.\"}},\"kind\":\"dev\",\"methods\":{\"addNode(uint64)\":{\"details\":\"Cannot add a node that already exists\"},\"allowance(address,address)\":{\"details\":\"Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through {transferFrom}. This is zero by default. This value changes when {approve} or {transferFrom} are called.\"},\"approve(address,uint256)\":{\"details\":\"See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address.\"},\"balanceOf(address)\":{\"details\":\"Returns the value of tokens owned by `account`.\"},\"cancelUnlockRequest(uint256)\":{\"details\":\"Order of unlock requests is not guaranteed between cancellations\"},\"compound(uint64[])\":{\"details\":\"Specifying an invalid node id will revert\"},\"contributeToPool(address)\":{\"details\":\"Restricts usage when total pooled is below a threshold to prevent share inflation attacks\",\"params\":{\"benefactor\":\"- Address used for tracking who is responsible for the contribution\"}},\"convertToAssets(uint96)\":{\"details\":\"`totalShares()` accounts for both minted and mintable shares\"},\"convertToShares(uint96)\":{\"details\":\"`totalShares()` accounts for both minted and mintable shares\"},\"decimals()\":{\"details\":\"Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}.\"},\"deposit(uint96,address)\":{\"params\":{\"minShares\":\"- Minimum quantity of shares that must be minted to prevent front running\",\"receiver\":\"- Recipient of the minted shares\"},\"returns\":{\"shares\":\"- Quantity of shares minted\"}},\"disableNode(uint64)\":{\"details\":\"Intended to prepare a node for removal via `Registry.removeNode()`Once disabled, node cannot be assigned a weight\"},\"getNodeIds()\":{\"details\":\"The order is not guaranteed to remain constant between callsThe order is not guaranteed to correlate to a position in `getNodes()`\"},\"getNodes()\":{\"details\":\"The order is not guaranteed to remain constant between calls\"},\"getRoleAdmin(bytes32)\":{\"details\":\"Returns the admin role that controls `role`. See {grantRole} and {revokeRole}. To change a role's admin, use {_setRoleAdmin}.\"},\"getWithdrawIds(uint64)\":{\"details\":\"Will not include FORCED_WITHDRAW_ID even if present\"},\"grantRole(bytes32,address)\":{\"details\":\"Grants `role` to `account`. If `account` had not been already granted `role`, emits a {RoleGranted} event. Requirements: - the caller must have ``role``'s admin role. May emit a {RoleGranted} event.\"},\"hasRole(bytes32,address)\":{\"details\":\"Returns `true` if `account` has been granted `role`.\"},\"initialize(address)\":{\"details\":\"It is recommended to transfer a small amount of MON when initializing to mitigate a rare DOS when:      1) All users make unlock requests      2) Batch is submitted, withdraw delay completes, and all sweep() calls are performed      3) Some dust is still pending undelegation      4) All unlock requests are redeemed\"},\"name()\":{\"details\":\"Returns the name of the token.\"},\"paused()\":{\"details\":\"Returns true if the contract is paused, and false otherwise.\"},\"proxiableUUID()\":{\"details\":\"Implementation of the ERC-1822 {proxiableUUID} function. This returns the storage slot used by the implementation. It is used to validate the implementation's compatibility when performing an upgrade. IMPORTANT: A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this function revert if invoked through a proxy. This is guaranteed by the `notDelegated` modifier.\"},\"redeem(uint256,address)\":{\"details\":\"Might need to first call `sweep()` to make funds availableDeletes the caller's unlock request\"},\"removeNode(uint64)\":{\"details\":\"Intended to prevent storage bloat\"},\"renounceRole(bytes32,address)\":{\"details\":\"Revokes `role` from the calling account. Roles are often managed via {grantRole} and {revokeRole}: this function's purpose is to provide a mechanism for accounts to lose their privileges if they are compromised (such as when a trusted device is misplaced). If the calling account had been revoked `role`, emits a {RoleRevoked} event. Requirements: - the caller must be `callerConfirmation`. May emit a {RoleRevoked} event.\"},\"revokeRole(bytes32,address)\":{\"details\":\"Revokes `role` from `account`. If `account` had been granted `role`, emits a {RoleRevoked} event. Requirements: - the caller must have ``role``'s admin role. May emit a {RoleRevoked} event.\"},\"submitBatch()\":{\"details\":\"Might need to first call `sweep()`For a net ingress batch, the amount bonded may be less than the requested amount due to integer arithmetic.      The remaining amount, or 'dust' is scheduled to be bonded in the next batch.For a net egress batch, the amount unbonded may be less than the requested amount due to integer arithmetic.      The remaining amount, or 'dust' is scheduled to be unbonded in the next batch.      In this scenario, `totalPooled` is temporarily increased by this dust amount to account for the assets      that were requested to be unbonded but were not unbonded from nodes, ensuring they remain trackable      in the pool for the next attempt.\"},\"supportsInterface(bytes4)\":{\"details\":\"Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section] to learn more about how these ids are created. This function call must use less than 30 000 gas.\"},\"sweep(uint64[],uint8)\":{\"details\":\"Required number of epochs must have passed since calling `undelegate`All withdrawals must be valid and complete or none will\"},\"sweepForced(uint64[])\":{\"details\":\"Required number of epochs must have passed since calling `undelegate`All withdrawals must be valid and complete or none will\"},\"symbol()\":{\"details\":\"Returns the symbol of the token, usually a shorter version of the name.\"},\"totalSupply()\":{\"details\":\"Returns the value of tokens in existence.\"},\"transfer(address,uint256)\":{\"details\":\"See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`.\"},\"transferFrom(address,address,uint256)\":{\"details\":\"See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`.\"},\"unbondDisableNode(uint64)\":{\"details\":\"This function is for emergency/cleanup purposes and does not depend on the standard batching processDoes NOT decrease `totalPooled` because funds never leave the protocol's custodyFunds will be scheduled for redelegation during `sweepForced()`\",\"params\":{\"nodeId\":\"- ID of the disabled node to unbond from\"}},\"updateWeights((uint64,uint96,bool)[])\":{\"details\":\"Cannot increase weight of a node that has been disabledDecreasing weight below 0 will not underflow and instead remains at 0Decreasing weight of a node that has been disabled is effectively a no-opUpdating a deleted or non-existent node is effectively a no-op\"},\"upgradeToAndCall(address,bytes)\":{\"custom:oz-upgrades-unsafe-allow-reachable\":\"delegatecall\",\"details\":\"Upgrade the implementation of the proxy to `newImplementation`, and subsequently execute the function call encoded in `data`. Calls {_authorizeUpgrade}. Emits an {Upgraded} event.\"}},\"stateVariables\":{\"currentBatchId\":{\"details\":\"Tracks the current batch being populated. Initialized to 1\"}},\"title\":\"StakedMonadV2\",\"version\":1},\"userdoc\":{\"errors\":{\"ActiveNode()\":[{\"notice\":\"Thrown when trying to interact with a node that is still active (not disabled)\"}],\"BatchNotSubmitted()\":[{\"notice\":\"Thrown when trying to redeem from a batch that hasn't been submitted\"}],\"CancellationWindowClosed()\":[{\"notice\":\"Thrown when trying to cancel an unlock request outside the cancellation window\"}],\"DepositOverflow()\":[{\"notice\":\"Thrown when deposit amount exceeds uint96 maximum value\"}],\"DisabledNode()\":[{\"notice\":\"Thrown when trying to interact with a node that is disabled\"}],\"DuplicateNode()\":[{\"notice\":\"Thrown when trying to duplicate a currently existing node\"}],\"EmptyBatch()\":[{\"notice\":\"Thrown when trying to submit an empty batch (no deposits or withdrawals)\"}],\"FeeTooLarge()\":[{\"notice\":\"Thrown when trying to set a fee percentage above the maximum allowed\"}],\"InvalidNode()\":[{\"notice\":\"Thrown when trying to interact or lookup a node that does not currently exist\"}],\"MinimumBatchDelay()\":[{\"notice\":\"Thrown when trying to submit a batch before the minimum submission delay\"}],\"MinimumContributeThreshold()\":[{\"notice\":\"Thrown when trying to contribute to the protocol when sufficient TVL has not been reached\"}],\"MinimumDeposit()\":[{\"notice\":\"Thrown when minted shares would not meet the user provided threshold\"}],\"MinimumUnlock()\":[{\"notice\":\"Thrown when unlock amount would not meet the user provided threshold\"}],\"NoChange()\":[{\"notice\":\"Thrown when an action will have no effect and should fail fast\"}],\"PendingWithdrawals()\":[{\"notice\":\"Thrown when trying to remove a node while withdrawals are still pending\"}],\"TransferFailed()\":[{\"notice\":\"Thrown when a transfer of ETH fails\"}],\"WithdrawDelay()\":[{\"notice\":\"Thrown when trying to redeem from a batch that hasn't completed its withdraw delay\"}],\"ZeroTotalWeight()\":[{\"notice\":\"Thrown when total weight is zero during bonding operations\"}]},\"kind\":\"user\",\"methods\":{\"addNode(uint64)\":{\"notice\":\"Adds a new node\"},\"cancelUnlockRequest(uint256)\":{\"notice\":\"Allow user to cancel their unlock requestMost users will have 1 concurrent unlock request (`unlockIndex` == 0) but advanced users may have moreMust be done before the associated batch is submitted\"},\"compound(uint64[])\":{\"notice\":\"Claims all claimable rewards and adds them to the next batch\"},\"contributeToPool(address)\":{\"notice\":\"Allows external funds to be added without minting shares\"},\"convertToAssets(uint96)\":{\"notice\":\"Converts LST shares into MON at the current block timestampDoes not apply exit fee\"},\"convertToShares(uint96)\":{\"notice\":\"Converts MON into LST shares at the current block timestamp\"},\"deposit(uint96,address)\":{\"notice\":\"Deposit asset into the protocol and receive shares to represent your positionDeposit amount must be specified by `msg.value`\"},\"disableNode(uint64)\":{\"notice\":\"Permanently set node weight to 0\"},\"getDelegator(uint64,address)\":{\"notice\":\"Provides a view of the delegator\\u2019s stake across execution, consensus, and snapshot contexts\"},\"getMintableProtocolShares()\":{\"notice\":\"Shares that could be minted by the protocol at the current block timestamp\"},\"getNodeIds()\":{\"notice\":\"View all unique node ids in their current order\"},\"getNodes()\":{\"notice\":\"View all nodes in their current order\"},\"getWithdrawIds(uint64)\":{\"notice\":\"Converts the WithdrawIdSummary for a validator into an array of withdraw ids\"},\"nodes(uint256)\":{\"notice\":\"List of currently managed nodes. Order is NOT guaranteed to remain constant\"},\"redeem(uint256,address)\":{\"notice\":\"Step 2 of 2 in process of withdrawing assetsAssociated batch must have been submitted and the cooldown period elapsed\"},\"removeNode(uint64)\":{\"notice\":\"Removes a node from storage\"},\"submitBatch()\":{\"notice\":\"Processes deposit and withdrawal requests and allocates MON according to Registry weights\"},\"sweep(uint64[],uint8)\":{\"notice\":\"Withdraws MON from completed un-delegationsStores withdrawn funds in the contract to fund redemptions\"},\"sweepForced(uint64[])\":{\"notice\":\"Withdraws MON from completed un-delegations of disabled nodesAdds withdrawn funds into the current batch to be redelegated\"},\"totalShares()\":{\"notice\":\"Shares that could exist at the current block timestampIncludes both minted and mintable shares\"},\"totalWeight()\":{\"notice\":\"Sum of node relative weights\"},\"unbondDisableNode(uint64)\":{\"notice\":\"Forcibly unbonds funds from a disabled node\"},\"updateWeights((uint64,uint96,bool)[])\":{\"notice\":\"Modifies node weights by incrementing/decrementing\"},\"viewNodeByNodeId(uint64)\":{\"notice\":\"View a node by its unique node id\"}},\"notice\":\"Core liquid staking contract for MON, allowing users to deposit MON to receive sMON shares         Manages the lifecycle of staking, un-staking, and rewards distribution         Facilitates batch processing of deposits and withdrawals         Dynamically adjusts bonding/unbonding node allocation based on Registry weights         Changes in v2:           * Added Deposit, BatchSent, Compounded, and VirtualSharesSnapshot events           * Modified function logic of deposit, submitBatch, compound, and _updateFees to include above events\",\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/StakedMonadV2.sol\":\"StakedMonadV2\"},\"evmVersion\":\"cancun\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":2000},\"remappings\":[\":@openzeppelin-contracts-5.4.0/=dependencies/@openzeppelin-contracts-5.4.0/\",\":@openzeppelin-contracts-upgradeable-5.4.0/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0/\",\":@openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0/\",\":@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0/\",\":forge-std-1.10.0/=dependencies/forge-std-1.10.0/src/\",\":forge-std/=dependencies/forge-std-1.10.0/\"]},\"sources\":{\"dependencies/@openzeppelin-contracts-5.4.0/access/IAccessControl.sol\":{\"keccak256\":\"0xbff9f59c84e5337689161ce7641c0ef8e872d6a7536fbc1f5133f128887aba3c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b308f882e796f7b79c9502deacb0a62983035c6f6f4e962b319ba6a1f4a77d3d\",\"dweb:/ipfs/QmaWCW7ahEQqFjwhSUhV7Ae7WhfNvzSpE7DQ58hvEooqPL\"]},\"dependencies/@openzeppelin-contracts-5.4.0/interfaces/IERC1967.sol\":{\"keccak256\":\"0xbf2aefe54b76d7f7bcd4f6da1080b7b1662611937d870b880db584d09cea56b5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f5e7e2f12e0feec75296e57f51f82fdaa8bd1551f4b8cc6560442c0bf60f818c\",\"dweb:/ipfs/QmcW9wDMaQ8RbQibMarfp17a3bABzY5KraWe2YDwuUrUoz\"]},\"dependencies/@openzeppelin-contracts-5.4.0/interfaces/draft-IERC1822.sol\":{\"keccak256\":\"0x82f757819bf2429a0d4db141b99a4bbe5039e4ef86dfb94e2e6d40577ed5b28b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://37c30ed931e19fb71fdb806bb504cfdb9913b7127545001b64d4487783374422\",\"dweb:/ipfs/QmUBHpv4hm3ZmwJ4GH8BeVzK4mv41Q6vBbWXxn8HExPXza\"]},\"dependencies/@openzeppelin-contracts-5.4.0/interfaces/draft-IERC6093.sol\":{\"keccak256\":\"0x19fdfb0f3b89a230e7dbd1cf416f1a6b531a3ee5db4da483f946320fc74afc0e\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://3490d794728f5bfecb46820431adaff71ba374141545ec20b650bb60353fac23\",\"dweb:/ipfs/QmPsfxjVpMcZbpE7BH93DzTpEaktESigEw4SmDzkXuJ4WR\"]},\"dependencies/@openzeppelin-contracts-5.4.0/proxy/ERC1967/ERC1967Utils.sol\":{\"keccak256\":\"0xa1ad192cd45317c788618bef5cb1fb3ca4ce8b230f6433ac68cc1d850fb81618\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b43447bb85a53679d269a403c693b9d88d6c74177dfb35eddca63abaf7cf110a\",\"dweb:/ipfs/QmXSDmpd4bNZj1PDgegr6C4w1jDaWHXCconC3rYiw9TSkQ\"]},\"dependencies/@openzeppelin-contracts-5.4.0/proxy/beacon/IBeacon.sol\":{\"keccak256\":\"0x20462ddb2665e9521372c76b001d0ce196e59dbbd989de9af5576cad0bd5628b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f417fd12aeec8fbfaceaa30e3a08a0724c0bc39de363e2acf6773c897abbaf6d\",\"dweb:/ipfs/QmU4Hko6sApdweVM92CsiuLKkCk8HfyBeutF89PCTz5Tye\"]},\"dependencies/@openzeppelin-contracts-5.4.0/token/ERC20/IERC20.sol\":{\"keccak256\":\"0x74ed01eb66b923d0d0cfe3be84604ac04b76482a55f9dd655e1ef4d367f95bc2\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://5282825a626cfe924e504274b864a652b0023591fa66f06a067b25b51ba9b303\",\"dweb:/ipfs/QmeCfPykghhMc81VJTrHTC7sF6CRvaA1FXVq2pJhwYp1dV\"]},\"dependencies/@openzeppelin-contracts-5.4.0/token/ERC20/extensions/IERC20Metadata.sol\":{\"keccak256\":\"0xd6fa4088198f04eef10c5bce8a2f4d60554b7ec4b987f684393c01bf79b94d9f\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f95ee0bbd4dd3ac730d066ba3e785ded4565e890dbec2fa7d3b9fe3bad9d0d6e\",\"dweb:/ipfs/QmSLr6bHkPFWT7ntj34jmwfyskpwo97T9jZUrk5sz3sdtR\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/Address.sol\":{\"keccak256\":\"0x6d0ae6e206645341fd122d278c2cb643dea260c190531f2f3f6a0426e77b00c0\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://032d1201d839435be2c85b72e33206b3ea980c569d6ebf7fa57d811ab580a82f\",\"dweb:/ipfs/QmeqQjAtMvdZT2tG7zm39itcRJkuwu8AEReK6WRnLJ18DD\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/Arrays.sol\":{\"keccak256\":\"0xa4b9958797e0e9cde82a090525e90f80d5745ba1c67ee72b488bd3087498a17e\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c9344f7c2f80322c2e76d9d89bed03fd12f3e011e74fde7cf24ea21bdd2abe2d\",\"dweb:/ipfs/QmPMAjF5x2fHUAee2FKMZDBbFVrbZbPCr3a9KHLZaSn1zY\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/Comparators.sol\":{\"keccak256\":\"0x302eecd8cf323b4690e3494a7d960b3cbce077032ab8ef655b323cdd136cec58\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://49ba706f1bc476d68fe6c1fad75517acea4e9e275be0989b548e292eb3a3eacd\",\"dweb:/ipfs/QmeBpvcdGWzWMKTQESUCEhHgnEQYYATVwPxLMxa6vMT7jC\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/Errors.sol\":{\"keccak256\":\"0x6afa713bfd42cf0f7656efa91201007ac465e42049d7de1d50753a373648c123\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ba1d02f4847670a1b83dec9f7d37f0b0418d6043447b69f3a29a5f9efc547fcf\",\"dweb:/ipfs/QmQ7iH2keLNUKgq2xSWcRmuBE5eZ3F5whYAkAGzCNNoEWB\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/Panic.sol\":{\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a\",\"dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/SlotDerivation.sol\":{\"keccak256\":\"0x67672e4ca1dafdcc661d4eba8475cfac631fa0933309258e3af7644b92e1fb26\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://30192451f05ea5ddb0c18bd0f9003f098505836ba19c08a9c365adf829454da2\",\"dweb:/ipfs/QmfCuZSCTyCdFoSKn7MSaN6hZksnQn9ZhrZDAdRTCbwGu2\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/StorageSlot.sol\":{\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://9f660b1f351b757dfe01438e59888f31f33ded3afcf5cb5b0d9bf9aa6f320a8b\",\"dweb:/ipfs/QmarDJ5hZEgBtCmmrVzEZWjub9769eD686jmzb2XpSU1cM\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/introspection/IERC165.sol\":{\"keccak256\":\"0x8891738ffe910f0cf2da09566928589bf5d63f4524dd734fd9cedbac3274dd5c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://971f954442df5c2ef5b5ebf1eb245d7105d9fbacc7386ee5c796df1d45b21617\",\"dweb:/ipfs/QmadRjHbkicwqwwh61raUEapaVEtaLMcYbQZWs9gUkgj3u\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/math/Math.sol\":{\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6c5fab4970634f9ab9a620983dc1c8a30153981a0b1a521666e269d0a11399d3\",\"dweb:/ipfs/QmVRnBC575MESGkEHndjujtR7qub2FzU9RWy9eKLp4hPZB\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/math/SafeCast.sol\":{\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8\",\"dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy\"]},\"dependencies/@openzeppelin-contracts-5.4.0/utils/structs/EnumerableSet.sol\":{\"keccak256\":\"0x1fc283df727585919c3db301b948a3e827aee16917457ad7f916db9da2228e77\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://a4f4b5e2cd0ebc3b74e41e4e94771a0417eedd9b11cec3ef9f90b2ac2989264b\",\"dweb:/ipfs/QmZmsEsvsXiwAyAe1YeoLSKezeFcvR1giUeEY6ex4zpsTS\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0/access/AccessControlUpgradeable.sol\":{\"keccak256\":\"0x85a70e2b1b65e9ba456add364d22b97eb9944083df1c39c0b4bd6a4b5aa386a4\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://d32a33be6ca4d8e89b9e82e3f9cec7a6c4e040534152313ff55da85b8f193059\",\"dweb:/ipfs/QmeR55L8t2A8xZ1nvT5y4yVWfFbbmpaGAtGBMz3GGNpuyP\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0/proxy/utils/Initializable.sol\":{\"keccak256\":\"0xdb4d24ee2c087c391d587cd17adfe5b3f9d93b3110b1388c2ab6c7c0ad1dcd05\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ab7b6d5b9e2b88176312967fe0f0e78f3d9a1422fa5e4b64e2440c35869b5d08\",\"dweb:/ipfs/QmXKYWWyzcLg1B2k7Sb1qkEXgLCYfXecR9wYW5obRzWP1Q\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0/proxy/utils/UUPSUpgradeable.sol\":{\"keccak256\":\"0x574a7451e42724f7de29e2855c392a8a5020acd695169466a18459467d719d63\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://5bc189f63b639ee173dd7b6fecc39baf7113bf161776aea22b34c57fdd1872ec\",\"dweb:/ipfs/QmZAf2VtjDLRULqjJkde6LNsxAg12tUqpPqgUQQZbAjgtZ\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0/token/ERC20/ERC20Upgradeable.sol\":{\"keccak256\":\"0xfcd09c2aa8cc3f93e12545454359f901965db312bc03833daf84de0c03e05022\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://07701188648d2ab83dab1037808298585264559bddf243bd8929037adcb984b0\",\"dweb:/ipfs/QmavmG5REdHCAWsZ8Cag26BCxAq27DRKGxr3uBg5ZYxQ51\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0/utils/ContextUpgradeable.sol\":{\"keccak256\":\"0xdbef5f0c787055227243a7318ef74c8a5a1108ca3a07f2b3a00ef67769e1e397\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://08e39f23d5b4692f9a40803e53a8156b72b4c1f9902a88cd65ba964db103dab9\",\"dweb:/ipfs/QmPKn6EYDgpga7KtpkA8wV2yJCYGMtc9K4LkJfhKX2RVSV\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0/utils/PausableUpgradeable.sol\":{\"keccak256\":\"0xa6bf6b7efe0e6625a9dcd30c5ddf52c4c24fe8372f37c7de9dbf5034746768d5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8c353ee3705bbf6fadb84c0fb10ef1b736e8ca3ca1867814349d1487ed207beb\",\"dweb:/ipfs/QmcugaPssrzGGE8q4YZKm2ZhnD3kCijjcgdWWg76nWt3FY\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0/utils/introspection/ERC165Upgradeable.sol\":{\"keccak256\":\"0x6694b63ddb2c59bbe341c846171798350e8f72fa02189fcdeaca864e28b54e1f\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://7d945d33e2189ac4e531e4ed228f59ca957b3898c4f9051f4b8c7ae44d72b23a\",\"dweb:/ipfs/QmRcEwubTe3xyXxthijs5fVzEgUFSxeddjd5PGfhBnkunX\"]},\"src/CustomErrors.sol\":{\"keccak256\":\"0x1ba383b9bef5e696f656063cab035fb4ab64aa8897058dcf18e18d31fd6ded59\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://b5a381b74add6e325972095ae4f285af900a7d014e3e01859428f11a319f631d\",\"dweb:/ipfs/QmRyADdcNPeZoupt5c2nWUj6NzRsKs7QeUCQXmVfKbXRaG\"]},\"src/Registry.sol\":{\"keccak256\":\"0x4806200e21dfc07a3c62e852f27a36098cc9fab7555d251ef80b7ea2ee011ebb\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://fa94b3bdaa65513441392965f05642734d66879e589f5cfb152f83444787c8f4\",\"dweb:/ipfs/QmZ2AWdFVMFC3aDLUJywHry4Q5wUSi9Rj7WGcj8zexJJbW\"]},\"src/StakedMonadV2.sol\":{\"keccak256\":\"0xd7cd3d458219be55015bac01d13a242f6588cfe7e665a19992402b581297f0bb\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://b5f39bf61b13d3c2c8900256246418531ef74a0b9aeebdab3944ccb7bdf6db0c\",\"dweb:/ipfs/QmRS65ZPdKF3j9uaCwu9isissoga5MqbB8cwkbKaK6xgLY\"]},\"src/precompile/StakerUpgradeable.sol\":{\"keccak256\":\"0xf4bc7283a25072476bf615ef54decc539ea0bec2eb487bbacdab6372e53cb8bb\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://a688b754762541652f7a66229db78d0bf334e7ebcceab4db64d0f41827856181\",\"dweb:/ipfs/QmWXxUCVWrXcG7qErrbuCsymUpZYVps6usNLLcYtxw5kJc\"]}},\"version\":1}",
+  "metadata": {
+    "compiler": {
+      "version": "0.8.30+commit.73712a01"
+    },
+    "language": "Solidity",
+    "output": {
+      "abi": [
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "AccessControlBadConfirmation"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "neededRole",
+              "type": "bytes32"
+            }
+          ],
+          "type": "error",
+          "name": "AccessControlUnauthorizedAccount"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ActiveNode"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "target",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "AddressEmptyCode"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "BatchNotSubmitted"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "CancellationWindowClosed"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "DepositOverflow"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "DisabledNode"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "DuplicateNode"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "implementation",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "ERC1967InvalidImplementation"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ERC1967NonPayable"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "allowance",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "needed",
+              "type": "uint256"
+            }
+          ],
+          "type": "error",
+          "name": "ERC20InsufficientAllowance"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "balance",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "needed",
+              "type": "uint256"
+            }
+          ],
+          "type": "error",
+          "name": "ERC20InsufficientBalance"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "approver",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "ERC20InvalidApprover"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "ERC20InvalidReceiver"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "ERC20InvalidSender"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "ERC20InvalidSpender"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "EmptyBatch"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "EnforcedPause"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ExpectedPause"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "FailedCall"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "FeeTooLarge"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InsufficientPendingWithdrawals"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InvalidInitialization"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InvalidNode"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "MaxPendingWithdrawals"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "MinimumBatchDelay"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "MinimumContributeThreshold"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "MinimumDeposit"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "MinimumUnlock"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "NoChange"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "NotInitializing"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "PendingWithdrawals"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "PrecompileCallFailed"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "TransferFailed"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "UUPSUnauthorizedCallContext"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "slot",
+              "type": "bytes32"
+            }
+          ],
+          "type": "error",
+          "name": "UUPSUnsupportedProxiableUUID"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "WithdrawDelay"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ZeroTotalWeight"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "owner",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Approval",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "batchId",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "sharesBurnt",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "unstakeValue",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "BatchSent",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "nodeId",
+              "type": "uint256",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Compounded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "benefactor",
+              "type": "address",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Contribution",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "staker",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "shares",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Deposit",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "newFee",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ExitFeeAdjusted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "managementFeeShares",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "exitFeeShares",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "FeesWithdrawn",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "version",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Initialized",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "newFee",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "ManagementFeeAdjusted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "index",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "NodeAdded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "NodeDisabled",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "NodeRemoved",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "newWeight",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "NodeUpdated",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Paused",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32",
+              "indexed": true
+            },
+            {
+              "internalType": "bytes32",
+              "name": "previousAdminRole",
+              "type": "bytes32",
+              "indexed": true
+            },
+            {
+              "internalType": "bytes32",
+              "name": "newAdminRole",
+              "type": "bytes32",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "RoleAdminChanged",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "RoleGranted",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "RoleRevoked",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "from",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Transfer",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "staker",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "unlockId",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "UnlockCancelled",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "staker",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "unlockId",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "UnlockRedeemed",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "staker",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "unlockId",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "shares",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "spotValue",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "toll",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "UnlockRequested",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Unpaused",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "implementation",
+              "type": "address",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "Upgraded",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "shares",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "VirtualSharesSnapshot",
+          "anonymous": false
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "DEFAULT_ADMIN_ROLE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "MINIMUM_CONTRIBUTE_THRESHOLD",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_ADD_NODE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_DISABLE_NODE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_FEE_CLAIMER",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_FEE_EXEMPTION",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_FEE_SETTER",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_PAUSE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_REMOVE_NODE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_UPDATE_WEIGHTS",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "ROLE_UPGRADE",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "UPGRADE_INTERFACE_VERSION",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "addNode"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "allowance",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "approve",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "balanceOf",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "batchDepositRequests",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "assets",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "batchSubmissions",
+          "outputs": [
+            {
+              "internalType": "uint64",
+              "name": "submissionEpoch",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "activationEpoch",
+              "type": "uint64"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "batchWithdrawRequests",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "assets",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint96",
+              "name": "newTotalStaked",
+              "type": "uint96"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "calculateStakeDeltas",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "totalExcess",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint96",
+              "name": "totalDeficit",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint96[]",
+              "name": "nodeExcesses",
+              "type": "uint96[]"
+            },
+            {
+              "internalType": "uint96[]",
+              "name": "nodeDeficits",
+              "type": "uint96[]"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "unlockIndex",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "cancelUnlockRequest"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "claimProtocolFees"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64[]",
+              "name": "nodeIds",
+              "type": "uint64[]"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "compound"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "benefactor",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "payable",
+          "type": "function",
+          "name": "contributeToPool"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "convertToAssets",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "assets",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint96",
+              "name": "assets",
+              "type": "uint96"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "convertToShares",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "currentBatchId",
+          "outputs": [
+            {
+              "internalType": "uint40",
+              "name": "",
+              "type": "uint40"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "decimals",
+          "outputs": [
+            {
+              "internalType": "uint8",
+              "name": "",
+              "type": "uint8"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint96",
+              "name": "minShares",
+              "type": "uint96"
+            },
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "payable",
+          "type": "function",
+          "name": "deposit",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "disableNode"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "user",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getAllUserUnlockRequests",
+          "outputs": [
+            {
+              "internalType": "struct StakedMonadV2.UnlockRequest[]",
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint96",
+                  "name": "shares",
+                  "type": "uint96"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "spotValue",
+                  "type": "uint96"
+                },
+                {
+                  "internalType": "uint40",
+                  "name": "batchId",
+                  "type": "uint40"
+                },
+                {
+                  "internalType": "uint16",
+                  "name": "exitFeeInBips",
+                  "type": "uint16"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "val_id",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "delegator",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "getDelegator",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "stake",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "acc_reward_per_token",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "rewards",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "delta_stake",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "next_delta_stake",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "delta_epoch",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "next_delta_epoch",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getExitFeeBips",
+          "outputs": [
+            {
+              "internalType": "uint16",
+              "name": "",
+              "type": "uint16"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getManagementFeeBips",
+          "outputs": [
+            {
+              "internalType": "uint16",
+              "name": "",
+              "type": "uint16"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getMintableProtocolShares",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getNodeIds",
+          "outputs": [
+            {
+              "internalType": "uint256[]",
+              "name": "",
+              "type": "uint256[]"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getNodes",
+          "outputs": [
+            {
+              "internalType": "struct Registry.Node[]",
+              "name": "",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint64",
+                  "name": "id",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "weight",
+                  "type": "uint96"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "staked",
+                  "type": "uint96"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getRoleAdmin",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "val_id",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWithdrawIds",
+          "outputs": [
+            {
+              "internalType": "uint8[]",
+              "name": "",
+              "type": "uint8[]"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "val_id",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getWithdrawIdsSize",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "grantRole"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "hasRole",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "admin",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "payable",
+          "type": "function",
+          "name": "initialize"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "initializeFromV1"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isExitFeeExempt",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "val_id",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isForceWithdrawPending",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isNodeDisabled",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "name",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "nodes",
+          "outputs": [
+            {
+              "internalType": "uint64",
+              "name": "id",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint96",
+              "name": "weight",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint96",
+              "name": "staked",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "pause"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "paused",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "proxiableUUID",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "unlockIndex",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address payable",
+              "name": "receiver",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "redeem",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "assets",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "removeNode"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "callerConfirmation",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "renounceRole"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint96",
+              "name": "minSpotValue",
+              "type": "uint96"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "requestUnlock",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "spotValue",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "role",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "revokeRole"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint16",
+              "name": "newFee",
+              "type": "uint16"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setExitFee"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "user",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "isExempt",
+              "type": "bool"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setExitFeeExemption"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint16",
+              "name": "newFee",
+              "type": "uint16"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setManagementFee"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "submitBatch"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes4",
+              "name": "interfaceId",
+              "type": "bytes4"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "supportsInterface",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64[]",
+              "name": "nodeIds",
+              "type": "uint64[]"
+            },
+            {
+              "internalType": "uint8",
+              "name": "maxWithdrawsPerNode",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "sweep"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64[]",
+              "name": "nodeIds",
+              "type": "uint64[]"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "sweepForced"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "symbol",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalPooled",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalShares",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "",
+              "type": "uint96"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalSupply",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "totalWeight",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "transfer",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "transferFrom",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "unbondDisableNode"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "unpause"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct Registry.WeightDelta[]",
+              "name": "weightDeltas",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint64",
+                  "name": "nodeId",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "delta",
+                  "type": "uint96"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "isIncreasing",
+                  "type": "bool"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "updateWeights"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "newImplementation",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+            }
+          ],
+          "stateMutability": "payable",
+          "type": "function",
+          "name": "upgradeToAndCall"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "userUnlockRequests",
+          "outputs": [
+            {
+              "internalType": "uint96",
+              "name": "shares",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint96",
+              "name": "spotValue",
+              "type": "uint96"
+            },
+            {
+              "internalType": "uint40",
+              "name": "batchId",
+              "type": "uint40"
+            },
+            {
+              "internalType": "uint16",
+              "name": "exitFeeInBips",
+              "type": "uint16"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "nodeId",
+              "type": "uint64"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "viewNodeByNodeId",
+          "outputs": [
+            {
+              "internalType": "struct Registry.Node",
+              "name": "node",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint64",
+                  "name": "id",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "weight",
+                  "type": "uint96"
+                },
+                {
+                  "internalType": "uint96",
+                  "name": "staked",
+                  "type": "uint96"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "payable",
+          "type": "receive"
+        }
+      ],
+      "devdoc": {
+        "kind": "dev",
+        "methods": {
+          "addNode(uint64)": {
+            "details": "Cannot add a node that already exists"
+          },
+          "allowance(address,address)": {
+            "details": "Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through {transferFrom}. This is zero by default. This value changes when {approve} or {transferFrom} are called."
+          },
+          "approve(address,uint256)": {
+            "details": "See {IERC20-approve}. NOTE: If `value` is the maximum `uint256`, the allowance is not updated on `transferFrom`. This is semantically equivalent to an infinite approval. Requirements: - `spender` cannot be the zero address."
+          },
+          "balanceOf(address)": {
+            "details": "Returns the value of tokens owned by `account`."
+          },
+          "cancelUnlockRequest(uint256)": {
+            "details": "Order of unlock requests is not guaranteed between cancellations"
+          },
+          "compound(uint64[])": {
+            "details": "Specifying an invalid node id will revert"
+          },
+          "contributeToPool(address)": {
+            "details": "Restricts usage when total pooled is below a threshold to prevent share inflation attacks",
+            "params": {
+              "benefactor": "- Address used for tracking who is responsible for the contribution"
+            }
+          },
+          "convertToAssets(uint96)": {
+            "details": "`totalShares()` accounts for both minted and mintable shares"
+          },
+          "convertToShares(uint96)": {
+            "details": "`totalShares()` accounts for both minted and mintable shares"
+          },
+          "decimals()": {
+            "details": "Returns the number of decimals used to get its user representation. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05` (`505 / 10 ** 2`). Tokens usually opt for a value of 18, imitating the relationship between Ether and Wei. This is the default value returned by this function, unless it's overridden. NOTE: This information is only used for _display_ purposes: it in no way affects any of the arithmetic of the contract, including {IERC20-balanceOf} and {IERC20-transfer}."
+          },
+          "deposit(uint96,address)": {
+            "params": {
+              "minShares": "- Minimum quantity of shares that must be minted to prevent front running",
+              "receiver": "- Recipient of the minted shares"
+            },
+            "returns": {
+              "shares": "- Quantity of shares minted"
+            }
+          },
+          "disableNode(uint64)": {
+            "details": "Intended to prepare a node for removal via `Registry.removeNode()`Once disabled, node cannot be assigned a weight"
+          },
+          "getNodeIds()": {
+            "details": "The order is not guaranteed to remain constant between callsThe order is not guaranteed to correlate to a position in `getNodes()`"
+          },
+          "getNodes()": {
+            "details": "The order is not guaranteed to remain constant between calls"
+          },
+          "getRoleAdmin(bytes32)": {
+            "details": "Returns the admin role that controls `role`. See {grantRole} and {revokeRole}. To change a role's admin, use {_setRoleAdmin}."
+          },
+          "getWithdrawIds(uint64)": {
+            "details": "Will not include FORCED_WITHDRAW_ID even if present"
+          },
+          "grantRole(bytes32,address)": {
+            "details": "Grants `role` to `account`. If `account` had not been already granted `role`, emits a {RoleGranted} event. Requirements: - the caller must have ``role``'s admin role. May emit a {RoleGranted} event."
+          },
+          "hasRole(bytes32,address)": {
+            "details": "Returns `true` if `account` has been granted `role`."
+          },
+          "initialize(address)": {
+            "details": "It is recommended to transfer a small amount of MON when initializing to mitigate a rare DOS when:      1) All users make unlock requests      2) Batch is submitted, withdraw delay completes, and all sweep() calls are performed      3) Some dust is still pending undelegation      4) All unlock requests are redeemed"
+          },
+          "name()": {
+            "details": "Returns the name of the token."
+          },
+          "paused()": {
+            "details": "Returns true if the contract is paused, and false otherwise."
+          },
+          "proxiableUUID()": {
+            "details": "Implementation of the ERC-1822 {proxiableUUID} function. This returns the storage slot used by the implementation. It is used to validate the implementation's compatibility when performing an upgrade. IMPORTANT: A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks bricking a proxy that upgrades to it, by delegating to itself until out of gas. Thus it is critical that this function revert if invoked through a proxy. This is guaranteed by the `notDelegated` modifier."
+          },
+          "redeem(uint256,address)": {
+            "details": "Might need to first call `sweep()` to make funds availableDeletes the caller's unlock request"
+          },
+          "removeNode(uint64)": {
+            "details": "Intended to prevent storage bloat"
+          },
+          "renounceRole(bytes32,address)": {
+            "details": "Revokes `role` from the calling account. Roles are often managed via {grantRole} and {revokeRole}: this function's purpose is to provide a mechanism for accounts to lose their privileges if they are compromised (such as when a trusted device is misplaced). If the calling account had been revoked `role`, emits a {RoleRevoked} event. Requirements: - the caller must be `callerConfirmation`. May emit a {RoleRevoked} event."
+          },
+          "revokeRole(bytes32,address)": {
+            "details": "Revokes `role` from `account`. If `account` had been granted `role`, emits a {RoleRevoked} event. Requirements: - the caller must have ``role``'s admin role. May emit a {RoleRevoked} event."
+          },
+          "submitBatch()": {
+            "details": "Might need to first call `sweep()`For a net ingress batch, the amount bonded may be less than the requested amount due to integer arithmetic.      The remaining amount, or 'dust' is scheduled to be bonded in the next batch.For a net egress batch, the amount unbonded may be less than the requested amount due to integer arithmetic.      The remaining amount, or 'dust' is scheduled to be unbonded in the next batch.      In this scenario, `totalPooled` is temporarily increased by this dust amount to account for the assets      that were requested to be unbonded but were not unbonded from nodes, ensuring they remain trackable      in the pool for the next attempt."
+          },
+          "supportsInterface(bytes4)": {
+            "details": "Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[ERC section] to learn more about how these ids are created. This function call must use less than 30 000 gas."
+          },
+          "sweep(uint64[],uint8)": {
+            "details": "Required number of epochs must have passed since calling `undelegate`All withdrawals must be valid and complete or none will"
+          },
+          "sweepForced(uint64[])": {
+            "details": "Required number of epochs must have passed since calling `undelegate`All withdrawals must be valid and complete or none will"
+          },
+          "symbol()": {
+            "details": "Returns the symbol of the token, usually a shorter version of the name."
+          },
+          "totalSupply()": {
+            "details": "Returns the value of tokens in existence."
+          },
+          "transfer(address,uint256)": {
+            "details": "See {IERC20-transfer}. Requirements: - `to` cannot be the zero address. - the caller must have a balance of at least `value`."
+          },
+          "transferFrom(address,address,uint256)": {
+            "details": "See {IERC20-transferFrom}. Skips emitting an {Approval} event indicating an allowance update. This is not required by the ERC. See {xref-ERC20-_approve-address-address-uint256-bool-}[_approve]. NOTE: Does not update the allowance if the current allowance is the maximum `uint256`. Requirements: - `from` and `to` cannot be the zero address. - `from` must have a balance of at least `value`. - the caller must have allowance for ``from``'s tokens of at least `value`."
+          },
+          "unbondDisableNode(uint64)": {
+            "details": "This function is for emergency/cleanup purposes and does not depend on the standard batching processDoes NOT decrease `totalPooled` because funds never leave the protocol's custodyFunds will be scheduled for redelegation during `sweepForced()`",
+            "params": {
+              "nodeId": "- ID of the disabled node to unbond from"
+            }
+          },
+          "updateWeights((uint64,uint96,bool)[])": {
+            "details": "Cannot increase weight of a node that has been disabledDecreasing weight below 0 will not underflow and instead remains at 0Decreasing weight of a node that has been disabled is effectively a no-opUpdating a deleted or non-existent node is effectively a no-op"
+          },
+          "upgradeToAndCall(address,bytes)": {
+            "custom:oz-upgrades-unsafe-allow-reachable": "delegatecall",
+            "details": "Upgrade the implementation of the proxy to `newImplementation`, and subsequently execute the function call encoded in `data`. Calls {_authorizeUpgrade}. Emits an {Upgraded} event."
+          }
+        },
+        "version": 1
+      },
+      "userdoc": {
+        "kind": "user",
+        "methods": {
+          "addNode(uint64)": {
+            "notice": "Adds a new node"
+          },
+          "cancelUnlockRequest(uint256)": {
+            "notice": "Allow user to cancel their unlock requestMost users will have 1 concurrent unlock request (`unlockIndex` == 0) but advanced users may have moreMust be done before the associated batch is submitted"
+          },
+          "compound(uint64[])": {
+            "notice": "Claims all claimable rewards and adds them to the next batch"
+          },
+          "contributeToPool(address)": {
+            "notice": "Allows external funds to be added without minting shares"
+          },
+          "convertToAssets(uint96)": {
+            "notice": "Converts LST shares into MON at the current block timestampDoes not apply exit fee"
+          },
+          "convertToShares(uint96)": {
+            "notice": "Converts MON into LST shares at the current block timestamp"
+          },
+          "deposit(uint96,address)": {
+            "notice": "Deposit asset into the protocol and receive shares to represent your positionDeposit amount must be specified by `msg.value`"
+          },
+          "disableNode(uint64)": {
+            "notice": "Permanently set node weight to 0"
+          },
+          "getDelegator(uint64,address)": {
+            "notice": "Provides a view of the delegator’s stake across execution, consensus, and snapshot contexts"
+          },
+          "getMintableProtocolShares()": {
+            "notice": "Shares that could be minted by the protocol at the current block timestamp"
+          },
+          "getNodeIds()": {
+            "notice": "View all unique node ids in their current order"
+          },
+          "getNodes()": {
+            "notice": "View all nodes in their current order"
+          },
+          "getWithdrawIds(uint64)": {
+            "notice": "Converts the WithdrawIdSummary for a validator into an array of withdraw ids"
+          },
+          "nodes(uint256)": {
+            "notice": "List of currently managed nodes. Order is NOT guaranteed to remain constant"
+          },
+          "redeem(uint256,address)": {
+            "notice": "Step 2 of 2 in process of withdrawing assetsAssociated batch must have been submitted and the cooldown period elapsed"
+          },
+          "removeNode(uint64)": {
+            "notice": "Removes a node from storage"
+          },
+          "submitBatch()": {
+            "notice": "Processes deposit and withdrawal requests and allocates MON according to Registry weights"
+          },
+          "sweep(uint64[],uint8)": {
+            "notice": "Withdraws MON from completed un-delegationsStores withdrawn funds in the contract to fund redemptions"
+          },
+          "sweepForced(uint64[])": {
+            "notice": "Withdraws MON from completed un-delegations of disabled nodesAdds withdrawn funds into the current batch to be redelegated"
+          },
+          "totalShares()": {
+            "notice": "Shares that could exist at the current block timestampIncludes both minted and mintable shares"
+          },
+          "totalWeight()": {
+            "notice": "Sum of node relative weights"
+          },
+          "unbondDisableNode(uint64)": {
+            "notice": "Forcibly unbonds funds from a disabled node"
+          },
+          "updateWeights((uint64,uint96,bool)[])": {
+            "notice": "Modifies node weights by incrementing/decrementing"
+          },
+          "viewNodeByNodeId(uint64)": {
+            "notice": "View a node by its unique node id"
+          }
+        },
+        "version": 1
+      }
+    },
+    "settings": {
+      "remappings": [
+        "@openzeppelin-contracts-5.4.0/=dependencies/@openzeppelin-contracts-5.4.0/",
+        "@openzeppelin-contracts-upgradeable-5.4.0/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0/",
+        "@openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0/",
+        "@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0/",
+        "forge-std-1.10.0/=dependencies/forge-std-1.10.0/src/",
+        "forge-std/=dependencies/forge-std-1.10.0/"
+      ],
+      "optimizer": {
+        "enabled": true,
+        "runs": 2000
+      },
+      "metadata": {
+        "bytecodeHash": "ipfs"
+      },
+      "compilationTarget": {
+        "src/StakedMonadV2.sol": "StakedMonadV2"
+      },
+      "evmVersion": "cancun",
+      "libraries": {}
+    },
+    "sources": {
+      "dependencies/@openzeppelin-contracts-5.4.0/access/IAccessControl.sol": {
+        "keccak256": "0xbff9f59c84e5337689161ce7641c0ef8e872d6a7536fbc1f5133f128887aba3c",
+        "urls": [
+          "bzz-raw://b308f882e796f7b79c9502deacb0a62983035c6f6f4e962b319ba6a1f4a77d3d",
+          "dweb:/ipfs/QmaWCW7ahEQqFjwhSUhV7Ae7WhfNvzSpE7DQ58hvEooqPL"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/interfaces/IERC1967.sol": {
+        "keccak256": "0xbf2aefe54b76d7f7bcd4f6da1080b7b1662611937d870b880db584d09cea56b5",
+        "urls": [
+          "bzz-raw://f5e7e2f12e0feec75296e57f51f82fdaa8bd1551f4b8cc6560442c0bf60f818c",
+          "dweb:/ipfs/QmcW9wDMaQ8RbQibMarfp17a3bABzY5KraWe2YDwuUrUoz"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/interfaces/draft-IERC1822.sol": {
+        "keccak256": "0x82f757819bf2429a0d4db141b99a4bbe5039e4ef86dfb94e2e6d40577ed5b28b",
+        "urls": [
+          "bzz-raw://37c30ed931e19fb71fdb806bb504cfdb9913b7127545001b64d4487783374422",
+          "dweb:/ipfs/QmUBHpv4hm3ZmwJ4GH8BeVzK4mv41Q6vBbWXxn8HExPXza"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/interfaces/draft-IERC6093.sol": {
+        "keccak256": "0x19fdfb0f3b89a230e7dbd1cf416f1a6b531a3ee5db4da483f946320fc74afc0e",
+        "urls": [
+          "bzz-raw://3490d794728f5bfecb46820431adaff71ba374141545ec20b650bb60353fac23",
+          "dweb:/ipfs/QmPsfxjVpMcZbpE7BH93DzTpEaktESigEw4SmDzkXuJ4WR"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/proxy/ERC1967/ERC1967Utils.sol": {
+        "keccak256": "0xa1ad192cd45317c788618bef5cb1fb3ca4ce8b230f6433ac68cc1d850fb81618",
+        "urls": [
+          "bzz-raw://b43447bb85a53679d269a403c693b9d88d6c74177dfb35eddca63abaf7cf110a",
+          "dweb:/ipfs/QmXSDmpd4bNZj1PDgegr6C4w1jDaWHXCconC3rYiw9TSkQ"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/proxy/beacon/IBeacon.sol": {
+        "keccak256": "0x20462ddb2665e9521372c76b001d0ce196e59dbbd989de9af5576cad0bd5628b",
+        "urls": [
+          "bzz-raw://f417fd12aeec8fbfaceaa30e3a08a0724c0bc39de363e2acf6773c897abbaf6d",
+          "dweb:/ipfs/QmU4Hko6sApdweVM92CsiuLKkCk8HfyBeutF89PCTz5Tye"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/token/ERC20/IERC20.sol": {
+        "keccak256": "0x74ed01eb66b923d0d0cfe3be84604ac04b76482a55f9dd655e1ef4d367f95bc2",
+        "urls": [
+          "bzz-raw://5282825a626cfe924e504274b864a652b0023591fa66f06a067b25b51ba9b303",
+          "dweb:/ipfs/QmeCfPykghhMc81VJTrHTC7sF6CRvaA1FXVq2pJhwYp1dV"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/token/ERC20/extensions/IERC20Metadata.sol": {
+        "keccak256": "0xd6fa4088198f04eef10c5bce8a2f4d60554b7ec4b987f684393c01bf79b94d9f",
+        "urls": [
+          "bzz-raw://f95ee0bbd4dd3ac730d066ba3e785ded4565e890dbec2fa7d3b9fe3bad9d0d6e",
+          "dweb:/ipfs/QmSLr6bHkPFWT7ntj34jmwfyskpwo97T9jZUrk5sz3sdtR"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/Address.sol": {
+        "keccak256": "0x6d0ae6e206645341fd122d278c2cb643dea260c190531f2f3f6a0426e77b00c0",
+        "urls": [
+          "bzz-raw://032d1201d839435be2c85b72e33206b3ea980c569d6ebf7fa57d811ab580a82f",
+          "dweb:/ipfs/QmeqQjAtMvdZT2tG7zm39itcRJkuwu8AEReK6WRnLJ18DD"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/Arrays.sol": {
+        "keccak256": "0xa4b9958797e0e9cde82a090525e90f80d5745ba1c67ee72b488bd3087498a17e",
+        "urls": [
+          "bzz-raw://c9344f7c2f80322c2e76d9d89bed03fd12f3e011e74fde7cf24ea21bdd2abe2d",
+          "dweb:/ipfs/QmPMAjF5x2fHUAee2FKMZDBbFVrbZbPCr3a9KHLZaSn1zY"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/Comparators.sol": {
+        "keccak256": "0x302eecd8cf323b4690e3494a7d960b3cbce077032ab8ef655b323cdd136cec58",
+        "urls": [
+          "bzz-raw://49ba706f1bc476d68fe6c1fad75517acea4e9e275be0989b548e292eb3a3eacd",
+          "dweb:/ipfs/QmeBpvcdGWzWMKTQESUCEhHgnEQYYATVwPxLMxa6vMT7jC"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/Errors.sol": {
+        "keccak256": "0x6afa713bfd42cf0f7656efa91201007ac465e42049d7de1d50753a373648c123",
+        "urls": [
+          "bzz-raw://ba1d02f4847670a1b83dec9f7d37f0b0418d6043447b69f3a29a5f9efc547fcf",
+          "dweb:/ipfs/QmQ7iH2keLNUKgq2xSWcRmuBE5eZ3F5whYAkAGzCNNoEWB"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/Panic.sol": {
+        "keccak256": "0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a",
+        "urls": [
+          "bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a",
+          "dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/SlotDerivation.sol": {
+        "keccak256": "0x67672e4ca1dafdcc661d4eba8475cfac631fa0933309258e3af7644b92e1fb26",
+        "urls": [
+          "bzz-raw://30192451f05ea5ddb0c18bd0f9003f098505836ba19c08a9c365adf829454da2",
+          "dweb:/ipfs/QmfCuZSCTyCdFoSKn7MSaN6hZksnQn9ZhrZDAdRTCbwGu2"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/StorageSlot.sol": {
+        "keccak256": "0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97",
+        "urls": [
+          "bzz-raw://9f660b1f351b757dfe01438e59888f31f33ded3afcf5cb5b0d9bf9aa6f320a8b",
+          "dweb:/ipfs/QmarDJ5hZEgBtCmmrVzEZWjub9769eD686jmzb2XpSU1cM"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/introspection/IERC165.sol": {
+        "keccak256": "0x8891738ffe910f0cf2da09566928589bf5d63f4524dd734fd9cedbac3274dd5c",
+        "urls": [
+          "bzz-raw://971f954442df5c2ef5b5ebf1eb245d7105d9fbacc7386ee5c796df1d45b21617",
+          "dweb:/ipfs/QmadRjHbkicwqwwh61raUEapaVEtaLMcYbQZWs9gUkgj3u"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/math/Math.sol": {
+        "keccak256": "0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6",
+        "urls": [
+          "bzz-raw://6c5fab4970634f9ab9a620983dc1c8a30153981a0b1a521666e269d0a11399d3",
+          "dweb:/ipfs/QmVRnBC575MESGkEHndjujtR7qub2FzU9RWy9eKLp4hPZB"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/math/SafeCast.sol": {
+        "keccak256": "0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54",
+        "urls": [
+          "bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8",
+          "dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0/utils/structs/EnumerableSet.sol": {
+        "keccak256": "0x1fc283df727585919c3db301b948a3e827aee16917457ad7f916db9da2228e77",
+        "urls": [
+          "bzz-raw://a4f4b5e2cd0ebc3b74e41e4e94771a0417eedd9b11cec3ef9f90b2ac2989264b",
+          "dweb:/ipfs/QmZmsEsvsXiwAyAe1YeoLSKezeFcvR1giUeEY6ex4zpsTS"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0/access/AccessControlUpgradeable.sol": {
+        "keccak256": "0x85a70e2b1b65e9ba456add364d22b97eb9944083df1c39c0b4bd6a4b5aa386a4",
+        "urls": [
+          "bzz-raw://d32a33be6ca4d8e89b9e82e3f9cec7a6c4e040534152313ff55da85b8f193059",
+          "dweb:/ipfs/QmeR55L8t2A8xZ1nvT5y4yVWfFbbmpaGAtGBMz3GGNpuyP"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0/proxy/utils/Initializable.sol": {
+        "keccak256": "0xdb4d24ee2c087c391d587cd17adfe5b3f9d93b3110b1388c2ab6c7c0ad1dcd05",
+        "urls": [
+          "bzz-raw://ab7b6d5b9e2b88176312967fe0f0e78f3d9a1422fa5e4b64e2440c35869b5d08",
+          "dweb:/ipfs/QmXKYWWyzcLg1B2k7Sb1qkEXgLCYfXecR9wYW5obRzWP1Q"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0/proxy/utils/UUPSUpgradeable.sol": {
+        "keccak256": "0x574a7451e42724f7de29e2855c392a8a5020acd695169466a18459467d719d63",
+        "urls": [
+          "bzz-raw://5bc189f63b639ee173dd7b6fecc39baf7113bf161776aea22b34c57fdd1872ec",
+          "dweb:/ipfs/QmZAf2VtjDLRULqjJkde6LNsxAg12tUqpPqgUQQZbAjgtZ"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0/token/ERC20/ERC20Upgradeable.sol": {
+        "keccak256": "0xfcd09c2aa8cc3f93e12545454359f901965db312bc03833daf84de0c03e05022",
+        "urls": [
+          "bzz-raw://07701188648d2ab83dab1037808298585264559bddf243bd8929037adcb984b0",
+          "dweb:/ipfs/QmavmG5REdHCAWsZ8Cag26BCxAq27DRKGxr3uBg5ZYxQ51"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0/utils/ContextUpgradeable.sol": {
+        "keccak256": "0xdbef5f0c787055227243a7318ef74c8a5a1108ca3a07f2b3a00ef67769e1e397",
+        "urls": [
+          "bzz-raw://08e39f23d5b4692f9a40803e53a8156b72b4c1f9902a88cd65ba964db103dab9",
+          "dweb:/ipfs/QmPKn6EYDgpga7KtpkA8wV2yJCYGMtc9K4LkJfhKX2RVSV"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0/utils/PausableUpgradeable.sol": {
+        "keccak256": "0xa6bf6b7efe0e6625a9dcd30c5ddf52c4c24fe8372f37c7de9dbf5034746768d5",
+        "urls": [
+          "bzz-raw://8c353ee3705bbf6fadb84c0fb10ef1b736e8ca3ca1867814349d1487ed207beb",
+          "dweb:/ipfs/QmcugaPssrzGGE8q4YZKm2ZhnD3kCijjcgdWWg76nWt3FY"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0/utils/introspection/ERC165Upgradeable.sol": {
+        "keccak256": "0x6694b63ddb2c59bbe341c846171798350e8f72fa02189fcdeaca864e28b54e1f",
+        "urls": [
+          "bzz-raw://7d945d33e2189ac4e531e4ed228f59ca957b3898c4f9051f4b8c7ae44d72b23a",
+          "dweb:/ipfs/QmRcEwubTe3xyXxthijs5fVzEgUFSxeddjd5PGfhBnkunX"
+        ],
+        "license": "MIT"
+      },
+      "src/CustomErrors.sol": {
+        "keccak256": "0x1ba383b9bef5e696f656063cab035fb4ab64aa8897058dcf18e18d31fd6ded59",
+        "urls": [
+          "bzz-raw://b5a381b74add6e325972095ae4f285af900a7d014e3e01859428f11a319f631d",
+          "dweb:/ipfs/QmRyADdcNPeZoupt5c2nWUj6NzRsKs7QeUCQXmVfKbXRaG"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/Registry.sol": {
+        "keccak256": "0x4806200e21dfc07a3c62e852f27a36098cc9fab7555d251ef80b7ea2ee011ebb",
+        "urls": [
+          "bzz-raw://fa94b3bdaa65513441392965f05642734d66879e589f5cfb152f83444787c8f4",
+          "dweb:/ipfs/QmZ2AWdFVMFC3aDLUJywHry4Q5wUSi9Rj7WGcj8zexJJbW"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/StakedMonadV2.sol": {
+        "keccak256": "0xd7cd3d458219be55015bac01d13a242f6588cfe7e665a19992402b581297f0bb",
+        "urls": [
+          "bzz-raw://b5f39bf61b13d3c2c8900256246418531ef74a0b9aeebdab3944ccb7bdf6db0c",
+          "dweb:/ipfs/QmRS65ZPdKF3j9uaCwu9isissoga5MqbB8cwkbKaK6xgLY"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/precompile/StakerUpgradeable.sol": {
+        "keccak256": "0xf4bc7283a25072476bf615ef54decc539ea0bec2eb487bbacdab6372e53cb8bb",
+        "urls": [
+          "bzz-raw://a688b754762541652f7a66229db78d0bf334e7ebcceab4db64d0f41827856181",
+          "dweb:/ipfs/QmWXxUCVWrXcG7qErrbuCsymUpZYVps6usNLLcYtxw5kJc"
+        ],
+        "license": "BUSL-1.1"
+      }
+    },
+    "version": 1
+  },
+  "id": 58
+}

--- a/packages/protocols/kintsu/abis-src/VENDOR.json
+++ b/packages/protocols/kintsu/abis-src/VENDOR.json
@@ -1,0 +1,7 @@
+{
+  "name": "@water-cooler-studios/monad-contracts-core",
+  "version": "2.2.0",
+  "tarballSha256": "ff5532ff6daabc7d1bec798aa18485df3aa28ff6c6a67bb946ec2dae8f8688da",
+  "vendoredAt": "2026-07-19",
+  "releaseAgeGuardDays": 7
+}

--- a/packages/protocols/kintsu/package.json
+++ b/packages/protocols/kintsu/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@themoss/protocol-kintsu",
+  "version": "0.1.0",
+  "description": "Moss protocol adapter for staking MON with Kintsu and receiving sMON",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "update:abis": "tsx scripts/update-abis.ts",
+    "gen:abis": "tsx scripts/gen-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/simulator": "workspace:*",
+    "@themoss/system": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/kintsu/scripts/abis.ts
+++ b/packages/protocols/kintsu/scripts/abis.ts
@@ -1,0 +1,42 @@
+/** Deterministically derives the full typed ABI from the committed upstream artifact. */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface VendorInfo {
+  name: string;
+  version: string;
+  tarballSha256: string;
+  vendoredAt: string;
+  releaseAgeGuardDays: number;
+}
+
+interface Artifact {
+  abi: readonly unknown[];
+}
+
+export const ARTIFACT_PATH = "out/StakedMonad.sol/143_artifact.json";
+// Keep the upstream bytes under a non-JSON extension so repository formatters
+// cannot rewrite the verbatim artifact (the source file itself is JSON).
+export const VENDORED_FILE = "StakedMonad.artifact";
+
+export function generate(packageRoot: string): string {
+  const vendor = JSON.parse(
+    readFileSync(join(packageRoot, "abis-src", "VENDOR.json"), "utf8"),
+  ) as VendorInfo;
+  const raw = readFileSync(join(packageRoot, "abis-src", VENDORED_FILE), "utf8");
+  const artifact = JSON.parse(raw) as Artifact;
+  if (!Array.isArray(artifact.abi)) throw new Error(`${VENDORED_FILE}: missing full ABI array`);
+
+  return `// GENERATED FILE — do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   ${vendor.name}@${vendor.version} (npm), ${ARTIFACT_PATH}
+//   tarball:  sha256 ${vendor.tarballSha256}
+//   vendored: ${vendor.vendoredAt} (release-age guard: ${vendor.releaseAgeGuardDays}d)
+//   deployment: the upstream 143_deployment.json and Monad protocol registry both name
+//   0xA3227C5969757783154C60bF0bC1944180ed81B9; live tests verify proxy bytecode and metadata.
+
+export const StakedMonadAbi = ${JSON.stringify(artifact.abi, null, 2)} as const;
+`;
+}

--- a/packages/protocols/kintsu/scripts/gen-abis.ts
+++ b/packages/protocols/kintsu/scripts/gen-abis.ts
@@ -1,0 +1,8 @@
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate } from "./abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+writeFileSync(join(packageRoot, "src", "abis", "staked-monad.ts"), generate(packageRoot));
+console.log("regenerated src/abis/staked-monad.ts from abis-src/ (offline)");

--- a/packages/protocols/kintsu/scripts/update-abis.ts
+++ b/packages/protocols/kintsu/scripts/update-abis.ts
@@ -1,0 +1,57 @@
+/** Re-vendor the stable official Kintsu artifact, then regenerate the typed ABI. */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ARTIFACT_PATH, generate, VENDORED_FILE, type VendorInfo } from "./abis.js";
+
+const PACKAGE_NAME = "@water-cooler-studios/monad-contracts-core";
+const MIN_RELEASE_AGE_DAYS = 7;
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const dayMs = 24 * 60 * 60 * 1000;
+
+interface RegistryDoc {
+  "dist-tags": Record<string, string>;
+  time: Record<string, string>;
+  versions: Record<string, { dist: { tarball: string } }>;
+}
+
+const registry = (await (
+  await fetch(`https://registry.npmjs.org/${PACKAGE_NAME.replace("/", "%2F")}`)
+).json()) as RegistryDoc;
+const publishedAt = (version: string) => Date.parse(registry.time[version] ?? "");
+const cutoff = Date.now() - MIN_RELEASE_AGE_DAYS * dayMs;
+const pinned = process.argv[2];
+const picked =
+  pinned ??
+  Object.keys(registry.versions)
+    .filter((version) => /^\d+\.\d+\.\d+$/.test(version))
+    .filter((version) => publishedAt(version) <= cutoff)
+    .sort((a, b) => publishedAt(b) - publishedAt(a))[0];
+if (!picked || !registry.versions[picked]) {
+  throw new Error(`no stable ${PACKAGE_NAME} release satisfies the age guard`);
+}
+
+const tarballUrl = registry.versions[picked]?.dist.tarball;
+if (!tarballUrl) throw new Error(`no tarball URL for ${PACKAGE_NAME}@${picked}`);
+const bytes = Buffer.from(await (await fetch(tarballUrl)).arrayBuffer());
+const sha256 = createHash("sha256").update(bytes).digest("hex");
+const work = mkdtempSync(join(tmpdir(), "kintsu-abis-"));
+const tarball = join(work, "package.tgz");
+writeFileSync(tarball, bytes);
+execFileSync("tar", ["-xzf", tarball, "-C", work]);
+
+mkdirSync(join(packageRoot, "abis-src"), { recursive: true });
+copyFileSync(join(work, "package", ARTIFACT_PATH), join(packageRoot, "abis-src", VENDORED_FILE));
+const vendor: VendorInfo = {
+  name: PACKAGE_NAME,
+  version: picked,
+  tarballSha256: sha256,
+  vendoredAt: new Date().toISOString().slice(0, 10),
+  releaseAgeGuardDays: MIN_RELEASE_AGE_DAYS,
+};
+writeFileSync(join(packageRoot, "abis-src", "VENDOR.json"), `${JSON.stringify(vendor, null, 2)}\n`);
+writeFileSync(join(packageRoot, "src", "abis", "staked-monad.ts"), generate(packageRoot));
+console.log(`vendored ${PACKAGE_NAME}@${picked} (${sha256.slice(0, 16)}…)`);

--- a/packages/protocols/kintsu/src/abis/staked-monad.ts
+++ b/packages/protocols/kintsu/src/abis/staked-monad.ts
@@ -1,0 +1,2151 @@
+// GENERATED FILE — do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   @water-cooler-studios/monad-contracts-core@2.2.0 (npm), out/StakedMonad.sol/143_artifact.json
+//   tarball:  sha256 ff5532ff6daabc7d1bec798aa18485df3aa28ff6c6a67bb946ec2dae8f8688da
+//   vendored: 2026-07-19 (release-age guard: 7d)
+//   deployment: the upstream 143_deployment.json and Monad protocol registry both name
+//   0xA3227C5969757783154C60bF0bC1944180ed81B9; live tests verify proxy bytecode and metadata.
+
+export const StakedMonadAbi = [
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "receive",
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "DEFAULT_ADMIN_ROLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MINIMUM_CONTRIBUTE_THRESHOLD",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_ADD_NODE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_DISABLE_NODE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_FEE_CLAIMER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_FEE_EXEMPTION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_FEE_SETTER",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_PAUSE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_REMOVE_NODE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_UPDATE_WEIGHTS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ROLE_UPGRADE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "addNode",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "batchDepositRequests",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "batchSubmissions",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "submissionEpoch",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "activationEpoch",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "batchWithdrawRequests",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "calculateStakeDeltas",
+    "inputs": [
+      {
+        "name": "newTotalStaked",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalExcess",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "totalDeficit",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "nodeExcesses",
+        "type": "uint96[]",
+        "internalType": "uint96[]"
+      },
+      {
+        "name": "nodeDeficits",
+        "type": "uint96[]",
+        "internalType": "uint96[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "cancelUnlockRequest",
+    "inputs": [
+      {
+        "name": "unlockIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimProtocolFees",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "compound",
+    "inputs": [
+      {
+        "name": "nodeIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "contributeToPool",
+    "inputs": [
+      {
+        "name": "benefactor",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "convertToAssets",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "convertToShares",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "currentBatchId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint40",
+        "internalType": "uint40"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "minShares",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "disableNode",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getAllUserUnlockRequests",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct StakedMonadV2.UnlockRequest[]",
+        "components": [
+          {
+            "name": "shares",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "spotValue",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "batchId",
+            "type": "uint40",
+            "internalType": "uint40"
+          },
+          {
+            "name": "exitFeeInBips",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDelegator",
+    "inputs": [
+      {
+        "name": "val_id",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "delegator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "stake",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "acc_reward_per_token",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "rewards",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "delta_stake",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "next_delta_stake",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "delta_epoch",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "next_delta_epoch",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getExitFeeBips",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getManagementFeeBips",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMintableProtocolShares",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNodeIds",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNodes",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct Registry.Node[]",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "weight",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "staked",
+            "type": "uint96",
+            "internalType": "uint96"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoleAdmin",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWithdrawIds",
+    "inputs": [
+      {
+        "name": "val_id",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8[]",
+        "internalType": "uint8[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getWithdrawIdsSize",
+    "inputs": [
+      {
+        "name": "val_id",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "grantRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "hasRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "admin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "initializeFromV1",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isExitFeeExempt",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isForceWithdrawPending",
+    "inputs": [
+      {
+        "name": "val_id",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isNodeDisabled",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nodes",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "id",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "weight",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "staked",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "redeem",
+    "inputs": [
+      {
+        "name": "unlockIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address payable"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removeNode",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "callerConfirmation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestUnlock",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "minSpotValue",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "spotValue",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "revokeRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setExitFee",
+    "inputs": [
+      {
+        "name": "newFee",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setExitFeeExemption",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "isExempt",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setManagementFee",
+    "inputs": [
+      {
+        "name": "newFee",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "submitBatch",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "sweep",
+    "inputs": [
+      {
+        "name": "nodeIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      },
+      {
+        "name": "maxWithdrawsPerNode",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sweepForced",
+    "inputs": [
+      {
+        "name": "nodeIds",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalPooled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalShares",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalWeight",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unbondDisableNode",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateWeights",
+    "inputs": [
+      {
+        "name": "weightDeltas",
+        "type": "tuple[]",
+        "internalType": "struct Registry.WeightDelta[]",
+        "components": [
+          {
+            "name": "nodeId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "delta",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "isIncreasing",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "userUnlockRequests",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "spotValue",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "batchId",
+        "type": "uint40",
+        "internalType": "uint40"
+      },
+      {
+        "name": "exitFeeInBips",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "viewNodeByNodeId",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "node",
+        "type": "tuple",
+        "internalType": "struct Registry.Node",
+        "components": [
+          {
+            "name": "id",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "weight",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "staked",
+            "type": "uint96",
+            "internalType": "uint96"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BatchSent",
+    "inputs": [
+      {
+        "name": "batchId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "sharesBurnt",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "unstakeValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Compounded",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Contribution",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "benefactor",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "staker",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExitFeeAdjusted",
+    "inputs": [
+      {
+        "name": "newFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeesWithdrawn",
+    "inputs": [
+      {
+        "name": "managementFeeShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "exitFeeShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ManagementFeeAdjusted",
+    "inputs": [
+      {
+        "name": "newFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeAdded",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeDisabled",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeRemoved",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeUpdated",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "newWeight",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleAdminChanged",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "previousAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleGranted",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleRevoked",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UnlockCancelled",
+    "inputs": [
+      {
+        "name": "staker",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "unlockId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UnlockRedeemed",
+    "inputs": [
+      {
+        "name": "staker",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "unlockId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UnlockRequested",
+    "inputs": [
+      {
+        "name": "staker",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "unlockId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "spotValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "toll",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VirtualSharesSnapshot",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccessControlBadConfirmation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AccessControlUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "neededRole",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ActiveNode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "BatchNotSubmitted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "CancellationWindowClosed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DepositOverflow",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DisabledNode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DuplicateNode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientAllowance",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "allowance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientBalance",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSpender",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "EmptyBatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EnforcedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ExpectedPause",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FeeTooLarge",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientPendingWithdrawals",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidNode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxPendingWithdrawals",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinimumBatchDelay",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinimumContributeThreshold",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinimumDeposit",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinimumUnlock",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PendingWithdrawals",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PrecompileCallFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "WithdrawDelay",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroTotalWeight",
+    "inputs": []
+  }
+] as const;

--- a/packages/protocols/kintsu/src/index.ts
+++ b/packages/protocols/kintsu/src/index.ts
@@ -1,0 +1,1 @@
+export { KINTSU_SMON_ADDRESS, Kintsu, type KintsuStakeOutcome } from "./kintsu.js";

--- a/packages/protocols/kintsu/src/kintsu.ts
+++ b/packages/protocols/kintsu/src/kintsu.ts
@@ -1,0 +1,238 @@
+import {
+  Address,
+  type AddressValue,
+  BasisPoints,
+  Capability,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type JsonSafeValue,
+  ParameterError,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptChange,
+  type ReceiptResult,
+} from "@themoss/core";
+import { ERC20 } from "@themoss/erc";
+import { decodeEventLog, formatUnits, getAddress, parseUnits } from "viem";
+import { StakedMonadAbi } from "./abis/staked-monad.js";
+
+// Kintsu official Monad mainnet deployment:
+// https://github.com/monad-crypto/protocols/blob/main/mainnet/kintsu.jsonc
+// The official npm artifact's 143_deployment.json names the same address.
+export const KINTSU_SMON_ADDRESS = "0xA3227C5969757783154C60bF0bC1944180ed81B9" as const;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const MAX_UINT96 = (1n << 96n) - 1n;
+const DEFAULT_SLIPPAGE_BPS = 50;
+
+const stakeSlippage = BasisPoints.max(5_000)
+  .default(DEFAULT_SLIPPAGE_BPS)
+  .describe("An integer basis-point count from 0 through 5000; 1 bps equals 0.01%.");
+
+const stakeParams = {
+  amount: {
+    type: PositiveDecimalString,
+    description: "Human-readable native MON amount deposited into Kintsu; MON uses 18 decimals.",
+  },
+  receiver: { type: Address, description: "Address receiving the minted sMON shares." },
+  slippageBps: {
+    type: stakeSlippage,
+    description: "Maximum quote movement allowed when deriving the minimum sMON shares.",
+  },
+} satisfies ParamsSpec;
+
+const assetQuoteParams = {
+  amount: {
+    type: PositiveDecimalString,
+    description: "Human-readable MON amount converted into an estimated sMON share quantity.",
+  },
+} satisfies ParamsSpec;
+
+const shareQuoteParams = {
+  shares: {
+    type: PositiveDecimalString,
+    description: "Human-readable sMON share quantity converted into its current MON value.",
+  },
+} satisfies ParamsSpec;
+
+const balanceParams = {
+  owner: { type: Address, description: "Address whose sMON balance is read." },
+} satisfies ParamsSpec;
+
+export type KintsuStakeOutcome = {
+  operation: "stake";
+  account: AddressValue;
+  receiver: AddressValue;
+  monAmount: string;
+  sMonShares: string;
+};
+
+@Protocol({
+  name: "kintsu",
+  category: "staking",
+  description: "Stake native MON with Kintsu and receive transferable sMON shares.",
+  contracts: { stakedMonad: { abi: StakedMonadAbi, addr: KINTSU_SMON_ADDRESS } },
+  protocols: { erc20: ERC20 },
+})
+export class Kintsu {
+  declare stakedMonad: Handle<typeof StakedMonadAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  @Capability<Kintsu, typeof stakeParams>({
+    intent: "Stake native MON with Kintsu and receive sMON",
+    verb: "stake",
+    params: stakeParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut", "priceImpact"],
+    tags: ["staking", "lst"],
+  })
+  async stake(params: InferParams<typeof stakeParams>) {
+    const amount = toUint96(parseUnits(params.amount, 18), "amount");
+    const quotedShares = await this.stakedMonad.read.convertToShares([amount]);
+    if (quotedShares === 0n) throw new ParameterError("Kintsu quote returned zero sMON shares");
+    const minShares =
+      (quotedShares * (10_000n - BigInt(params.slippageBps ?? DEFAULT_SLIPPAGE_BPS))) / 10_000n;
+    if (minShares === 0n) throw new ParameterError("minimum sMON shares rounds to zero");
+    return [this.stakedMonad.deposit([minShares, params.receiver], { value: amount })];
+  }
+
+  @Query({ intent: "Quote sMON shares received for staking MON", params: assetQuoteParams })
+  async convertToShares(params: InferParams<typeof assetQuoteParams>) {
+    const assets = toUint96(parseUnits(params.amount, 18), "amount");
+    const shares = await this.stakedMonad.read.convertToShares([assets]);
+    return { amount: params.amount, shares: formatUnits(shares, 18) };
+  }
+
+  @Query({ intent: "Quote the MON value of sMON shares", params: shareQuoteParams })
+  async convertToAssets(params: InferParams<typeof shareQuoteParams>) {
+    const shares = toUint96(parseUnits(params.shares, 18), "shares");
+    const assets = await this.stakedMonad.read.convertToAssets([shares]);
+    return { shares: params.shares, amount: formatUnits(assets, 18) };
+  }
+
+  @Query({ intent: "Read an sMON balance", params: balanceParams, tags: ["balance"] })
+  async balanceOf(params: InferParams<typeof balanceParams>) {
+    const balance = await this.stakedMonad.read.balanceOf([params.owner]);
+    return {
+      token: KINTSU_SMON_ADDRESS,
+      symbol: "sMON",
+      decimals: 18,
+      owner: params.owner,
+      balance: balance.toString(),
+    };
+  }
+
+  @Receipt()
+  stakeReceipt(changes: readonly Change[]): ReceiptResult<KintsuStakeOutcome> {
+    let native: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+    let deposit: { receiver: AddressValue; shares: string; value: string } | undefined;
+    let mint: { from: AddressValue; to: AddressValue; value: string } | undefined;
+    let snapshots = 0;
+
+    const parsed = changes.map<ReceiptChange | ReceiptResult<JsonSafeValue>>((change) => {
+      if (change.kind === "nativeTransfer") {
+        if (native) throw new Error("Kintsu stake emitted multiple native transfers");
+        if (!sameAddress(change.to, KINTSU_SMON_ADDRESS)) {
+          throw new Error("Kintsu stake native transfer has the wrong recipient");
+        }
+        native = change;
+        return receiptChange(
+          change,
+          { operation: "nativeTransfer", ...change },
+          `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
+        );
+      }
+      if (!sameAddress(change.address, KINTSU_SMON_ADDRESS)) {
+        throw new Error(`Unexpected Change: event emitted by ${change.address}`);
+      }
+
+      let event: ReturnType<typeof decodeEventLog<typeof StakedMonadAbi>>;
+      try {
+        event = decodeEventLog({
+          abi: StakedMonadAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error("Unexpected Change: unsupported Kintsu event");
+      }
+
+      if (event.eventName === "Transfer") {
+        if (mint) throw new Error("Kintsu stake emitted multiple sMON Transfer events");
+        mint = {
+          from: event.args.from,
+          to: event.args.to,
+          value: event.args.value.toString(),
+        };
+        return this.erc20.changesReceipt([change]);
+      }
+      if (event.eventName === "VirtualSharesSnapshot") {
+        snapshots += 1;
+        if (snapshots > 1) throw new Error("Kintsu stake emitted multiple fee snapshots");
+        const value = event.args.shares.toString();
+        return receiptChange(
+          change,
+          { event: "VirtualSharesSnapshot", shares: value },
+          `Kintsu Virtual Shares Snapshot: ${value}`,
+        );
+      }
+      if (event.eventName !== "Deposit" || deposit) {
+        throw new Error(`Unexpected Change: Kintsu stake received ${event.eventName}`);
+      }
+      deposit = {
+        receiver: event.args.staker,
+        shares: event.args.shares.toString(),
+        value: event.args.value.toString(),
+      };
+      return receiptChange(
+        change,
+        { operation: "stake", ...deposit },
+        `Kintsu Stake: ${deposit.value} MON for ${deposit.shares} sMON to ${deposit.receiver}`,
+      );
+    });
+
+    if (!native || !deposit || !mint) {
+      throw new Error("Kintsu stake Receipt requires native transfer, sMON mint, and Deposit");
+    }
+    if (!sameAddress(mint.from, ZERO_ADDRESS))
+      throw new Error("Kintsu stake Transfer is not a mint");
+    if (!sameAddress(mint.to, deposit.receiver) || mint.value !== deposit.shares) {
+      throw new Error("Kintsu stake sMON mint differs from Deposit");
+    }
+    if (native.value !== deposit.value) {
+      throw new Error("Kintsu stake MON amount differs between native transfer and Deposit");
+    }
+    const outcome: KintsuStakeOutcome = {
+      operation: "stake",
+      account: getAddress(native.from),
+      receiver: deposit.receiver,
+      monAmount: deposit.value,
+      sMonShares: deposit.shares,
+    };
+    return {
+      kind: "receipt",
+      outcome,
+      text: `Kintsu Stake: ${outcome.monAmount} MON for ${outcome.sMonShares} sMON to ${outcome.receiver}`,
+      changes: parsed,
+    };
+  }
+}
+
+function toUint96(value: bigint, field: string): bigint {
+  if (value > MAX_UINT96) throw new ParameterError(`${field} exceeds the Kintsu uint96 limit`);
+  return value;
+}
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function receiptChange(change: Change, data: JsonSafeValue, text: string): ReceiptChange {
+  return { kind: "change", change, data, text };
+}

--- a/packages/protocols/kintsu/test/abis.test.ts
+++ b/packages/protocols/kintsu/test/abis.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { generate } from "../scripts/abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("Kintsu ABI provenance", () => {
+  it("derives the committed typed ABI from the full vendored artifact", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "staked-monad.ts"), "utf8");
+    expect(committed).toBe(generate(packageRoot));
+  });
+});

--- a/packages/protocols/kintsu/test/kintsu.test.ts
+++ b/packages/protocols/kintsu/test/kintsu.test.ts
@@ -1,0 +1,204 @@
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  Registry,
+} from "@themoss/core";
+import { createTraceSimulator } from "@themoss/simulator";
+import { monadRuntime } from "@themoss/system";
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { StakedMonadAbi } from "../src/abis/staked-monad.js";
+import { KINTSU_SMON_ADDRESS, Kintsu } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const RECEIVER = getAddress("0xdddddddddddddddddddddddddddddddddddddddd");
+const ZERO = getAddress("0x0000000000000000000000000000000000000000");
+
+function offlineRegistry() {
+  const client = {
+    readContract: async ({
+      functionName,
+      args = [],
+    }: {
+      functionName: string;
+      args?: readonly unknown[];
+    }) => {
+      const value = BigInt(String(args[0] ?? 0));
+      if (functionName === "convertToShares") return (value * 9n) / 10n;
+      if (functionName === "convertToAssets") return (value * 10n) / 9n;
+      if (functionName === "balanceOf") return 42n;
+      throw new Error(`unexpected read ${functionName}`);
+    },
+  } as unknown as MossRuntime["client"];
+  return new Registry({ rpcUrl: "http://offline", client }).use(Kintsu);
+}
+
+function eventChange(
+  eventName: "VirtualSharesSnapshot" | "Transfer" | "Deposit",
+  args: Record<string, unknown>,
+): Change {
+  const topics = encodeEventTopics({
+    abi: StakedMonadAbi,
+    eventName,
+    args,
+  } as Parameters<typeof encodeEventTopics>[0]) as readonly Hex[];
+  const data =
+    eventName === "VirtualSharesSnapshot"
+      ? encodeAbiParameters([{ type: "uint256" }], [BigInt(String(args.shares))])
+      : eventName === "Transfer"
+        ? encodeAbiParameters([{ type: "uint256" }], [BigInt(String(args.value))])
+        : encodeAbiParameters(
+            [{ type: "uint256" }, { type: "uint256" }],
+            [BigInt(String(args.shares)), BigInt(String(args.value))],
+          );
+  return { kind: "event", address: KINTSU_SMON_ADDRESS, topics, data };
+}
+
+function successfulChanges(amount = 2n * 10n ** 18n, shares = 18n * 10n ** 17n) {
+  const native = {
+    kind: "nativeTransfer",
+    from: ACCOUNT,
+    to: KINTSU_SMON_ADDRESS,
+    value: amount.toString(),
+  } satisfies Change;
+  const snapshot = eventChange("VirtualSharesSnapshot", { shares: 123n });
+  const transfer = eventChange("Transfer", { from: ZERO, to: RECEIVER, value: shares });
+  const deposit = eventChange("Deposit", { staker: RECEIVER, shares, value: amount });
+  return { native, snapshot, transfer, deposit };
+}
+
+describe("Kintsu", () => {
+  it("loads clear parameter schemas and builds one slippage-protected deposit", async () => {
+    const registry = offlineRegistry();
+    const [loaded] = registry.load([{ protocol: "kintsu", method: "stake" }]);
+    expect(loaded?.params.amount).toMatchObject({
+      description: expect.stringContaining("MON amount"),
+    });
+    expect(loaded?.params.slippageBps).toMatchObject({
+      type: { default: 50, maximum: 5_000 },
+      description: expect.stringContaining("minimum sMON"),
+    });
+
+    const capability = await registry.action("kintsu", "stake", ACCOUNT, {
+      amount: "2",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const [node] = flattenCapabilityTree(capability);
+    if (!node) throw new Error("missing Kintsu transaction");
+    expect(node.transaction).toMatchObject({
+      to: KINTSU_SMON_ADDRESS,
+      value: "0x1bc16d674ec80000",
+    });
+    expect(decodeFunctionData({ abi: StakedMonadAbi, data: node.transaction.data })).toEqual({
+      functionName: "deposit",
+      args: [1_791_000_000_000_000_000n, RECEIVER],
+    });
+  });
+
+  it("exposes share, asset, and balance queries with JSON-safe results", async () => {
+    const registry = offlineRegistry();
+    await expect(
+      registry.action("kintsu", "convertToShares", ACCOUNT, { amount: "2" }),
+    ).resolves.toMatchObject({
+      kind: "query",
+      data: { amount: "2", shares: "1.8" },
+    });
+    await expect(
+      registry.action("kintsu", "convertToAssets", ACCOUNT, { shares: "1.8" }),
+    ).resolves.toMatchObject({
+      kind: "query",
+      data: { shares: "1.8", amount: "2" },
+    });
+    await expect(
+      registry.action("kintsu", "balanceOf", ACCOUNT, { owner: RECEIVER }),
+    ).resolves.toMatchObject({
+      kind: "query",
+      data: { token: KINTSU_SMON_ADDRESS, symbol: "sMON", decimals: 18, balance: "42" },
+    });
+  });
+
+  it("preserves and exhaustively covers ordered stake Changes", async () => {
+    const registry = offlineRegistry();
+    const capability = await registry.action("kintsu", "stake", ACCOUNT, {
+      amount: "2",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const changes = successfulChanges();
+    const ordered = [changes.native, changes.snapshot, changes.transfer, changes.deposit];
+    const receipt = registry.parseReceipt(capability, ordered);
+    expect(receipt.outcome).toEqual({
+      operation: "stake",
+      account: ACCOUNT,
+      receiver: RECEIVER,
+      monAmount: "2000000000000000000",
+      sMonShares: "1800000000000000000",
+    });
+    expect(receipt.changes).toHaveLength(4);
+  });
+
+  it("rejects missing or inconsistent stake evidence", async () => {
+    const registry = offlineRegistry();
+    const capability = await registry.action("kintsu", "stake", ACCOUNT, {
+      amount: "2",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const changes = successfulChanges();
+    expect(() => registry.parseReceipt(capability, [changes.native, changes.deposit])).toThrow(
+      "requires native transfer, sMON mint, and Deposit",
+    );
+    const wrongMint = eventChange("Transfer", { from: ZERO, to: RECEIVER, value: 1n });
+    expect(() =>
+      registry.parseReceipt(capability, [changes.native, wrongMint, changes.deposit]),
+    ).toThrow("sMON mint differs from Deposit");
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Kintsu Monad mainnet", () => {
+  it("has deployed bytecode and expected sMON metadata", { timeout: 60_000 }, async () => {
+    const { client } = await monadRuntime();
+    const [bytecode, symbol, decimals] = await Promise.all([
+      client.getCode({ address: KINTSU_SMON_ADDRESS }),
+      client.readContract({
+        address: KINTSU_SMON_ADDRESS,
+        abi: StakedMonadAbi,
+        functionName: "symbol",
+      }),
+      client.readContract({
+        address: KINTSU_SMON_ADDRESS,
+        abi: StakedMonadAbi,
+        functionName: "decimals",
+      }),
+    ]);
+    expect(bytecode?.length).toBeGreaterThan(2);
+    expect(symbol).toBe("sMON");
+    expect(Number(decimals)).toBe(18);
+  });
+
+  it("simulates staking with zero Warnings and exact Receipt coverage", {
+    timeout: 120_000,
+  }, async () => {
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(Kintsu);
+    const capability = await registry.action("kintsu", "stake", ACCOUNT, {
+      amount: "0.01",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const result = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+    expect(result.halted).toBeUndefined();
+    expect(result.results[0]?.warnings).toEqual([]);
+    expect(result.results[0]?.receipt?.outcome).toMatchObject({
+      operation: "stake",
+      account: ACCOUNT,
+      receiver: ACCOUNT,
+      monAmount: "10000000000000000",
+    });
+  });
+});

--- a/packages/protocols/kintsu/test/types.fixture.ts
+++ b/packages/protocols/kintsu/test/types.fixture.ts
@@ -1,0 +1,75 @@
+import {
+  Capability,
+  type Change,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  PositiveDecimalString,
+  type ProtocolRef,
+  Receipt,
+  type ReceiptResult,
+} from "@themoss/core";
+import type { StakedMonadAbi } from "../src/abis/staked-monad.js";
+import { Kintsu } from "../src/kintsu.js";
+
+const fixtureParams = {
+  amount: { type: PositiveDecimalString, description: "Fixture MON amount." },
+} satisfies ParamsSpec;
+
+const valid: InferParams<typeof fixtureParams> = { amount: "1" };
+// @ts-expect-error Amounts are decimal strings, not numbers.
+const invalid: InferParams<typeof fixtureParams> = { amount: 1 };
+
+const dependency = null as unknown as ProtocolRef<Kintsu>;
+void dependency.stake;
+// @ts-expect-error Injected Protocol references expose methods, not Handles.
+void dependency.stakedMonad;
+
+function handleFixture(handle: Handle<typeof StakedMonadAbi>) {
+  handle.deposit([1n, "0x1111111111111111111111111111111111111111"], { value: 1n });
+  handle.read.convertToShares([1n]);
+  // @ts-expect-error Full ABI typing rejects unknown functions.
+  handle.stake([]);
+  // @ts-expect-error The receiver must be an address.
+  handle.deposit([1n, "not-an-address"]);
+}
+
+class ReceiptNameFixture extends Kintsu {
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "stake",
+    params: fixtureParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+  })
+  async valid(_: InferParams<typeof fixtureParams>) {
+    return [];
+  }
+
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "stake",
+    params: fixtureParams,
+    // @ts-expect-error Receipt names are limited to typed Receipt methods.
+    receipt: "missingReceipt",
+    risk: ["fundOut"],
+  })
+  async invalidReceiptName(_: InferParams<typeof fixtureParams>) {
+    return [];
+  }
+
+  @Receipt()
+  fixtureReceipt(changes: readonly Change[]): ReceiptResult<{ ok: true }> {
+    return {
+      kind: "receipt",
+      outcome: { ok: true },
+      text: "valid",
+      changes: changes.map((change) => ({ kind: "change", change, data: null, text: "change" })),
+    };
+  }
+}
+
+void valid;
+void invalid;
+void handleFixture;
+void ReceiptNameFixture;

--- a/packages/protocols/kintsu/tsconfig.json
+++ b/packages/protocols/kintsu/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/kintsu/vitest.config.ts
+++ b/packages/protocols/kintsu/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@themoss/erc':
         specifier: workspace:*
         version: link:../erc
+      '@themoss/protocol-kintsu':
+        specifier: workspace:*
+        version: link:../protocols/kintsu
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
@@ -173,6 +176,37 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/kintsu:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
       typescript:
         specifier: ~5.9.0
         version: 5.9.3


### PR DESCRIPTION
## What and why

Adds a Kintsu Protocol package so Moss Agents can stake native MON and receive sMON shares on Monad mainnet.

- Builds one `deposit(minShares, receiver)` transaction after reading the current share quote and applying configurable slippage protection (50 bps default).
- Exposes `convertToShares`, `convertToAssets`, and `balanceOf` Queries.
- Parses native MON transfer, sMON mint, Kintsu `Deposit`, and optional `VirtualSharesSnapshot` evidence into one exhaustive typed Receipt.
- Vendors the full official Kintsu 2.2.0 artifact through an offline-reproducible ABI pipeline.
- Adds Kintsu to the MCP CLI composition root and supported-Protocol documentation.

Kintsu's asynchronous `requestUnlock` / `redeem` flow is intentionally outside this focused first PR.

Closes #94.

## Type of change

- [x] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [x] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

No core or simulator contract changes. Adds `@themoss/protocol-kintsu`, declares its ERC-20 Protocol dependency, and adds the package module only to the explicit MCP CLI composition root. The `stake` Capability owns exactly one direct transaction and one typed Receipt.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

### Protocol changes

- [x] Parameters separate reusable Zod value types from field-purpose descriptions
- [x] Every Capability owns one direct TransactionNode and one typed Receipt
- [x] Receipt tests preserve every original Change object in exact length and order
- [x] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [x] Fixed addresses and ABIs include sources and verification
- [x] A live Monad happy path returns zero Warnings

## Evidence

- Full repository `pnpm test` passes, including all Kintsu, WMON, and Kuru Monad-mainnet E2E tests.
- Kintsu tests: 7/7 pass, including deployed proxy bytecode, sMON symbol/decimals, and a live unsigned `stake` simulation with zero Warnings.
- ABI provenance test enforces byte-for-byte regeneration from the full artifact vendored from `@water-cooler-studios/monad-contracts-core@2.2.0` (tarball SHA-256 `ff5532ff6daabc7d1bec798aa18485df3aa28ff6c6a67bb946ec2dae8f8688da`).
