### PR TITLE
feat(core): observe Query metadata for OnChain labels

### DIFF
--- a/.changeset/core-query-observations.md
+++ b/.changeset/core-query-observations.md
@@ -1,0 +1,5 @@
+---
+"@themoss/core": minor
+---
+
+Add `tokenMetadata` Query observations and Registry-scoped `OnChain(name,address)` Receipt labels learned only from successful Queries.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   verifyReceiptCoverage,
 } from "./framework.js";
 export { createHandle, type Handle, transaction } from "./handle.js";
+export { tokenMetadata } from "./observations.js";
 export {
   type ActionCtx,
   type Coordinate,

--- a/packages/core/src/observations.ts
+++ b/packages/core/src/observations.ts
@@ -1,0 +1,71 @@
+import { type Address, isAddress } from "viem";
+
+const QUERY_OBSERVATION = Symbol("moss.queryObservation");
+
+interface TokenMetadata {
+  address: Address;
+  symbol?: string;
+  name?: string;
+}
+
+export interface TokenMetadataObservation extends TokenMetadata {
+  kind: "tokenMetadata";
+}
+
+export type QueryObservation = TokenMetadataObservation;
+
+export function tokenMetadata<const Result extends object>(
+  result: Result,
+  metadata: TokenMetadata,
+): Result {
+  Object.defineProperty(result, QUERY_OBSERVATION, {
+    value: {
+      kind: "tokenMetadata",
+      address: metadata.address,
+      ...(metadata.symbol === undefined ? {} : { symbol: metadata.symbol }),
+      ...(metadata.name === undefined ? {} : { name: metadata.name }),
+    } satisfies TokenMetadataObservation,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return result;
+}
+
+export function queryObservationOf(value: unknown): QueryObservation | undefined {
+  if (typeof value !== "object" || value === null || !Object.hasOwn(value, QUERY_OBSERVATION)) {
+    return undefined;
+  }
+  const observation = (value as Record<symbol, unknown>)[QUERY_OBSERVATION];
+  if (!observation || typeof observation !== "object" || Array.isArray(observation)) {
+    throw new Error("invalid Query observation: expected an object");
+  }
+  const prototype = Object.getPrototypeOf(observation);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error("invalid Query observation: expected a plain object");
+  }
+  const fields = Reflect.ownKeys(observation);
+  const allowed = new Set<PropertyKey>(["kind", "address", "symbol", "name"]);
+  if (fields.some((field) => !allowed.has(field))) {
+    throw new Error("invalid Query observation: contains an unknown field");
+  }
+  const candidate = observation as Record<string, unknown>;
+  if (candidate.kind !== "tokenMetadata") {
+    throw new Error(`unknown Query observation kind "${String(candidate.kind)}"`);
+  }
+  if (typeof candidate.address !== "string" || !isAddress(candidate.address, { strict: false })) {
+    throw new Error("invalid tokenMetadata observation: address must be a 20-byte address");
+  }
+  if (candidate.symbol !== undefined && typeof candidate.symbol !== "string") {
+    throw new Error("invalid tokenMetadata observation: symbol must be a string");
+  }
+  if (candidate.name !== undefined && typeof candidate.name !== "string") {
+    throw new Error("invalid tokenMetadata observation: name must be a string");
+  }
+  return {
+    kind: "tokenMetadata",
+    address: candidate.address,
+    ...(candidate.symbol === undefined ? {} : { symbol: candidate.symbol }),
+    ...(candidate.name === undefined ? {} : { name: candidate.name }),
+  };
+}

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -10,6 +10,7 @@ import {
   RECEIPT_META,
 } from "./decorators.js";
 import { flattenCapabilityTree, toJsonSafe, verifyReceiptCoverage } from "./framework.js";
+import { queryObservationOf, type TokenMetadataObservation } from "./observations.js";
 import type { MossRuntime } from "./runtime.js";
 import { describeParams, parameterTypeDescription, parseParams } from "./semantics.js";
 import type {
@@ -98,6 +99,10 @@ function requireMetadataText(value: unknown, path: string): void {
 const SAFE_LABEL_PART = /^[A-Za-z0-9 ._-]+$/;
 const ADDRESS_IN_TEXT = /(?<![0-9a-f])0x[0-9a-f]{40}(?![0-9a-f])/gi;
 
+function isSafeLabelName(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 32 && SAFE_LABEL_PART.test(value);
+}
+
 function collectLabels(
   entries: Iterable<readonly [name: string, address: Address]>,
   provenance: "Trusted" | "Package",
@@ -108,7 +113,7 @@ function collectLabels(
   const names = new Set<string>();
   for (const [name, address] of entries) {
     const payload = packageName ? `${packageName}:${name}` : name;
-    if (!SAFE_LABEL_PART.test(name) || payload.length > 32) {
+    if (!isSafeLabelName(name) || payload.length > 32) {
       throw new Error(`${owner} ${provenance} label must be a 1-32 character safe name`);
     }
     if (!isAddress(address, { strict: false })) {
@@ -142,6 +147,10 @@ function hasProtocol(receipt: ReceiptResult): receipt is Receipt {
 export class Registry {
   #protocols = new Map<string, Registered>();
   #assignedReceiptProtocols = new WeakMap<object, string>();
+  #onChainMetadata = new Map<
+    string,
+    Pick<TokenMetadataObservation, "address" | "symbol" | "name">
+  >();
   #trustedLabels: ReadonlyMap<string, string>;
   readonly runtime: MossRuntime;
 
@@ -388,7 +397,31 @@ export class Registry {
     const params = await parseParams(meta.spec.params, rawParams);
     const instance = this.#instantiate(protocol, account);
     // biome-ignore lint/suspicious/noExplicitAny: metadata validates dynamic method dispatch
-    return toJsonSafe(await (instance as any)[method](params, { account } satisfies ActionCtx));
+    const result = await (instance as any)[method](params, { account } satisfies ActionCtx);
+    this.#processQueryObservation(result);
+    return toJsonSafe(result);
+  }
+
+  #processQueryObservation(result: unknown): void {
+    const observation = queryObservationOf(result);
+    if (!observation) return;
+    switch (observation.kind) {
+      case "tokenMetadata": {
+        const symbol = isSafeLabelName(observation.symbol) ? observation.symbol : undefined;
+        const name = isSafeLabelName(observation.name) ? observation.name : undefined;
+        const key = observation.address.toLowerCase();
+        if (!symbol && !name) {
+          this.#onChainMetadata.delete(key);
+          return;
+        }
+        this.#onChainMetadata.set(key, {
+          address: observation.address,
+          ...(symbol ? { symbol } : {}),
+          ...(name ? { name } : {}),
+        });
+        return;
+      }
+    }
   }
 
   #runReceipt(protocol: string, receiptName: string, changes: readonly Change[]): Receipt {
@@ -570,7 +603,10 @@ export class Registry {
             if (label) return `Package(${scope.packageName}:${label})`;
           }
           const dependency = current.dependencies.get(key);
-          return dependency ? `Package(${dependency.packageName}:${dependency.name})` : address;
+          if (dependency) return `Package(${dependency.packageName}:${dependency.name})`;
+          const onChain = this.#onChainMetadata.get(key);
+          const name = onChain?.symbol ?? onChain?.name;
+          return name ? `OnChain(${name},${address})` : address;
         });
 
       return {

--- a/packages/core/test/query-observations.test.ts
+++ b/packages/core/test/query-observations.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AddressValue,
+  Capability,
+  type Change,
+  type InferParams,
+  type MossRuntime,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  Registry,
+  tokenMetadata,
+  transaction,
+} from "../src/index.js";
+
+const ACCOUNT = "0x1111111111111111111111111111111111111111" as const;
+const ONCHAIN = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa" as const;
+const TRUSTED = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as const;
+const PACKAGE = "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC" as const;
+const ORDINARY = "0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd" as const;
+const noParams = {} satisfies ParamsSpec;
+
+function queryObservationMarker(): symbol {
+  const marker = Object.getOwnPropertySymbols(tokenMetadata({}, { address: ONCHAIN }))[0];
+  if (!marker) throw new Error("missing Query observation marker");
+  return marker;
+}
+
+const observationMarker = queryObservationMarker();
+
+function forgedObservation(observation: unknown) {
+  return Object.defineProperty({}, observationMarker, {
+    value: observation,
+    enumerable: false,
+  });
+}
+
+@Protocol({
+  name: "observed-token",
+  category: "token",
+  description: "Query observation fixture.",
+  contracts: {},
+  labels: { PackageToken: PACKAGE },
+})
+class ObservedTokenProtocol {
+  @Query({ intent: "Observe safe token metadata", params: noParams })
+  async observeSafe() {
+    const result = {
+      address: ONCHAIN,
+      symbol: "CHAIN",
+      name: "Chain Token",
+      decimals: 18,
+    } as const;
+    return tokenMetadata(result, {
+      address: ONCHAIN,
+      symbol: result.symbol,
+      name: result.name,
+    });
+  }
+
+  @Query({ intent: "Observe metadata with a name fallback", params: noParams })
+  async observeFallback() {
+    return tokenMetadata(
+      { status: "fallback" as const },
+      { address: ONCHAIN, symbol: "Bad/Name", name: "Fallback Name" },
+    );
+  }
+
+  @Query({ intent: "Replace observed metadata", params: noParams })
+  async observeReplacement() {
+    return tokenMetadata(
+      { status: "replacement" as const },
+      { address: ONCHAIN, symbol: "NEXT", name: "Next Token" },
+    );
+  }
+
+  @Query({ intent: "Delete unsafe observed metadata", params: noParams })
+  async observeUnsafe() {
+    return tokenMetadata(
+      { status: "unsafe" as const },
+      { address: ONCHAIN, symbol: "Bad/Name", name: "x".repeat(33) },
+    );
+  }
+
+  @Query({ intent: "Observe metadata for a Trusted token", params: noParams })
+  async observeTrusted() {
+    return tokenMetadata({ status: "trusted" as const }, { address: TRUSTED, symbol: "CHAIN-T" });
+  }
+
+  @Query({ intent: "Observe metadata for a Package token", params: noParams })
+  async observePackage() {
+    return tokenMetadata({ status: "package" as const }, { address: PACKAGE, symbol: "CHAIN-P" });
+  }
+
+  @Query({ intent: "Return ordinary metadata-shaped fields", params: noParams })
+  async ordinaryFields() {
+    return { address: ORDINARY, symbol: "ORD", name: "Ordinary Token" };
+  }
+
+  @Query({ intent: "Fail the metadata Query", params: noParams })
+  async fail() {
+    throw new Error("metadata unavailable");
+  }
+
+  @Query({ intent: "Return an unknown observation", params: noParams })
+  async unknownObservation() {
+    return forgedObservation({ kind: "futureObservation", address: ONCHAIN });
+  }
+
+  @Query({ intent: "Return malformed token metadata", params: noParams })
+  async malformedObservation() {
+    return forgedObservation({ kind: "tokenMetadata", address: ONCHAIN, symbol: 7 });
+  }
+
+  @Capability<ObservedTokenProtocol, typeof noParams>({
+    intent: "Render observed token labels",
+    verb: "transfer",
+    params: noParams,
+    receipt: "renderReceipt",
+    risk: ["fundOut"],
+  })
+  async render(_: InferParams<typeof noParams>, ctx: { account: AddressValue }) {
+    return transaction(ctx.account, ONCHAIN);
+  }
+
+  @Receipt()
+  renderReceipt(_: readonly Change[]): ReceiptResult<null> {
+    return {
+      kind: "receipt",
+      outcome: null,
+      text: `onchain ${ONCHAIN.toLowerCase()} trusted ${TRUSTED} package ${PACKAGE} ordinary ${ORDINARY}`,
+      changes: [],
+    };
+  }
+}
+
+const runtime: MossRuntime = {
+  rpcUrl: "http://offline",
+  // biome-ignore lint/suspicious/noExplicitAny: calls are not used by this unit test
+  client: {} as any,
+};
+
+async function runQuery(registry: Registry, method: string) {
+  return registry.action("observed-token", method, ACCOUNT, {});
+}
+
+async function renderText(registry: Registry): Promise<string> {
+  const capability = await registry.action("observed-token", "render", ACCOUNT, {});
+  if (capability.kind !== "capability") throw new Error("expected Capability");
+  return registry.parseReceipt(capability, []).text;
+}
+
+describe("Registry Query observations", () => {
+  it("keeps tokenMetadata invisible while preserving the exact result object", () => {
+    const result = { kind: "metadata" as const, decimals: 18 as const };
+    const observed = tokenMetadata(result, { address: ONCHAIN, symbol: "CHAIN" });
+
+    expect(observed).toBe(result);
+    expect(Object.keys(observed)).toEqual(["kind", "decimals"]);
+    expect({ ...observed }).toEqual({ kind: "metadata", decimals: 18 });
+    expect(JSON.parse(JSON.stringify(observed))).toEqual({ kind: "metadata", decimals: 18 });
+    const [marker] = Object.getOwnPropertySymbols(observed);
+    expect(marker).toBe(observationMarker);
+    expect(Object.getOwnPropertyDescriptor(observed, marker as symbol)).toMatchObject({
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  });
+
+  it("returns ordinary JSON and learns a case-insensitive OnChain label", async () => {
+    const registry = new Registry(runtime).use(ObservedTokenProtocol);
+    const query = await runQuery(registry, "observeSafe");
+
+    expect(query).toEqual({
+      kind: "query",
+      protocol: "observed-token",
+      method: "observeSafe",
+      data: { address: ONCHAIN, symbol: "CHAIN", name: "Chain Token", decimals: 18 },
+    });
+    expect(await renderText(registry)).toContain(`onchain OnChain(CHAIN,${ONCHAIN.toLowerCase()})`);
+  });
+
+  it("ignores ordinary metadata-shaped fields and isolates Registry instances", async () => {
+    const observed = new Registry(runtime).use(ObservedTokenProtocol);
+    const isolated = new Registry(runtime).use(ObservedTokenProtocol);
+    await runQuery(observed, "ordinaryFields");
+    await runQuery(observed, "observeSafe");
+
+    expect(await renderText(observed)).toContain(`ordinary ${ORDINARY}`);
+    expect(await renderText(isolated)).toContain(`onchain ${ONCHAIN.toLowerCase()}`);
+  });
+
+  it("prefers safe symbol, falls back to name, replaces, and deletes metadata", async () => {
+    const registry = new Registry(runtime).use(ObservedTokenProtocol);
+
+    await runQuery(registry, "observeFallback");
+    expect(await renderText(registry)).toContain(`OnChain(Fallback Name,${ONCHAIN.toLowerCase()})`);
+    await runQuery(registry, "observeReplacement");
+    expect(await renderText(registry)).toContain(`OnChain(NEXT,${ONCHAIN.toLowerCase()})`);
+    await runQuery(registry, "observeUnsafe");
+    expect(await renderText(registry)).toContain(`onchain ${ONCHAIN.toLowerCase()}`);
+  });
+
+  it("leaves metadata unchanged when a Query fails", async () => {
+    const registry = new Registry(runtime).use(ObservedTokenProtocol);
+    await runQuery(registry, "observeSafe");
+
+    await expect(runQuery(registry, "fail")).rejects.toThrow("metadata unavailable");
+    expect(await renderText(registry)).toContain(`OnChain(CHAIN,${ONCHAIN.toLowerCase()})`);
+  });
+
+  it("rejects unknown and malformed observations without changing metadata", async () => {
+    const registry = new Registry(runtime).use(ObservedTokenProtocol);
+    await runQuery(registry, "observeSafe");
+
+    await expect(runQuery(registry, "unknownObservation")).rejects.toThrow(
+      'unknown Query observation kind "futureObservation"',
+    );
+    await expect(runQuery(registry, "malformedObservation")).rejects.toThrow(
+      "symbol must be a string",
+    );
+    expect(await renderText(registry)).toContain(`OnChain(CHAIN,${ONCHAIN.toLowerCase()})`);
+  });
+
+  it("keeps Trusted and visible Package labels above OnChain metadata", async () => {
+    const registry = new Registry(runtime, {
+      trustedTokens: [{ address: TRUSTED, label: "Trusted Token" }],
+    }).use(ObservedTokenProtocol);
+    await runQuery(registry, "observeSafe");
+    await runQuery(registry, "observeTrusted");
+    await runQuery(registry, "observePackage");
+
+    expect(await renderText(registry)).toBe(
+      `onchain OnChain(CHAIN,${ONCHAIN.toLowerCase()}) trusted Trusted(Trusted Token) ` +
+        `package Package(Observed Token:PackageToken) ordinary ${ORDINARY}`,
+    );
+  });
+});

--- a/packages/core/test/types.fixture.ts
+++ b/packages/core/test/types.fixture.ts
@@ -1,4 +1,4 @@
-import { type MossRuntime, Protocol, Registry } from "../src/index.js";
+import { type MossRuntime, Protocol, Registry, tokenMetadata } from "../src/index.js";
 
 const ADDRESS = "0x1111111111111111111111111111111111111111" as const;
 
@@ -28,5 +28,20 @@ new Registry(runtime, {
   trustedTokens: [{ address: "not-an-address", label: "Token" }],
 });
 
+const metadataResult = tokenMetadata(
+  { kind: "metadata" as const, decimals: 18 as const },
+  { address: ADDRESS, symbol: "TOKEN", name: "Token" },
+);
+const metadataKind: "metadata" = metadataResult.kind;
+const metadataDecimals: 18 = metadataResult.decimals;
+// @ts-expect-error token metadata requires a valid EVM address.
+tokenMetadata({}, { address: "not-an-address", symbol: "TOKEN" });
+// @ts-expect-error token metadata symbol must be a string.
+tokenMetadata({}, { address: ADDRESS, symbol: 18 });
+// @ts-expect-error tokenMetadata attaches observations only to object Query results.
+tokenMetadata("metadata", { address: ADDRESS });
+
 void LabeledFixture;
 void InvalidLabeledFixture;
+void metadataKind;
+void metadataDecimals;


### PR DESCRIPTION
## Problem

Receipt labels currently support explicit Trusted identities and Protocol-owned Package identities, but Registry cannot learn presentation-only token metadata from successful Queries.

Inferring metadata from ordinary `address`, `symbol`, or `name` result fields would create an implicit trust boundary. Performing metadata RPC during Receipt parsing would also violate Receipt purity.

Closes #63.

## Approach

This PR adds the smallest Core-only observation channel described by #63:

- expose one `tokenMetadata(result, metadata)` helper;
- attach a closed `tokenMetadata` observation under a framework-owned, non-enumerable Symbol;
- preserve the original Query result object's identity and exact TypeScript type;
- process the observation only after the Query method returns successfully and before JSON-safe projection;
- keep learned metadata private to the current Registry instance;
- use learned metadata only during the existing Receipt text projection.

The Symbol, observation dispatcher, cache, and internal observation types are not part of the public package API.

## Validation and cache behavior

Registry accepts only the closed observation shape:

```text
kind: "tokenMetadata"
address: valid EVM address
symbol?: string
name?: string
```

Unknown kinds, malformed values, and additional observation fields are rejected before cache mutation.

The Registry-scoped cache:

- is in-memory and case-insensitive by address;
- stores only the observed address and safe symbol/name candidates;
- has no persistence, TTL, global state, or public cache API;
- prefers a safe symbol over a safe name;
- replaces an older entry with the latest successful safe observation;
- deletes an older entry when the latest observation has no safe candidate;
- remains unchanged when the Query throws.

Names reuse the existing 1–32 character ASCII safety rule.

## Receipt rendering

The existing rendering precedence remains:

```text
Trusted
-> visible Package
-> OnChain
-> raw address
```

OnChain metadata renders as:

```text
OnChain(name,0x...)
```

Unlike Trusted and Package labels, the complete matched address remains visible because on-chain metadata is untrusted presentation data.

Only Receipt and ReceiptChange text is projected. Outcomes, data, original Changes, protocol provenance, identity, length, and order remain unchanged.

## Tests

Added public-API coverage for:

- non-enumerable and JSON-invisible observations;
- exact Query result type and object preservation;
- ordinary metadata-shaped fields producing no observation;
- safe symbol preference and safe name fallback;
- replacement and unsafe-observation deletion;
- failed Queries leaving prior metadata unchanged;
- rejection of unknown and malformed observations before mutation;
- Registry instance isolation;
- case-insensitive address lookup;
- Trusted and visible Package precedence over OnChain;
- positive and `@ts-expect-error` compile-time helper contracts.

## Scope

This is intentionally limited to Core and one changeset.

It does not modify ERC, System, MCP, Simulator, Kuru, ABIs, or architectural documentation. Metadata producers and protocol migrations remain follow-up work for #64-#67.

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `NODE_USE_ENV_PROXY=1 pnpm test`
  - 61 tests passed
  - Monad WMON live checks passed
  - Kuru live quote and simulation checks passed
- `pnpm audit --prod`
  - no known vulnerabilities
