### PR TITLE
feat: add x402 quantum optimization service adapter

### DIFF
--- a/examples/x402-qopt/README.md
+++ b/examples/x402-qopt/README.md
@@ -1,0 +1,26 @@
+# x402 QOpt Example
+
+## Start the server
+
+```bash
+pnpm --filter @themoss/example-x402-qopt server
+```
+
+## Run the client
+
+```bash
+pnpm --filter @themoss/example-x402-qopt client
+```
+
+## Expected flow
+
+1. Client sends QUBO request.
+2. Server returns HTTP 402.
+3. Adapter validates payment requirements.
+4. Demo supplies an external mock signature.
+5. Server returns optimization result.
+6. Adapter parses settlement metadata.
+
+## Warning
+
+This example uses no production funds and does not settle a real blockchain payment.

--- a/examples/x402-qopt/package.json
+++ b/examples/x402-qopt/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@themoss/example-x402-qopt",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "server": "tsx src/server.ts",
+    "client": "tsx src/client.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "echo \"examples are exercised by package tests\" && exit 0",
+    "build": "echo \"examples are not built\" && exit 0"
+  },
+  "dependencies": {
+    "@themoss/x402-qopt-adapter": "workspace:*",
+    "express": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "tsx": "^4.20.0",
+    "typescript": "~5.9.0"
+  }
+}

--- a/examples/x402-qopt/src/client.ts
+++ b/examples/x402-qopt/src/client.ts
@@ -1,0 +1,29 @@
+import { QOptX402Adapter } from "@themoss/x402-qopt-adapter";
+
+const endpoint = "http://localhost:4021/optimize/qubo";
+
+const problem = {
+  matrix: [
+    [1, -2, 0],
+    [-2, 4, -1],
+    [0, -1, 2],
+  ],
+};
+
+const adapter = new QOptX402Adapter();
+
+const quote = await adapter.quote(endpoint, problem, {
+  maxAmount: 2000n,
+  expectedNetwork: "eip155:143",
+  expectedAsset: "0x0000000000000000000000000000000000000002",
+  expectedPayTo: "0x0000000000000000000000000000000000000003",
+  expectedResource: endpoint,
+});
+
+console.log("Verified payment quote:");
+console.log(quote);
+
+const response = await adapter.submitPaid(endpoint, problem, quote, "demo-payment-signature");
+
+console.log("Optimization result:");
+console.log(response);

--- a/examples/x402-qopt/src/server.ts
+++ b/examples/x402-qopt/src/server.ts
@@ -1,0 +1,131 @@
+import { createHash, randomUUID } from "node:crypto";
+import { encodeBase64Json, validateQuboProblem } from "@themoss/x402-qopt-adapter";
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+const PORT = 4021;
+const PRICE = "1000";
+const NETWORK = "eip155:143";
+const ASSET = "0x0000000000000000000000000000000000000002";
+const PAY_TO = "0x0000000000000000000000000000000000000003";
+const RESOURCE = `http://localhost:${PORT}/optimize/qubo`;
+
+function evaluate(matrix: number[][], solution: number[]): number {
+  let total = 0;
+
+  for (let i = 0; i < matrix.length; i += 1) {
+    const left = solution[i];
+    const row = matrix[i];
+
+    if (left === undefined || row === undefined) {
+      throw new Error("Invalid QUBO matrix or solution shape");
+    }
+
+    for (let j = 0; j < matrix.length; j += 1) {
+      const coefficient = row[j];
+      const right = solution[j];
+
+      if (coefficient === undefined || right === undefined) {
+        throw new Error("Invalid QUBO matrix or solution shape");
+      }
+
+      total += left * coefficient * right;
+    }
+  }
+
+  return total;
+}
+
+function solveReference(matrix: number[][]) {
+  const size = matrix.length;
+  const combinations = 2 ** size;
+
+  let bestSolution: number[] = [];
+  let bestValue = Number.POSITIVE_INFINITY;
+
+  for (let mask = 0; mask < combinations; mask += 1) {
+    const solution = Array.from({ length: size }, (_, index) => (mask >> index) & 1);
+    const value = evaluate(matrix, solution);
+
+    if (value < bestValue) {
+      bestValue = value;
+      bestSolution = solution;
+    }
+  }
+
+  return {
+    solution: bestSolution,
+    objectiveValue: bestValue,
+  };
+}
+
+app.post("/optimize/qubo", (request, response) => {
+  const problem = validateQuboProblem(request.body.problem);
+  const paymentSignature = request.header("PAYMENT-SIGNATURE");
+
+  if (!paymentSignature) {
+    const paymentRequired = {
+      x402Version: 2,
+      resource: {
+        url: RESOURCE,
+        description: "Pay-per-solve QUBO optimization",
+        mimeType: "application/json",
+      },
+      accepts: [
+        {
+          scheme: "exact",
+          network: NETWORK,
+          amount: PRICE,
+          asset: ASSET,
+          payTo: PAY_TO,
+          resource: RESOURCE,
+        },
+      ],
+    };
+
+    response.status(402).set("PAYMENT-REQUIRED", encodeBase64Json(paymentRequired)).json({
+      error: "Payment required",
+    });
+    return;
+  }
+
+  // Offline demonstration only:
+  // this does not verify or settle a real blockchain payment.
+  if (paymentSignature !== "demo-payment-signature") {
+    response.status(402).json({
+      error: "Invalid demonstration payment signature",
+    });
+    return;
+  }
+
+  const reference = solveReference(problem.matrix);
+  const problemHash = createHash("sha256").update(JSON.stringify(problem)).digest("hex");
+
+  response
+    .status(200)
+    .set(
+      "PAYMENT-RESPONSE",
+      encodeBase64Json({
+        success: true,
+        transaction: "offline-demo",
+        network: NETWORK,
+        problemHash,
+      }),
+    )
+    .json({
+      jobId: randomUUID(),
+      status: "completed",
+      solution: reference.solution,
+      objectiveValue: reference.objectiveValue,
+      classicalObjective: reference.objectiveValue,
+      optimalityGap: 0,
+      backend: "offline-qopt-demo",
+      backendType: "mock-quantum-simulator",
+    });
+});
+
+app.listen(PORT, () => {
+  console.log(`QOpt x402 demonstration server: http://localhost:${PORT}`);
+});

--- a/examples/x402-qopt/tsconfig.json
+++ b/examples/x402-qopt/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/x402-qopt-adapter/README.md
+++ b/packages/x402-qopt-adapter/README.md
@@ -1,0 +1,75 @@
+# QOpt x402 Adapter
+
+## Purpose
+
+`@themoss/x402-qopt-adapter` adds a service-level adapter for QUBO optimization APIs protected by x402 payments. It validates payment requirements before a paid request is retried.
+
+## Architecture
+
+This package is an HTTP adapter, not a Moss on-chain Protocol package. It handles x402 headers, policy checks, and result parsing without creating Monad `TransactionNode` objects.
+
+## Supported x402 version
+
+- x402 V2 only
+- Required headers:
+	- `PAYMENT-REQUIRED`
+	- `PAYMENT-SIGNATURE`
+	- `PAYMENT-RESPONSE`
+
+## Supported payment scheme
+
+- `exact` only
+
+## Adapter workflow
+
+1. `quote()` sends a QUBO request and expects HTTP 402.
+2. Adapter decodes `PAYMENT-REQUIRED` and selects an `exact` requirement.
+3. Adapter validates budget, network, asset, recipient, and optional resource.
+4. Caller obtains an external `PAYMENT-SIGNATURE`.
+5. `submitPaid()` retries request with signature and parses result + settlement metadata.
+
+## Payment-policy validation
+
+`validatePaymentPolicy()` enforces:
+
+- `maxAmount` upper bound
+- exact network match
+- exact asset match (case-insensitive)
+- optional recipient match
+- optional resource URL match
+
+## Quantum provenance
+
+Results include:
+
+- `backend`
+- `backendType`
+- `classicalObjective`
+- `optimalityGap`
+
+This keeps solver provenance explicit and avoids overstating quantum execution.
+
+## Security boundaries
+
+- Adapter never accepts or stores private keys.
+- Adapter never creates blockchain signatures.
+- Adapter never broadcasts or settles payments.
+- Signature generation is an external wallet/client boundary.
+
+## Offline demonstration
+
+See [examples/x402-qopt](../../examples/x402-qopt/README.md) for a local mock flow using `demo-payment-signature`.
+
+## Limitations
+
+- No support for x402 V1.
+- No support for non-`exact` schemes.
+- Demo settlement metadata is mock data.
+- Demo backend is `mock-quantum-simulator`, not a physical QPU.
+
+## Future work
+
+- Integrate official x402 client SDK for wallet-facing flows.
+- Add facilitator/testnet integration.
+- Add additional optimization problem formats.
+- Add richer payment receipt verification policies.

--- a/packages/x402-qopt-adapter/package.json
+++ b/packages/x402-qopt-adapter/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@themoss/x402-qopt-adapter",
+  "version": "0.0.0",
+  "private": true,
+  "description": "x402 service adapter for pay-per-solve QUBO optimization APIs",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/x402-qopt-adapter/src/adapter.ts
+++ b/packages/x402-qopt-adapter/src/adapter.ts
@@ -1,0 +1,103 @@
+import { hashQuboProblem } from "./hash.js";
+import { decodePaymentRequired, decodePaymentResponse } from "./headers.js";
+import { validatePaymentPolicy } from "./policy.js";
+import { validateQuboProblem } from "./qubo.js";
+import { selectExactRequirement } from "./requirements.js";
+import {
+  type PaidQOptResponse,
+  type PaymentPolicy,
+  type PaymentQuote,
+  paymentPolicySchema,
+  type QuboProblem,
+  qoptResultSchema,
+} from "./types.js";
+
+export class QOptX402Adapter {
+  constructor(private readonly fetchImpl: typeof fetch = fetch) {}
+
+  async quote(
+    endpoint: string,
+    problemInput: unknown,
+    policyInput: PaymentPolicy,
+  ): Promise<PaymentQuote> {
+    const problem = validateQuboProblem(problemInput);
+    const policy = paymentPolicySchema.parse(policyInput);
+    const problemHash = hashQuboProblem(problem);
+
+    const response = await this.fetchImpl(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        problem,
+        problemHash,
+      }),
+    });
+
+    if (response.status !== 402) {
+      throw new Error(`Expected HTTP 402, received ${response.status}`);
+    }
+
+    const header = response.headers.get("PAYMENT-REQUIRED");
+
+    if (!header) {
+      throw new Error("HTTP 402 response is missing PAYMENT-REQUIRED");
+    }
+
+    const decoded = decodePaymentRequired(header);
+    const requirement = selectExactRequirement(decoded);
+
+    validatePaymentPolicy(requirement, policy);
+
+    return {
+      requirement,
+      problemHash,
+      rawPaymentRequired: header,
+    };
+  }
+
+  async submitPaid(
+    endpoint: string,
+    problemInput: QuboProblem,
+    quote: PaymentQuote,
+    paymentSignature: string,
+  ): Promise<PaidQOptResponse> {
+    if (!paymentSignature.trim()) {
+      throw new Error("PAYMENT-SIGNATURE is required");
+    }
+
+    const problem = validateQuboProblem(problemInput);
+    const currentHash = hashQuboProblem(problem);
+
+    if (currentHash !== quote.problemHash) {
+      throw new Error("QUBO problem does not match the quoted problem hash");
+    }
+
+    const response = await this.fetchImpl(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "PAYMENT-SIGNATURE": paymentSignature,
+      },
+      body: JSON.stringify({
+        problem,
+        problemHash: currentHash,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Paid request failed with HTTP ${response.status}`);
+    }
+
+    const result = qoptResultSchema.parse(await response.json());
+    const paymentResponseHeader = response.headers.get("PAYMENT-RESPONSE");
+
+    return {
+      result,
+      paymentResponse: paymentResponseHeader
+        ? decodePaymentResponse(paymentResponseHeader)
+        : undefined,
+    };
+  }
+}

--- a/packages/x402-qopt-adapter/src/hash.ts
+++ b/packages/x402-qopt-adapter/src/hash.ts
@@ -1,0 +1,7 @@
+import { createHash } from "node:crypto";
+
+import type { QuboProblem } from "./types.js";
+
+export function hashQuboProblem(problem: QuboProblem): string {
+  return createHash("sha256").update(JSON.stringify(problem)).digest("hex");
+}

--- a/packages/x402-qopt-adapter/src/headers.ts
+++ b/packages/x402-qopt-adapter/src/headers.ts
@@ -1,0 +1,20 @@
+function decodeBase64Json(value: string): unknown {
+  try {
+    const decoded = Buffer.from(value, "base64").toString("utf8");
+    return JSON.parse(decoded);
+  } catch {
+    throw new Error("Invalid Base64-encoded x402 JSON header");
+  }
+}
+
+export function encodeBase64Json(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+
+export function decodePaymentRequired(value: string): unknown {
+  return decodeBase64Json(value);
+}
+
+export function decodePaymentResponse(value: string): unknown {
+  return decodeBase64Json(value);
+}

--- a/packages/x402-qopt-adapter/src/index.ts
+++ b/packages/x402-qopt-adapter/src/index.ts
@@ -1,0 +1,24 @@
+export { QOptX402Adapter } from "./adapter.js";
+export { hashQuboProblem } from "./hash.js";
+export {
+  decodePaymentRequired,
+  decodePaymentResponse,
+  encodeBase64Json,
+} from "./headers.js";
+export { validatePaymentPolicy } from "./policy.js";
+export { validateQuboProblem } from "./qubo.js";
+export { selectExactRequirement } from "./requirements.js";
+export type {
+  PaidQOptResponse,
+  PaymentPolicy,
+  PaymentQuote,
+  PaymentRequirement,
+  QOptResult,
+  QuboProblem,
+} from "./types.js";
+export {
+  paymentPolicySchema,
+  paymentRequirementSchema,
+  qoptResultSchema,
+  quboProblemSchema,
+} from "./types.js";

--- a/packages/x402-qopt-adapter/src/policy.ts
+++ b/packages/x402-qopt-adapter/src/policy.ts
@@ -1,0 +1,41 @@
+import type { PaymentPolicy, PaymentRequirement } from "./types.js";
+
+function normalizeAddress(value: string): string {
+  return value.toLowerCase();
+}
+
+export function validatePaymentPolicy(
+  requirement: PaymentRequirement,
+  policy: PaymentPolicy,
+): void {
+  let amount: bigint;
+
+  try {
+    amount = BigInt(requirement.amount);
+  } catch {
+    throw new Error("Payment amount is not an integer string");
+  }
+
+  if (amount > policy.maxAmount) {
+    throw new Error(`Payment exceeds approved budget: ${amount} > ${policy.maxAmount}`);
+  }
+
+  if (requirement.network !== policy.expectedNetwork) {
+    throw new Error(`Unexpected network: ${requirement.network}`);
+  }
+
+  if (normalizeAddress(requirement.asset) !== normalizeAddress(policy.expectedAsset)) {
+    throw new Error(`Unexpected payment asset: ${requirement.asset}`);
+  }
+
+  if (
+    policy.expectedPayTo &&
+    normalizeAddress(requirement.payTo) !== normalizeAddress(policy.expectedPayTo)
+  ) {
+    throw new Error(`Unexpected payment recipient: ${requirement.payTo}`);
+  }
+
+  if (policy.expectedResource && requirement.resource !== policy.expectedResource) {
+    throw new Error(`Unexpected paid resource: ${requirement.resource}`);
+  }
+}

--- a/packages/x402-qopt-adapter/src/qubo.ts
+++ b/packages/x402-qopt-adapter/src/qubo.ts
@@ -1,0 +1,14 @@
+import { type QuboProblem, quboProblemSchema } from "./types.js";
+
+export function validateQuboProblem(input: unknown): QuboProblem {
+  const problem = quboProblemSchema.parse(input);
+  const size = problem.matrix.length;
+
+  for (const row of problem.matrix) {
+    if (row.length !== size) {
+      throw new Error("QUBO matrix must be square");
+    }
+  }
+
+  return problem;
+}

--- a/packages/x402-qopt-adapter/src/requirements.ts
+++ b/packages/x402-qopt-adapter/src/requirements.ts
@@ -1,0 +1,42 @@
+import { type PaymentRequirement, paymentRequirementSchema } from "./types.js";
+
+type PaymentRequiredEnvelope = {
+  x402Version?: number;
+  accepts?: unknown[];
+  resource?: {
+    url?: string;
+    description?: string;
+    mimeType?: string;
+  };
+};
+
+export function selectExactRequirement(decoded: unknown): PaymentRequirement {
+  if (!decoded || typeof decoded !== "object") {
+    throw new Error("Invalid PAYMENT-REQUIRED object");
+  }
+
+  const envelope = decoded as PaymentRequiredEnvelope;
+
+  if (envelope.x402Version !== 2) {
+    throw new Error("Only x402 V2 is supported");
+  }
+
+  if (!Array.isArray(envelope.accepts)) {
+    throw new Error("PAYMENT-REQUIRED has no accepts array");
+  }
+
+  const exact = envelope.accepts.find((item) => {
+    return (
+      item !== null && typeof item === "object" && (item as { scheme?: unknown }).scheme === "exact"
+    );
+  });
+
+  if (!exact) {
+    throw new Error("No supported exact payment requirement");
+  }
+
+  return paymentRequirementSchema.parse({
+    ...(exact as Record<string, unknown>),
+    resource: (exact as { resource?: string }).resource ?? envelope.resource?.url,
+  });
+}

--- a/packages/x402-qopt-adapter/src/types.ts
+++ b/packages/x402-qopt-adapter/src/types.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+export const quboProblemSchema = z.object({
+  matrix: z.array(z.array(z.number().finite())).min(1).max(16),
+});
+
+export type QuboProblem = z.infer<typeof quboProblemSchema>;
+
+export const paymentPolicySchema = z.object({
+  maxAmount: z.bigint().nonnegative(),
+  expectedNetwork: z.string().min(1),
+  expectedAsset: z.string().min(1),
+  expectedPayTo: z.string().optional(),
+  expectedResource: z.string().optional(),
+});
+
+export type PaymentPolicy = z.infer<typeof paymentPolicySchema>;
+
+export const paymentRequirementSchema = z.object({
+  scheme: z.string(),
+  network: z.string(),
+  amount: z.string(),
+  asset: z.string(),
+  payTo: z.string(),
+  resource: z.string().optional(),
+  maxTimeoutSeconds: z.number().int().positive().optional(),
+  extra: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type PaymentRequirement = z.infer<typeof paymentRequirementSchema>;
+
+export const qoptResultSchema = z.object({
+  jobId: z.string(),
+  status: z.enum(["completed", "failed"]),
+  solution: z.array(z.union([z.literal(0), z.literal(1)])),
+  objectiveValue: z.number(),
+  classicalObjective: z.number(),
+  optimalityGap: z.number(),
+  backend: z.string(),
+  backendType: z.enum([
+    "mock-quantum-simulator",
+    "local-quantum-simulator",
+    "remote-quantum-simulator",
+    "physical-qpu",
+    "hybrid-quantum-classical",
+  ]),
+});
+
+export type QOptResult = z.infer<typeof qoptResultSchema>;
+
+export interface PaymentQuote {
+  requirement: PaymentRequirement;
+  problemHash: string;
+  rawPaymentRequired: string;
+}
+
+export interface PaidQOptResponse {
+  result: QOptResult;
+  paymentResponse?: unknown;
+}

--- a/packages/x402-qopt-adapter/test/adapter.test.ts
+++ b/packages/x402-qopt-adapter/test/adapter.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { QOptX402Adapter } from "../src/adapter.js";
+import { encodeBase64Json } from "../src/headers.js";
+import type { PaymentPolicy } from "../src/types.js";
+
+const endpoint = "http://localhost:4021/optimize/qubo";
+const problem = {
+  matrix: [
+    [1, -2],
+    [-2, 4],
+  ],
+};
+
+const policy: PaymentPolicy = {
+  maxAmount: 2000n,
+  expectedNetwork: "eip155:143",
+  expectedAsset: "0x0000000000000000000000000000000000000002",
+  expectedPayTo: "0x0000000000000000000000000000000000000003",
+  expectedResource: endpoint,
+};
+
+function makeJsonResponse(
+  status: number,
+  body: unknown,
+  headers?: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      ...(headers ?? {}),
+    },
+  });
+}
+
+describe("QOptX402Adapter", () => {
+  it("rejects non-402 quote responses", async () => {
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(makeJsonResponse(200, { ok: true }));
+    const adapter = new QOptX402Adapter(mockFetch);
+
+    await expect(adapter.quote(endpoint, problem, policy)).rejects.toThrow("Expected HTTP 402");
+  });
+
+  it("rejects 402 without PAYMENT-REQUIRED header", async () => {
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(makeJsonResponse(402, { error: "required" }));
+    const adapter = new QOptX402Adapter(mockFetch);
+
+    await expect(adapter.quote(endpoint, problem, policy)).rejects.toThrow(
+      "missing PAYMENT-REQUIRED",
+    );
+  });
+
+  it("rejects unsupported x402 version", async () => {
+    const paymentRequired = encodeBase64Json({
+      x402Version: 1,
+      accepts: [
+        {
+          scheme: "exact",
+          network: policy.expectedNetwork,
+          amount: "1000",
+          asset: policy.expectedAsset,
+          payTo: policy.expectedPayTo,
+          resource: endpoint,
+        },
+      ],
+    });
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      makeJsonResponse(
+        402,
+        { error: "required" },
+        {
+          "PAYMENT-REQUIRED": paymentRequired,
+        },
+      ),
+    );
+    const adapter = new QOptX402Adapter(mockFetch);
+
+    await expect(adapter.quote(endpoint, problem, policy)).rejects.toThrow(
+      "Only x402 V2 is supported",
+    );
+  });
+
+  it("rejects non-exact payment schemes", async () => {
+    const paymentRequired = encodeBase64Json({
+      x402Version: 2,
+      accepts: [
+        {
+          scheme: "something-else",
+        },
+      ],
+    });
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      makeJsonResponse(
+        402,
+        { error: "required" },
+        {
+          "PAYMENT-REQUIRED": paymentRequired,
+        },
+      ),
+    );
+    const adapter = new QOptX402Adapter(mockFetch);
+
+    await expect(adapter.quote(endpoint, problem, policy)).rejects.toThrow(
+      "No supported exact payment requirement",
+    );
+  });
+
+  it("rejects changed problem between quote and submit", async () => {
+    const paymentRequired = encodeBase64Json({
+      x402Version: 2,
+      accepts: [
+        {
+          scheme: "exact",
+          network: policy.expectedNetwork,
+          amount: "1000",
+          asset: policy.expectedAsset,
+          payTo: policy.expectedPayTo,
+          resource: endpoint,
+        },
+      ],
+    });
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      makeJsonResponse(
+        402,
+        { error: "required" },
+        {
+          "PAYMENT-REQUIRED": paymentRequired,
+        },
+      ),
+    );
+    const adapter = new QOptX402Adapter(mockFetch);
+    const quote = await adapter.quote(endpoint, problem, policy);
+
+    await expect(
+      adapter.submitPaid(
+        endpoint,
+        {
+          matrix: [
+            [1, -2],
+            [-2, 5],
+          ],
+        },
+        quote,
+        "demo-payment-signature",
+      ),
+    ).rejects.toThrow("does not match the quoted problem hash");
+  });
+
+  it("rejects empty PAYMENT-SIGNATURE", async () => {
+    const paymentRequired = encodeBase64Json({
+      x402Version: 2,
+      accepts: [
+        {
+          scheme: "exact",
+          network: policy.expectedNetwork,
+          amount: "1000",
+          asset: policy.expectedAsset,
+          payTo: policy.expectedPayTo,
+          resource: endpoint,
+        },
+      ],
+    });
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      makeJsonResponse(
+        402,
+        { error: "required" },
+        {
+          "PAYMENT-REQUIRED": paymentRequired,
+        },
+      ),
+    );
+    const adapter = new QOptX402Adapter(mockFetch);
+    const quote = await adapter.quote(endpoint, problem, policy);
+
+    await expect(adapter.submitPaid(endpoint, problem, quote, "   ")).rejects.toThrow(
+      "PAYMENT-SIGNATURE is required",
+    );
+  });
+
+  it("parses optimization result and payment response", async () => {
+    const paymentRequired = encodeBase64Json({
+      x402Version: 2,
+      accepts: [
+        {
+          scheme: "exact",
+          network: policy.expectedNetwork,
+          amount: "1000",
+          asset: policy.expectedAsset,
+          payTo: policy.expectedPayTo,
+          resource: endpoint,
+        },
+      ],
+    });
+    const paymentResponse = encodeBase64Json({
+      success: true,
+      transaction: "offline-demo",
+      network: policy.expectedNetwork,
+    });
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        makeJsonResponse(
+          402,
+          { error: "required" },
+          {
+            "PAYMENT-REQUIRED": paymentRequired,
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        makeJsonResponse(
+          200,
+          {
+            jobId: "job-1",
+            status: "completed",
+            solution: [1, 0],
+            objectiveValue: -2,
+            classicalObjective: -2,
+            optimalityGap: 0,
+            backend: "offline-qopt-demo",
+            backendType: "mock-quantum-simulator",
+          },
+          {
+            "PAYMENT-RESPONSE": paymentResponse,
+          },
+        ),
+      );
+    const adapter = new QOptX402Adapter(mockFetch);
+    const quote = await adapter.quote(endpoint, problem, policy);
+    const paid = await adapter.submitPaid(endpoint, problem, quote, "demo-payment-signature");
+
+    expect(paid.result.status).toBe("completed");
+    expect(paid.result.backendType).toBe("mock-quantum-simulator");
+    expect(paid.paymentResponse).toEqual({
+      success: true,
+      transaction: "offline-demo",
+      network: policy.expectedNetwork,
+    });
+  });
+});

--- a/packages/x402-qopt-adapter/test/headers.test.ts
+++ b/packages/x402-qopt-adapter/test/headers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { decodePaymentRequired, decodePaymentResponse, encodeBase64Json } from "../src/headers.js";
+
+describe("headers", () => {
+  it("encodes and decodes valid base64 json", () => {
+    const encoded = encodeBase64Json({ hello: "world", count: 1 });
+    const decoded = decodePaymentRequired(encoded);
+
+    expect(decoded).toEqual({ hello: "world", count: 1 });
+  });
+
+  it("rejects invalid base64 payload", () => {
+    expect(() => decodePaymentRequired("%%%not-base64%%%")).toThrow(
+      "Invalid Base64-encoded x402 JSON header",
+    );
+  });
+
+  it("rejects invalid json payload", () => {
+    const invalidJson = Buffer.from("not-json", "utf8").toString("base64");
+
+    expect(() => decodePaymentRequired(invalidJson)).toThrow(
+      "Invalid Base64-encoded x402 JSON header",
+    );
+  });
+
+  it("parses payment response header", () => {
+    const encoded = encodeBase64Json({ success: true, tx: "0xabc" });
+
+    expect(decodePaymentResponse(encoded)).toEqual({
+      success: true,
+      tx: "0xabc",
+    });
+  });
+});

--- a/packages/x402-qopt-adapter/test/policy.test.ts
+++ b/packages/x402-qopt-adapter/test/policy.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePaymentPolicy } from "../src/policy.js";
+import type { PaymentPolicy, PaymentRequirement } from "../src/types.js";
+
+const requirement: PaymentRequirement = {
+  scheme: "exact",
+  network: "eip155:143",
+  amount: "1000",
+  asset: "0x0000000000000000000000000000000000000002",
+  payTo: "0x0000000000000000000000000000000000000003",
+  resource: "http://localhost:4021/optimize/qubo",
+};
+
+const policy: PaymentPolicy = {
+  maxAmount: 1000n,
+  expectedNetwork: "eip155:143",
+  expectedAsset: "0x0000000000000000000000000000000000000002",
+  expectedPayTo: "0x0000000000000000000000000000000000000003",
+  expectedResource: "http://localhost:4021/optimize/qubo",
+};
+
+describe("validatePaymentPolicy", () => {
+  it("accepts amount below budget", () => {
+    validatePaymentPolicy({ ...requirement, amount: "999" }, policy);
+  });
+
+  it("accepts amount equal to budget", () => {
+    validatePaymentPolicy(requirement, policy);
+  });
+
+  it("rejects amount above budget", () => {
+    expect(() => validatePaymentPolicy({ ...requirement, amount: "1001" }, policy)).toThrow(
+      "Payment exceeds approved budget",
+    );
+  });
+
+  it("rejects network mismatch", () => {
+    expect(() => validatePaymentPolicy({ ...requirement, network: "eip155:1" }, policy)).toThrow(
+      "Unexpected network",
+    );
+  });
+
+  it("rejects asset mismatch", () => {
+    expect(() =>
+      validatePaymentPolicy(
+        {
+          ...requirement,
+          asset: "0x0000000000000000000000000000000000000009",
+        },
+        policy,
+      ),
+    ).toThrow("Unexpected payment asset");
+  });
+
+  it("rejects recipient mismatch", () => {
+    expect(() =>
+      validatePaymentPolicy(
+        {
+          ...requirement,
+          payTo: "0x0000000000000000000000000000000000000010",
+        },
+        policy,
+      ),
+    ).toThrow("Unexpected payment recipient");
+  });
+
+  it("rejects resource mismatch", () => {
+    expect(() =>
+      validatePaymentPolicy(
+        {
+          ...requirement,
+          resource: "http://localhost:4021/other",
+        },
+        policy,
+      ),
+    ).toThrow("Unexpected paid resource");
+  });
+});

--- a/packages/x402-qopt-adapter/tsconfig.json
+++ b/packages/x402-qopt-adapter/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,25 @@ importers:
         specifier: ~5.9.0
         version: 5.9.3
 
+  examples/x402-qopt:
+    dependencies:
+      '@themoss/x402-qopt-adapter':
+        specifier: workspace:*
+        version: link:../../packages/x402-qopt-adapter
+      express:
+        specifier: ^5.0.0
+        version: 5.2.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      tsx:
+        specifier: ^4.20.0
+        version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+
   packages/core:
     dependencies:
       viem:
@@ -245,6 +264,22 @@ importers:
       '@themoss/simulator':
         specifier: workspace:*
         version: link:../simulator
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/x402-qopt-adapter:
+    dependencies:
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
+    devDependencies:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
@@ -1059,8 +1094,14 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1068,11 +1109,32 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@5.1.2':
+    resolution: {integrity: sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
   '@types/node@22.20.0':
     resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
@@ -2742,20 +2804,57 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.20.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.20.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@5.1.2':
+    dependencies:
+      '@types/node': 22.20.0
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.2
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/node@12.20.55': {}
 
   '@types/node@22.20.0':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.20.0
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.20.0
 
   '@vitest/expect@3.2.6':
     dependencies:


### PR DESCRIPTION
## What and why

This PR adds a service adapter for x402-protected quantum and hybrid optimization APIs.

The adapter allows an application or Agent to request a QUBO optimization service, parse HTTP 402 payment requirements, validate the payment against an explicit user policy, accept an externally created payment signature, and parse a structured optimization result.

## Adapter

`@themoss/x402-qopt-adapter`

## Scope

- x402 V2 `PAYMENT-REQUIRED`, `PAYMENT-SIGNATURE`, and `PAYMENT-RESPONSE`
- `exact` payment requirements
- budget, network, asset, recipient, and resource checks
- QUBO input validation and problem hashing
- structured solver provenance and classical benchmark
- offline runnable example with mock settlement

## Architecture boundary

This is implemented as a service adapter rather than a Moss `@Protocol` package because it handles HTTP resource payment rather than constructing a Monad contract `TransactionNode`.

It does not change Moss's existing MCP tool surface.

## Security

- no private key is accepted or stored
- no payment is signed by the adapter
- no transaction is broadcast by the adapter
- the example uses a mock signature and no production funds
- the example does not claim to use a physical QPU

## Verification

- [x] Adapter unit tests
- [x] Offline example
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:offline`

## Future work

- official x402 client integration
- testnet facilitator integration
- real quantum-service provider
- additional optimization problem types
- MCP application composition after architecture review