### PR TITLE
test(simulator): cover chained transaction state

### DIFF
--- a/.changeset/pin-simulation-block.md
+++ b/.changeset/pin-simulation-block.md
@@ -1,0 +1,7 @@
+---
+"@themoss/simulator": patch
+---
+
+Pin one base block per simulate run so per-transaction Change evidence, state
+chaining, and gas estimates cannot straddle a block boundary between separate
+RPC calls.

--- a/docs/adr/0002-simulation-via-debug-tracecall.md
+++ b/docs/adr/0002-simulation-via-debug-tracecall.md
@@ -22,6 +22,16 @@ Monad retains logs inside a failed child frame even though the frame reports `er
 ## Consequences
 
 - The default RPC endpoint is `rpc.monad.xyz` (full support, no key).
+- Every simulate run resolves `eth_blockNumber` once and pins that block on
+  all `debug_traceCall` and `eth_estimateGas` requests in the run. The
+  evidence trace and the prestate diff for one transaction are separate RPC
+  calls; against `latest` they could straddle a new block and compute on
+  different base states. Verified 2026-07-20 on `rpc.monad.xyz`:
+  `debug_traceCall` accepts an explicit block number together with
+  `stateOverrides`. If the base block cannot be resolved, simulation halts
+  before the first trace. Re-verified the same day that `eth_simulateV1`,
+  `debug_traceCallMany`, `trace_callMany`, and `eth_callMany` all remain
+  unavailable (`-32601`) on `rpc.monad.xyz` and `rpc-mainnet.monadinfra.com`.
 - Monad's `debug_traceCall` **enforces sender balance** (discovered 2026-07-07: a 2-MON transfer from an underfunded address is rejected with `insufficient balance`, unlike geth's default). The simulator therefore pre-funds the transaction sender via a balance override — matching `eth_simulateV1`'s validation-off semantics. Simulation answers "what would this transaction do", not "can the account afford it"; affordability is the wallet's question at signing time.
 - When `debug_traceCall` is unavailable or cannot supply provably ordered Change evidence, simulate fails loudly — it never silently skips evidence or falls back to an approximate ordering.
 - Exact ordering is reconstructed in one recursive pass over call-frame `position` data; protocol ABI semantics enter only in the Receipt parser.

--- a/packages/simulator/src/index.ts
+++ b/packages/simulator/src/index.ts
@@ -2,6 +2,7 @@ import {
   type CapabilityNode,
   type Change,
   flattenCapabilityTree,
+  type Hex,
   type MossRuntime,
   type Receipt,
   ReceiptCoverageError,
@@ -14,6 +15,7 @@ import {
   type CallFrame,
   DEFAULT_SIMULATION_GAS,
   estimateGasWithOverrides,
+  resolveSimulationBlock,
   SimulatorUnavailableError,
   type StateOverrides,
   type TraceCall,
@@ -76,13 +78,41 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
       const overrides: StateOverrides = {};
       const results: TransactionSimulation[] = [];
 
+      // Pin one base block for the whole run so per-transaction evidence and
+      // state chaining cannot straddle a block boundary (ADR 0002).
+      let block: Hex;
+      try {
+        block = await resolveSimulationBlock(runtime.client);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        const first = executable[0];
+        if (first) {
+          results.push({
+            protocol: first.capability.protocol,
+            method: first.capability.method,
+            transaction: first.transaction,
+            reverted: false,
+            warnings: [{ code: "TRACE_FAILED", message: reason }],
+            gas: null,
+          });
+        }
+        return { results, halted: { transactionIndex: 0, reason } };
+      }
+
       for (const [transactionIndex, { capability, transaction }] of executable.entries()) {
         const sender = transaction.from.toLowerCase() as keyof StateOverrides;
         overrides[sender] = { balance: prefund, ...overrides[sender] };
         const call: TraceCall = transaction;
         let frame: CallFrame;
         try {
-          frame = await traceWithCalls(runtime.client, runtime.rpcUrl, call, overrides, gasBudget);
+          frame = await traceWithCalls(
+            runtime.client,
+            runtime.rpcUrl,
+            call,
+            block,
+            overrides,
+            gasBudget,
+          );
         } catch (error) {
           const reason = error instanceof Error ? error.message : String(error);
           results.push({
@@ -156,13 +186,14 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
           return { results, halted: { transactionIndex, reason } };
         }
 
-        const gas = await estimateGasWithOverrides(runtime.client, call, overrides);
+        const gas = await estimateGasWithOverrides(runtime.client, call, block, overrides);
         if (transactionIndex < executable.length - 1) {
           try {
             const diff = await traceWithDiff(
               runtime.client,
               runtime.rpcUrl,
               call,
+              block,
               overrides,
               gasBudget,
             );

--- a/packages/simulator/src/trace.ts
+++ b/packages/simulator/src/trace.ts
@@ -62,6 +62,17 @@ export interface TraceCall {
  */
 export const DEFAULT_SIMULATION_GAS = 10_000_000n;
 
+/**
+ * Resolve the base block for one simulate() run. Every trace, diff, and gas
+ * estimate in the run pins this block so evidence extraction and state
+ * chaining share a single base state even when new blocks land mid-run
+ * (ADR 0002). Monad's debug_traceCall accepts an explicit block number with
+ * stateOverrides (verified live 2026-07-20).
+ */
+export async function resolveSimulationBlock(client: PublicClient): Promise<Hex> {
+  return (await client.request({ method: "eth_blockNumber" })) as Hex;
+}
+
 export class SimulatorUnavailableError extends Error {
   constructor(rpcUrl: string) {
     super(
@@ -83,6 +94,7 @@ async function traceCall<T>(
   client: PublicClient,
   rpcUrl: string,
   call: TraceCall,
+  block: Hex,
   traceOpts: Record<string, unknown>,
   overrides: StateOverrides,
   gas: bigint,
@@ -94,7 +106,7 @@ async function traceCall<T>(
       // biome-ignore lint/suspicious/noExplicitAny: non-standard namespace, untyped in viem
       method: "debug_traceCall" as any,
       // biome-ignore lint/suspicious/noExplicitAny: non-standard namespace, untyped in viem
-      params: [{ ...call, gas: `0x${gas.toString(16)}` }, "latest", opts] as any,
+      params: [{ ...call, gas: `0x${gas.toString(16)}` }, block, opts] as any,
     })) as T;
   } catch (err) {
     if (isMethodNotFound(err)) throw new SimulatorUnavailableError(rpcUrl);
@@ -107,6 +119,7 @@ export function traceWithCalls(
   client: PublicClient,
   rpcUrl: string,
   call: TraceCall,
+  block: Hex,
   overrides: StateOverrides,
   gas: bigint = DEFAULT_SIMULATION_GAS,
 ): Promise<CallFrame> {
@@ -114,6 +127,7 @@ export function traceWithCalls(
     client,
     rpcUrl,
     call,
+    block,
     { tracer: "callTracer", tracerConfig: { withLog: true } },
     overrides,
     gas,
@@ -125,6 +139,7 @@ export function traceWithDiff(
   client: PublicClient,
   rpcUrl: string,
   call: TraceCall,
+  block: Hex,
   overrides: StateOverrides,
   gas: bigint = DEFAULT_SIMULATION_GAS,
 ): Promise<PrestateDiff> {
@@ -132,6 +147,7 @@ export function traceWithDiff(
     client,
     rpcUrl,
     call,
+    block,
     { tracer: "prestateTracer", tracerConfig: { diffMode: true } },
     overrides,
     gas,
@@ -147,10 +163,11 @@ export function traceWithDiff(
 export async function estimateGasWithOverrides(
   client: PublicClient,
   call: TraceCall,
+  block: Hex,
   overrides: StateOverrides,
 ): Promise<bigint | null> {
   try {
-    const params: unknown[] = [call, "latest"];
+    const params: unknown[] = [call, block];
     if (Object.keys(overrides).length > 0) params.push(overrides);
     const result = (await client.request({
       // biome-ignore lint/suspicious/noExplicitAny: overrides param is non-standard

--- a/packages/simulator/test/overrides.test.ts
+++ b/packages/simulator/test/overrides.test.ts
@@ -1,0 +1,72 @@
+import type { Address, Hex } from "@themoss/core";
+import { describe, expect, it } from "vitest";
+import { mergeDiff } from "../src/overrides.js";
+import type { PrestateDiff, StateOverrides } from "../src/trace.js";
+
+const A = "0x1111111111111111111111111111111111111111" as Address;
+const B = "0x2222222222222222222222222222222222222222" as Address;
+const EXISTING_SLOT = `0x${"01".repeat(32)}` as Hex;
+const UPDATED_SLOT = `0x${"02".repeat(32)}` as Hex;
+const CLEARED_SLOT = `0x${"03".repeat(32)}` as Hex;
+const EXISTING_VALUE = `0x${"11".repeat(32)}` as Hex;
+const UPDATED_VALUE = `0x${"22".repeat(32)}` as Hex;
+const ZERO_WORD = `0x${"00".repeat(32)}` as Hex;
+
+describe("mergeDiff", () => {
+  it("merges account fields and storage while preserving existing overrides", () => {
+    const overrides: StateOverrides = {
+      [A]: {
+        balance: "0x1",
+        stateDiff: { [EXISTING_SLOT]: EXISTING_VALUE },
+      },
+    };
+    const diff: PrestateDiff = {
+      pre: {
+        [A]: {
+          storage: {
+            [UPDATED_SLOT]: EXISTING_VALUE,
+            [CLEARED_SLOT]: EXISTING_VALUE,
+          },
+        },
+      },
+      post: {
+        [A]: {
+          balance: "0x2",
+          nonce: 7,
+          code: "0x6000",
+          storage: { [UPDATED_SLOT]: UPDATED_VALUE },
+        },
+      },
+    };
+
+    mergeDiff(overrides, diff);
+
+    expect(overrides[A]).toEqual({
+      balance: "0x2",
+      nonce: "0x7",
+      code: "0x6000",
+      stateDiff: {
+        [EXISTING_SLOT]: EXISTING_VALUE,
+        [UPDATED_SLOT]: UPDATED_VALUE,
+        [CLEARED_SLOT]: ZERO_WORD,
+      },
+    });
+  });
+
+  it("normalizes account keys and keeps different accounts isolated", () => {
+    const mixedCaseA = "0x11111111111111111111111111111111111111AA" as Address;
+    const overrides: StateOverrides = { [B]: { balance: "0x5" } };
+    const diff: PrestateDiff = {
+      pre: {},
+      post: {
+        [mixedCaseA]: { balance: "0x9" },
+        [B]: { nonce: 3 },
+      },
+    };
+
+    mergeDiff(overrides, diff);
+
+    expect(overrides[mixedCaseA.toLowerCase() as Address]).toEqual({ balance: "0x9" });
+    expect(overrides[B]).toEqual({ balance: "0x5", nonce: "0x3" });
+  });
+});

--- a/packages/simulator/test/receipt-simulator.test.ts
+++ b/packages/simulator/test/receipt-simulator.test.ts
@@ -6,6 +6,7 @@ import type { CallFrame, PrestateDiff, StateOverrides } from "../src/trace.js";
 const A = "0x1111111111111111111111111111111111111111" as Address;
 const B = "0x2222222222222222222222222222222222222222" as Address;
 const C = "0x3333333333333333333333333333333333333333" as Address;
+const PINNED_BLOCK = "0x100";
 
 function capability(
   protocol: string,
@@ -48,8 +49,12 @@ function runtimeWithFrames(
   return {
     rpcUrl: "http://offline",
     client: {
-      request: async ({ method, params }: { method: string; params: unknown[] }) => {
-        const tracer = (params[2] as { tracer?: string } | undefined)?.tracer;
+      request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+        if (method === "eth_blockNumber") {
+          requests?.push({ method });
+          return PINNED_BLOCK;
+        }
+        const tracer = (params?.[2] as { tracer?: string } | undefined)?.tracer;
         requests?.push({ method, ...(tracer ? { tracer } : {}) });
         if (method === "eth_estimateGas") return "0x5208";
         if (tracer === "callTracer") return frames[frameIndex++];
@@ -93,10 +98,11 @@ describe("Capability simulation", () => {
     const runtime: MossRuntime = {
       rpcUrl: "http://offline",
       client: {
-        request: async ({ method, params }: { method: string; params: unknown[] }) => {
-          requests.push({ method, params });
+        request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+          requests.push({ method, params: params ?? [] });
+          if (method === "eth_blockNumber") return PINNED_BLOCK;
           if (method === "eth_estimateGas") return "0x5208";
-          const tracer = (params[2] as { tracer?: string } | undefined)?.tracer;
+          const tracer = (params?.[2] as { tracer?: string } | undefined)?.tracer;
           if (tracer === "prestateTracer") return diff;
           if (tracer === "callTracer") {
             const to = callIndex++ === 0 ? B : C;
@@ -121,13 +127,20 @@ describe("Capability simulation", () => {
         tracer: (params[2] as { tracer?: string } | undefined)?.tracer,
       })),
     ).toEqual([
+      { method: "eth_blockNumber", tracer: undefined },
       { method: "debug_traceCall", tracer: "callTracer" },
       { method: "eth_estimateGas", tracer: undefined },
       { method: "debug_traceCall", tracer: "prestateTracer" },
       { method: "debug_traceCall", tracer: "callTracer" },
       { method: "eth_estimateGas", tracer: undefined },
     ]);
-    const secondCall = requests[3]?.params[2] as { stateOverrides?: StateOverrides } | undefined;
+    // Every trace, diff, and gas estimate in the run pins the same base block.
+    for (const { method, params } of requests) {
+      if (method === "debug_traceCall" || method === "eth_estimateGas") {
+        expect(params[1]).toBe(PINNED_BLOCK);
+      }
+    }
+    const secondCall = requests[4]?.params[2] as { stateOverrides?: StateOverrides } | undefined;
     expect(secondCall?.stateOverrides?.[B]).toEqual({
       balance: "0x10",
       nonce: "0x2",
@@ -141,9 +154,10 @@ describe("Capability simulation", () => {
     const runtime: MossRuntime = {
       rpcUrl: "http://offline",
       client: {
-        request: async ({ method, params }: { method: string; params: unknown[] }) => {
-          const tracer = (params[2] as { tracer?: string } | undefined)?.tracer;
+        request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+          const tracer = (params?.[2] as { tracer?: string } | undefined)?.tracer;
           requests.push(tracer ?? method);
+          if (method === "eth_blockNumber") return PINNED_BLOCK;
           if (method === "eth_estimateGas") return "0x5208";
           if (tracer === "callTracer") {
             return { type: "CALL", from: A, to: B, logs: [] } satisfies CallFrame;
@@ -159,7 +173,12 @@ describe("Capability simulation", () => {
       receipt: (node, changes) => coveringReceipt(node.protocol, changes),
     }).simulate(capability("parent", C, [capability("child", B)]));
 
-    expect(requests).toEqual(["callTracer", "eth_estimateGas", "prestateTracer"]);
+    expect(requests).toEqual([
+      "eth_blockNumber",
+      "callTracer",
+      "eth_estimateGas",
+      "prestateTracer",
+    ]);
     expect(outcome.results).toHaveLength(1);
     expect(outcome.results[0]?.receipt?.protocol).toBe("child");
     expect(outcome.results[0]?.warnings).toEqual([
@@ -202,7 +221,8 @@ describe("Capability simulation", () => {
     const runtime: MossRuntime = {
       rpcUrl: "http://offline",
       client: {
-        request: async () => {
+        request: async ({ method }: { method: string }) => {
+          if (method === "eth_blockNumber") return PINNED_BLOCK;
           throw new Error("debug_traceCall unavailable");
         },
         // biome-ignore lint/suspicious/noExplicitAny: minimal failing RPC fixture
@@ -215,6 +235,29 @@ describe("Capability simulation", () => {
       { code: "TRACE_FAILED", message: "debug_traceCall unavailable" },
     ]);
     expect(outcome.halted?.transactionIndex).toBe(0);
+  });
+
+  it("halts before any trace when the base block cannot be resolved", async () => {
+    const requests: string[] = [];
+    const runtime: MossRuntime = {
+      rpcUrl: "http://offline",
+      client: {
+        request: async ({ method }: { method: string }) => {
+          requests.push(method);
+          throw new Error("rpc unreachable");
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal failing RPC fixture
+      } as any,
+    };
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    }).simulate(capability("fixture", B));
+    expect(requests).toEqual(["eth_blockNumber"]);
+    expect(outcome.results).toHaveLength(1);
+    expect(outcome.results[0]?.warnings).toEqual([
+      { code: "TRACE_FAILED", message: "rpc unreachable" },
+    ]);
+    expect(outcome.halted).toEqual({ transactionIndex: 0, reason: "rpc unreachable" });
   });
 
   it("classifies forged Change coverage and halts before later work", async () => {
@@ -248,7 +291,10 @@ describe("Capability simulation", () => {
       transactionIndex: 0,
       reason: "Receipt Change 0 does not retain the original object in order",
     });
-    expect(requests).toEqual([{ method: "debug_traceCall", tracer: "callTracer" }]);
+    expect(requests).toEqual([
+      { method: "eth_blockNumber" },
+      { method: "debug_traceCall", tracer: "callTracer" },
+    ]);
   });
 
   it("treats arbitrary Receipt parser failures as terminal warnings", async () => {

--- a/packages/simulator/test/receipt-simulator.test.ts
+++ b/packages/simulator/test/receipt-simulator.test.ts
@@ -1,7 +1,7 @@
 import type { Address, CapabilityNode, Change, MossRuntime, Receipt } from "@themoss/core";
 import { describe, expect, it } from "vitest";
 import { createTraceSimulator } from "../src/index.js";
-import type { CallFrame } from "../src/trace.js";
+import type { CallFrame, PrestateDiff, StateOverrides } from "../src/trace.js";
 
 const A = "0x1111111111111111111111111111111111111111" as Address;
 const B = "0x2222222222222222222222222222222222222222" as Address;
@@ -75,6 +75,97 @@ describe("Capability simulation", () => {
     expect(outcome.results.map(({ protocol }) => protocol)).toEqual(["child", "parent"]);
     expect(outcome.results.every(({ receipt }) => receipt?.kind === "receipt")).toBe(true);
     expect(outcome.results.every(({ warnings }) => warnings.length === 0)).toBe(true);
+  });
+
+  it("passes the first transaction state diff into the second transaction trace", async () => {
+    const requests: { method: string; params: unknown[] }[] = [];
+    const slot = `0x${"01".repeat(32)}` as `0x${string}`;
+    const value = `0x${"02".repeat(32)}` as `0x${string}`;
+    const cleared = `0x${"03".repeat(32)}` as `0x${string}`;
+    const zeroWord = `0x${"00".repeat(32)}` as `0x${string}`;
+    const diff: PrestateDiff = {
+      pre: { [B]: { storage: { [slot]: "0x00", [cleared]: "0x01" } } },
+      post: {
+        [B]: { balance: "0x10", nonce: 2, code: "0x6000", storage: { [slot]: value } },
+      },
+    };
+    let callIndex = 0;
+    const runtime: MossRuntime = {
+      rpcUrl: "http://offline",
+      client: {
+        request: async ({ method, params }: { method: string; params: unknown[] }) => {
+          requests.push({ method, params });
+          if (method === "eth_estimateGas") return "0x5208";
+          const tracer = (params[2] as { tracer?: string } | undefined)?.tracer;
+          if (tracer === "prestateTracer") return diff;
+          if (tracer === "callTracer") {
+            const to = callIndex++ === 0 ? B : C;
+            return { type: "CALL", from: A, to, logs: [] } satisfies CallFrame;
+          }
+          throw new Error(`unexpected RPC method ${method}`);
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal debug RPC fixture
+      } as any,
+    };
+
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    }).simulate(capability("parent", C, [capability("child", B)]));
+
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results).toHaveLength(2);
+    expect(outcome.results.every(({ warnings }) => warnings.length === 0)).toBe(true);
+    expect(
+      requests.map(({ method, params }) => ({
+        method,
+        tracer: (params[2] as { tracer?: string } | undefined)?.tracer,
+      })),
+    ).toEqual([
+      { method: "debug_traceCall", tracer: "callTracer" },
+      { method: "eth_estimateGas", tracer: undefined },
+      { method: "debug_traceCall", tracer: "prestateTracer" },
+      { method: "debug_traceCall", tracer: "callTracer" },
+      { method: "eth_estimateGas", tracer: undefined },
+    ]);
+    const secondCall = requests[3]?.params[2] as { stateOverrides?: StateOverrides } | undefined;
+    expect(secondCall?.stateOverrides?.[B]).toEqual({
+      balance: "0x10",
+      nonce: "0x2",
+      code: "0x6000",
+      stateDiff: { [slot]: value, [cleared]: zeroWord },
+    });
+  });
+
+  it("keeps the first Receipt and halts when state chaining fails", async () => {
+    const requests: string[] = [];
+    const runtime: MossRuntime = {
+      rpcUrl: "http://offline",
+      client: {
+        request: async ({ method, params }: { method: string; params: unknown[] }) => {
+          const tracer = (params[2] as { tracer?: string } | undefined)?.tracer;
+          requests.push(tracer ?? method);
+          if (method === "eth_estimateGas") return "0x5208";
+          if (tracer === "callTracer") {
+            return { type: "CALL", from: A, to: B, logs: [] } satisfies CallFrame;
+          }
+          if (tracer === "prestateTracer") throw new Error("prestate unavailable");
+          throw new Error(`unexpected RPC method ${method}`);
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal debug RPC fixture
+      } as any,
+    };
+
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    }).simulate(capability("parent", C, [capability("child", B)]));
+
+    expect(requests).toEqual(["callTracer", "eth_estimateGas", "prestateTracer"]);
+    expect(outcome.results).toHaveLength(1);
+    expect(outcome.results[0]?.receipt?.protocol).toBe("child");
+    expect(outcome.results[0]?.warnings).toEqual([
+      { code: "STATE_CHAIN_FAILED", message: "prestate unavailable" },
+    ]);
+    expect(outcome.halted).toEqual({ transactionIndex: 0, reason: "prestate unavailable" });
   });
 
   it("returns no Receipt for a revert and stops later transactions", async () => {

--- a/packages/system/test/wmon.test.ts
+++ b/packages/system/test/wmon.test.ts
@@ -1,4 +1,5 @@
 import {
+  type CapabilityNode,
   type Change,
   flattenCapabilityTree,
   type Hex,
@@ -7,11 +8,18 @@ import {
 } from "@themoss/core";
 import { ERC20Abi, WETH9Abi } from "@themoss/erc";
 import { createTraceSimulator } from "@themoss/simulator";
-import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  formatUnits,
+  getAddress,
+} from "viem";
 import { describe, expect, it } from "vitest";
 import { AUSD_ADDRESS, monadRuntime, USDC_ADDRESS, WMON, WMON_ADDRESS } from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const RECEIVER = getAddress("0xdddddddddddddddddddddddddddddddddddddddd");
 const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
 
 function depositChange(amount: bigint): Change {
@@ -110,6 +118,59 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Monad official token constants", (
       operation: "wrap",
       account: ACCOUNT,
       amount: "250000000000000000",
+    });
+  });
+
+  it("chains a live WMON wrap into a transfer", { timeout: 180_000 }, async () => {
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(WMON);
+    const wrapAmount = 1_000_000_000_000n;
+    const initialBalance = await runtime.client.readContract({
+      address: WMON_ADDRESS,
+      abi: ERC20Abi,
+      functionName: "balanceOf",
+      args: [ACCOUNT],
+    });
+    const transferAmount = initialBalance + wrapAmount;
+    const wrap = await registry.action("wmon", "wrap", ACCOUNT, {
+      amount: formatUnits(wrapAmount, 18),
+    });
+    const transfer = await registry.action("erc20", "transfer", ACCOUNT, {
+      token: WMON_ADDRESS,
+      to: RECEIVER,
+      amount: formatUnits(transferAmount, 18),
+    });
+    if (wrap.kind !== "capability" || transfer.kind !== "capability") {
+      throw new Error("expected Capabilities");
+    }
+    const capability = {
+      ...transfer,
+      children: [wrap, ...transfer.children],
+    } satisfies CapabilityNode;
+    expect(() => registry.validateCapabilityTree(capability)).not.toThrow();
+    expect(flattenCapabilityTree(capability)).toHaveLength(2);
+
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results.map(({ protocol, method }) => ({ protocol, method }))).toEqual([
+      { protocol: "wmon", method: "wrap" },
+      { protocol: "erc20", method: "transfer" },
+    ]);
+    expect(outcome.results.every(({ warnings }) => warnings.length === 0)).toBe(true);
+    expect(outcome.results[0]?.receipt?.outcome).toEqual({
+      operation: "wrap",
+      account: ACCOUNT,
+      amount: wrapAmount.toString(),
+    });
+    expect(outcome.results[1]?.receipt?.outcome).toEqual({
+      operation: "transfer",
+      token: WMON_ADDRESS.toLowerCase(),
+      from: ACCOUNT,
+      to: RECEIVER,
+      amount: transferAmount.toString(),
     });
   });
 });


### PR DESCRIPTION
## Problem

The Simulator executes nested Capability transactions in depth-first order and carries each transaction's post-state into the next `debug_traceCall`.

This state-chaining behavior is security-critical, but it did not have focused coverage for:

- balance, nonce, bytecode, and storage propagation;
- storage slots cleared by a previous transaction;
- preserving existing state overrides;
- normalized account keys and account isolation;
- stopping execution when the intermediate state diff cannot be obtained;
- a real two-transaction Monad mainnet flow where the second transaction necessarily depends on state created by the first.

A single-transaction simulation test cannot prove these invariants.

## Changes

- add focused `mergeDiff` tests covering account fields, storage updates, cleared slots, existing overrides, address normalization, and account isolation;
- verify the exact RPC sequence used for two chained transactions;
- verify the first transaction's state diff is supplied to the second trace;
- verify a state-chaining failure preserves the first Receipt, emits `STATE_CHAIN_FAILED`, and prevents the second transaction from running;
- add a live Monad mainnet proof using `wmon.wrap` followed by `erc20.transfer`.

## Why the live test proves state propagation

The test reads the account's initial WMON balance `B`, wraps an additional amount `D`, then attempts to transfer `B + D`.

Without the first transaction's state diff, the second transaction only sees `B` and must fail with insufficient balance. With correct state propagation, it sees `B + D` and succeeds. This remains valid even if the fixed test account receives WMON in the future.

The test only uses simulation. It does not sign or broadcast a transaction.

## Scope

This PR changes tests only:

- no production behavior changes;
- no dependency changes;
- no ABI changes;
- no changeset is required.

It is based on `main` at `95dc4ef`.

The tests do not depend on the final bound Protocol factory design in #74. If #74 later adds required fields to `CapabilityNode`, the live fixture may need a mechanical update, but the state-chaining invariant remains unchanged.

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `NODE_USE_ENV_PROXY=1 pnpm test`
  - 127 tests passed
  - Monad WMON live checks passed
  - Kuru live checks passed
- `pnpm audit --prod`
  - no known vulnerabilities

## Residual risk

The live proof depends on the configured Monad mainnet RPC supporting `debug_traceCall` and `prestateTracer`. It is skipped with `MOSS_SKIP_E2E=1` in offline environments.

The test proves the WMON-to-ERC20 state chain and the generic override merge mechanics; it does not claim to exercise every possible contract-specific storage layout or RPC implementation.