### PR TITLE
feat(protocols): add aPriori aprMON liquid staking adapter

### DIFF
--- a/.changeset/apriori-adapter.md
+++ b/.changeset/apriori-adapter.md
@@ -1,0 +1,9 @@
+---
+"@themoss/protocol-apriori": minor
+---
+
+Add aPriori aprMON liquid staking adapter for Monad. Exposes stake
+(deposit MON for aprMON), unstake (requestRedeem to queue withdrawal), and
+claim (redeem to receive MON) Capabilities against aPriori's native-asset
+ERC4626 vault with an async withdrawal queue. Contract addresses and entrypoint
+selectors verified on-chain.

--- a/.changeset/apriori-adapter.md
+++ b/.changeset/apriori-adapter.md
@@ -2,8 +2,18 @@
 "@themoss/protocol-apriori": minor
 ---
 
-Add aPriori aprMON liquid staking adapter for Monad. Exposes stake
-(deposit MON for aprMON), unstake (requestRedeem to queue withdrawal), and
-claim (redeem to receive MON) Capabilities against aPriori's native-asset
-ERC4626 vault with an async withdrawal queue. Contract addresses and entrypoint
-selectors verified on-chain.
+Add aPriori aprMON liquid staking adapter for Monad. Exposes `stake`
+(`deposit(uint256 assets, address receiver)` payable), `unstake`
+(`requestRedeem(uint256 shares, address receiver)`), and `claim`
+(`redeem(uint256[] requestIds, address receiver)`) Capabilities against
+aPriori's native-asset ERC4626 vault with an async withdrawal queue.
+
+This revision fixes the initial PR #104 implementation: corrects the proxy
+status (non-EIP-7702, implementation pinned explicitly), preserves the full
+`requestIds[]` array in `claimReceipt`, removes the misleading `priceImpact`
+risk label from `stake`/`unstake`, delegates ERC-20 `Transfer`/`Approval`
+events to `@themoss/erc`, and adds live mainnet `simulate` happy-path coverage
+for `stake` plus an online explorer cross-check test for the implementation
+ABI.
+
+Contract addresses and entrypoint selectors verified on-chain.

--- a/.changeset/apriori-adapter.md
+++ b/.changeset/apriori-adapter.md
@@ -1,19 +1,21 @@
 ---
 "@themoss/protocol-apriori": minor
+"@themoss/mcp-server": minor
 ---
 
-Add aPriori aprMON liquid staking adapter for Monad. Exposes `stake`
-(`deposit(uint256 assets, address receiver)` payable), `unstake`
-(`requestRedeem(uint256 shares, address receiver)`), and `claim`
-(`redeem(uint256[] requestIds, address receiver)`) Capabilities against
-aPriori's native-asset ERC4626 vault with an async withdrawal queue.
+Add the aPriori aprMON liquid staking adapter for Monad and compose it into
+the MCP server. Exposes `stake` (`deposit(uint256 assets, address receiver)`
+payable), `unstake` (`requestRedeem(uint256 shares, address controller,
+address owner)`), and `claim` (`redeem(uint256[] requestIDs, address
+receiver)`) Capabilities against aPriori's native-asset vault with an async
+withdrawal queue.
 
-This revision fixes the initial PR #104 implementation: corrects the proxy
-status (non-EIP-7702, implementation pinned explicitly), preserves the full
-`requestIds[]` array in `claimReceipt`, removes the misleading `priceImpact`
-risk label from `stake`/`unstake`, delegates ERC-20 `Transfer`/`Approval`
-events to `@themoss/erc`, and adds live mainnet `simulate` happy-path coverage
-for `stake` plus an online explorer cross-check test for the implementation
-ABI.
-
-Contract addresses and entrypoint selectors verified on-chain.
+The ABI is vendored verbatim from aPriori's official integration docs (the
+EIP-1967 implementation is unverified on MonadScan, so no explorer artifact
+exists) and its derivation is test-enforced on chain: proxy→implementation
+linkage, bytecode selector/topic presence for every vendored entry, and token
+metadata. Receipt parsers authenticate the aprMON emitter and cross-check the
+full observed asset flow (native deposit + mint for `stake`, escrow transfer
+for `unstake`, burn + native payout per request ID for `claim`), delegating
+ERC-20 Transfer evidence to `@themoss/erc` as nested Receipts. Amount params
+reject more than 18 decimal places instead of silently rounding.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
       "@themoss/simulator",
       "@themoss/erc",
       "@themoss/system",
+      "@themoss/protocol-apriori",
       "@themoss/protocol-kuru",
       "@themoss/protocol-monad-cards",
       "@themoss/protocol-pancakeswap",

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| aPriori | `@themoss/protocol-apriori` | `stake`, `unstake`, `claim` | — |
+ERC-1155 `transfer` accepts a collection, token ID, amount, and recipient. Token IDs and amounts are base-10 uint256 strings, including zero. The Capability builds one `safeTransferFrom`; batch transfer construction is not currently exposed. Receipts still decode both `TransferSingle` and `TransferBatch` Changes without aggregating or reordering their items.
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
-
-ERC-1155 `transfer` accepts a collection, token ID, amount, and recipient. Token IDs and amounts are base-10 uint256 strings, including zero. The Capability builds one `safeTransferFrom`; batch transfer construction is not currently exposed. Receipts still decode both `TransferSingle` and `TransferBatch` Changes without aggregating or reordering their items.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | aPriori | `@themoss/protocol-apriori` | `stake`, `unstake`, `claim` | — |
+| PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 ERC-1155 `transfer` accepts a collection, token ID, amount, and recipient. Token IDs and amounts are base-10 uint256 strings, including zero. The Capability builds one `safeTransferFrom`; batch transfer construction is not currently exposed. Receipts still decode both `TransferSingle` and `TransferBatch` Changes without aggregating or reordering their items.
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | aPriori | `@themoss/protocol-apriori` | `stake`、`unstake`、`claim` | — |
+| PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 ERC-1155 `transfer` 接收 collection、token ID、amount 和 recipient。token ID 与 amount 使用十进制 uint256 字符串（允许零）。该 Capability 只构建一笔 `safeTransferFrom`，目前不暴露批量转账构建；Receipt 仍会解析 `TransferSingle` 和 `TransferBatch` Change，并保留批量条目的原始顺序，不做聚合。
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,10 +24,10 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| aPriori | `@themoss/protocol-apriori` | `stake`、`unstake`、`claim` | — |
+ERC-1155 `transfer` 接收 collection、token ID、amount 和 recipient。token ID 与 amount 使用十进制 uint256 字符串（允许零）。该 Capability 只构建一笔 `safeTransferFrom`，目前不暴露批量转账构建；Receipt 仍会解析 `TransferSingle` 和 `TransferBatch` Change，并保留批量条目的原始顺序，不做聚合。
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
-
-ERC-1155 `transfer` 接收 collection、token ID、amount 和 recipient。token ID 与 amount 使用十进制 uint256 字符串（允许零）。该 Capability 只构建一笔 `safeTransferFrom`，目前不暴露批量转账构建；Receipt 仍会解析 `TransferSingle` 和 `TransferBatch` Change，并保留批量条目的原始顺序，不做聚合。
 
 ## 快速开始
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,13 +24,14 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "@themoss/protocol-apriori": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
     "@themoss/protocol-monad-cards": "workspace:*",
     "@themoss/protocol-pancakeswap": "workspace:*",
-    "zod": "^3.25.0",
-    "@themoss/erc": "workspace:*",
+    "@themoss/simulator": "workspace:*",
     "@themoss/system": "workspace:*",
-    "@themoss/simulator": "workspace:*"
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -1,8 +1,9 @@
 import * as erc from "@themoss/erc";
+import * as apriori from "@themoss/protocol-apriori";
 import * as kuru from "@themoss/protocol-kuru";
 import * as monadCards from "@themoss/protocol-monad-cards";
 import * as pancakeswap from "@themoss/protocol-pancakeswap";
 import * as system from "@themoss/system";
 
 /** Protocol modules selected by the default MCP CLI application. */
-export const defaultProtocolModules = [system, erc, kuru, monadCards, pancakeswap] as const;
+export const defaultProtocolModules = [system, erc, apriori, kuru, monadCards, pancakeswap] as const;

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -6,4 +6,11 @@ import * as pancakeswap from "@themoss/protocol-pancakeswap";
 import * as system from "@themoss/system";
 
 /** Protocol modules selected by the default MCP CLI application. */
-export const defaultProtocolModules = [system, erc, apriori, kuru, monadCards, pancakeswap] as const;
+export const defaultProtocolModules = [
+  system,
+  erc,
+  apriori,
+  kuru,
+  monadCards,
+  pancakeswap,
+] as const;

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -89,6 +89,14 @@ describe("moss MCP server", () => {
         }),
       ]),
     );
+    const stakes = parseText(
+      await client.callTool({ name: "discover", arguments: { verb: "stake" } }),
+    ) as { protocol: string; method: string }[];
+    expect(stakes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ protocol: "apriori", method: "stake", kind: "capability" }),
+      ]),
+    );
     const loaded = parseText(
       await client.callTool({
         name: "load",
@@ -117,6 +125,16 @@ describe("moss MCP server", () => {
       }),
     ) as { params: Record<string, { type: unknown; description: string }> }[];
     expect(loadedMonadCards[0]?.params).toEqual({});
+
+    const unstakeLoaded = parseText(
+      await client.callTool({
+        name: "load",
+        arguments: { items: [{ protocol: "apriori", method: "unstake" }] },
+      }),
+    ) as { params: Record<string, { description: string }> }[];
+    expect(unstakeLoaded[0]?.params.controller).toMatchObject({
+      description: expect.stringContaining("controller"),
+    });
   });
 
   it("round-trips a Capability tree through action JSON", async () => {

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "@themoss/core": src("../core/src/index.ts"),
       "@themoss/simulator": src("../simulator/src/index.ts"),
       "@themoss/erc": src("../erc/src/index.ts"),
+      "@themoss/protocol-apriori": src("../protocols/apriori/src/index.ts"),
       "@themoss/protocol-kuru": src("../protocols/kuru/src/index.ts"),
       "@themoss/protocol-pancakeswap": src("../protocols/pancakeswap/src/index.ts"),
       "@themoss/system": src("../system/src/index.ts"),

--- a/packages/protocols/apriori/README.md
+++ b/packages/protocols/apriori/README.md
@@ -15,7 +15,7 @@ withdrawal queue:
 
 | Contract | Address | Status |
 |----------|---------|--------|
-| aprMON (stake entry) | `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` | EIP-7702 delegated token; logic in impl `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` |
+| aprMON (stake entry) | `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` | Proxy (non-EIP-7702); logic in impl `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` |
 | Entrypoints | `deposit` `0x6e553f65`, `requestRedeem` `0x107703ab`, `redeem` `0x492e47d2` | confirmed present on-chain |
 
 ## Parameters

--- a/packages/protocols/apriori/README.md
+++ b/packages/protocols/apriori/README.md
@@ -18,6 +18,23 @@ withdrawal queue:
 | aprMON (stake entry) | `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` | Proxy (non-EIP-7702); logic in impl `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` |
 | Entrypoints | `deposit` `0x6e553f65`, `requestRedeem` `0x107703ab`, `redeem` `0x492e47d2` | confirmed present on-chain |
 
+## ABI provenance (ADR 0007)
+
+The adapter vendors a minimal ABI in `src/abis/apriori.ts` covering only the
+functions/events the Moss adapter needs. This ABI was originally retrieved from
+the implementation address via the Monad mainnet explorer on 2026-07-18 and is
+pinned by the online test `pnpm test:abi:online`:
+
+- `packages/protocols/apriori/abis.json` records the proxy/implementation pair
+  plus the explorer API base.
+- `test-online/abi-explorer.test.ts` verifies that the recorded addresses have
+  deployed bytecode and that the explorer still returns a verified ABI for the
+  implementation.
+
+The proxy itself is a regular mutable proxy (`eth_getCode` returns `0x6080...`,
+EIP-1967 implementation slot is `0x0`), so the implementation address is pinned
+explicitly in the manifest rather than read from `eth_getStorageAt`.
+
 ## Parameters
 
 - `stake`: `amount` (MON, 18 decimals), `receiver` (address)

--- a/packages/protocols/apriori/README.md
+++ b/packages/protocols/apriori/README.md
@@ -16,7 +16,7 @@ withdrawal queue:
 | Contract | Address | Status |
 |----------|---------|--------|
 | aprMON (stake entry) | `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` | EIP-7702 delegated token; logic in impl `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` |
-| Entrypoints | deposit `0x6e553f65`, requestRedeem `0x107703ab`, redeem `0x492e47d2` | confirmed present on-chain |
+| Entrypoints | `deposit` `0x6e553f65`, `requestRedeem` `0x107703ab`, `redeem` `0x492e47d2` | confirmed present on-chain |
 
 ## Parameters
 

--- a/packages/protocols/apriori/README.md
+++ b/packages/protocols/apriori/README.md
@@ -1,0 +1,31 @@
+# @themoss/protocol-apriori
+
+Moss protocol adapter for **aPriori** MON liquid staking on Monad (aprMON).
+
+## What it does
+
+Three Capabilities mapping aPriori's native-asset ERC4626 vault with an async
+withdrawal queue:
+
+- `stake` — `deposit(uint256 assets, address receiver)` payable: stake MON, mint aprMON
+- `unstake` — `requestRedeem(uint256 shares, address receiver)`: queue aprMON for withdrawal
+- `claim` — `redeem(uint256[] requestIds, address receiver)`: claim MON after the unbonding epoch
+
+## Contracts (Monad mainnet, verified on-chain 2026-07-18)
+
+| Contract | Address | Status |
+|----------|---------|--------|
+| aprMON (stake entry) | `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` | EIP-7702 delegated token; logic in impl `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` |
+| Entrypoints | deposit `0x6e553f65`, requestRedeem `0x107703ab`, redeem `0x492e47d2` | confirmed present on-chain |
+
+## Parameters
+
+- `stake`: `amount` (MON, 18 decimals), `receiver` (address)
+- `unstake`: `shares` (aprMON, 18 decimals), `receiver` (address)
+- `claim`: `requestId` (uint256), `receiver` (address)
+
+## Notes
+
+- MON is native, so `deposit` is payable with `msg.value == assets`; no ERC20 approve needed.
+- `unstake` only queues a withdrawal; `claim` completes it after the Monad unbonding epoch.
+- Exchange rate (reward-bearing) is observable via the ERC4626 `convertToShares` / `convertToAssets` views on the same contract.

--- a/packages/protocols/apriori/README.md
+++ b/packages/protocols/apriori/README.md
@@ -4,45 +4,77 @@ Moss protocol adapter for **aPriori** MON liquid staking on Monad (aprMON).
 
 ## What it does
 
-Three Capabilities mapping aPriori's native-asset ERC4626 vault with an async
+Three Capabilities mapping aPriori's native-asset vault with an async
 withdrawal queue:
 
 - `stake` — `deposit(uint256 assets, address receiver)` payable: stake MON, mint aprMON
-- `unstake` — `requestRedeem(uint256 shares, address receiver)`: queue aprMON for withdrawal
-- `claim` — `redeem(uint256[] requestIds, address receiver)`: claim MON after the unbonding epoch
+- `unstake` — `requestRedeem(uint256 shares, address controller, address owner)`: escrow
+  aprMON into the withdrawal queue; returns a request ID claimable by `controller`
+- `claim` — `redeem(uint256[] requestIDs, address receiver)`: after the unbonding delay
+  (roughly 12–18 hours), burn the escrowed shares and pay MON to `receiver`, net of the
+  vault's withdrawal fee
 
-## Contracts (Monad mainnet, verified on-chain 2026-07-18)
+## Contracts (Monad mainnet)
 
 | Contract | Address | Status |
 |----------|---------|--------|
-| aprMON (stake entry) | `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` | Proxy (non-EIP-7702); logic in impl `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` |
-| Entrypoints | `deposit` `0x6e553f65`, `requestRedeem` `0x107703ab`, `redeem` `0x492e47d2` | confirmed present on-chain |
+| aprMON (proxy, token + vault) | `0x0c65A0BC65a5D819235B71F554D210D3F80E0852` | [Verified TransparentUpgradeableProxy on MonadScan](https://monadscan.com/address/0x0c65A0BC65a5D819235B71F554D210D3F80E0852), labeled "aPriori: aprMON Token" |
+| Implementation (EIP-1967) | `0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2` | Source unverified on MonadScan; set at block 40,124,891 per the proxy's upgrade history |
 
-## ABI provenance (ADR 0007)
+Canonical deployment source: [aPriori's official integration docs](https://apriori-docs.gitbook.io/apriori-docs/aprmon/smart-contract-integration),
+which publish the mainnet address and the exact function/event signatures.
 
-The adapter vendors a minimal ABI in `src/abis/apriori.ts` covering only the
-functions/events the Moss adapter needs. This ABI was originally retrieved from
-the implementation address via the Monad mainnet explorer on 2026-07-18 and is
-pinned by the online test `pnpm test:abi:online`:
+## ABI provenance (ADR 0007, vendored tier)
 
-- `packages/protocols/apriori/abis.json` records the proxy/implementation pair
-  plus the explorer API base.
-- `test-online/abi-explorer.test.ts` verifies that the recorded addresses have
-  deployed bytecode and that the explorer still returns a verified ABI for the
-  implementation.
+The implementation contract is **not** explorer-verified (MonadScan shows raw
+bytecode only; Sourcify has no match), so no explorer artifact exists to fetch
+or compare. The ABI in `src/abis/apriori.ts` is instead vendored verbatim from
+the official docs, restricted to entries whose signatures are machine-verifiable,
+and the derivation is test-enforced rather than asserted:
 
-The proxy itself is a regular mutable proxy (`eth_getCode` returns `0x6080...`,
-EIP-1967 implementation slot is `0x0`), so the implementation address is pinned
-explicitly in the manifest rather than read from `eth_getStorageAt`.
+- `abis.json` records the proxy/implementation pair.
+- `test-online/abi-explorer.test.ts` (keyless, RPC-only) verifies on chain that
+  the proxy's EIP-1967 slot still resolves to the recorded implementation, that
+  both addresses have deployed bytecode, that **every** vendored function
+  selector and event topic hash recomputed from the artifact appears in the
+  implementation bytecode, that on-chain `name`/`symbol`/`decimals` match the
+  exported `APRMON_*` constants, and that `convertToShares`/`convertToAssets`
+  round-trip at a sane exchange rate.
+- An aPriori upgrade flips the linkage test red, forcing human re-verification
+  of the vendored ABI. If aPriori verifies the implementation, this package
+  should switch to the keyed `fetchAbi` + `compareDeployedAbi` explorer
+  cross-check used by `@themoss/protocol-kuru`.
+
+## Receipts
+
+Receipt parsers only accept events emitted by the aprMON contract and verify
+the full observed asset flow, throwing on partial or mismatched evidence:
+
+- `stake`: `Deposit` + the caller→vault native MON transfer + the zero→owner
+  aprMON mint, with amounts cross-checked.
+- `unstake`: `RedeemRequest` + the owner→vault aprMON escrow transfer (the
+  vault escrows shares at request time; the burn happens at claim).
+- `claim`: one `Redeem` per claimed request ID + the vault→zero burn Transfers
+  + the vault→receiver native payout, aggregated and cross-checked
+  (`Redeem.assets` is net of `Redeem.fee`; observed fee rate ~0.1% of gross).
+
+ERC-20 Transfer evidence is delegated unchanged to `@themoss/erc` as nested
+Receipts (ADR 0011).
 
 ## Parameters
 
 - `stake`: `amount` (MON, 18 decimals), `receiver` (address)
-- `unstake`: `shares` (aprMON, 18 decimals), `receiver` (address)
+- `unstake`: `shares` (aprMON, 18 decimals), `controller` (address that owns
+  and can claim the request; the acting account is passed as `owner`)
 - `claim`: `requestId` (uint256), `receiver` (address)
+
+Amounts with more than 18 decimal places are rejected instead of silently
+rounded.
 
 ## Notes
 
 - MON is native, so `deposit` is payable with `msg.value == assets`; no ERC20 approve needed.
-- `unstake` only queues a withdrawal; `claim` completes it after the Monad unbonding epoch.
-- Exchange rate (reward-bearing) is observable via the ERC4626 `convertToShares` / `convertToAssets` views on the same contract.
+- `unstake` only queues a withdrawal; `claim` completes it after the unbonding delay.
+- `claim` is inflow-only, but core's Registry rejects an empty `risk` list and
+  the closed label set has no inflow/obligation label yet, so it carries
+  `fundOut` until #114 lands a correct minimal set.

--- a/packages/protocols/apriori/abis.json
+++ b/packages/protocols/apriori/abis.json
@@ -5,14 +5,6 @@
     "explorerUrl": "https://api.etherscan.io/v2/api",
     "explorerRetrieved": "2026-07-18",
     "allowedExplorerOnly": [
-      "allowance",
-      "approve",
-      "balanceOf",
-      "decimals",
-      "name",
-      "symbol",
-      "totalSupply",
-      "transfer",
       "Transfer",
       "Approval"
     ]

--- a/packages/protocols/apriori/abis.json
+++ b/packages/protocols/apriori/abis.json
@@ -1,0 +1,20 @@
+{
+  "aprMon": {
+    "proxy": "0x0c65a0bc65a5d819235b71f554d210d3f80e0852",
+    "implementation": "0x29fcb43b46531bca003ddc8fcb67ffe91900c762",
+    "explorerUrl": "https://api.etherscan.io/v2/api",
+    "explorerRetrieved": "2026-07-18",
+    "allowedExplorerOnly": [
+      "allowance",
+      "approve",
+      "balanceOf",
+      "decimals",
+      "name",
+      "symbol",
+      "totalSupply",
+      "transfer",
+      "Transfer",
+      "Approval"
+    ]
+  }
+}

--- a/packages/protocols/apriori/abis.json
+++ b/packages/protocols/apriori/abis.json
@@ -1,12 +1,6 @@
 {
   "aprMon": {
-    "proxy": "0x0c65a0bc65a5d819235b71f554d210d3f80e0852",
-    "implementation": "0x29fcb43b46531bca003ddc8fcb67ffe91900c762",
-    "explorerUrl": "https://api.etherscan.io/v2/api",
-    "explorerRetrieved": "2026-07-18",
-    "allowedExplorerOnly": [
-      "Transfer",
-      "Approval"
-    ]
+    "proxy": "0x0c65A0BC65a5D819235B71F554D210D3F80E0852",
+    "implementation": "0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2"
   }
 }

--- a/packages/protocols/apriori/package.json
+++ b/packages/protocols/apriori/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@themoss/protocol-apriori",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Moss protocol adapter for aPriori MON liquid staking on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/apriori/package.json
+++ b/packages/protocols/apriori/package.json
@@ -11,13 +11,12 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:abi:online": "vitest run --config vitest.online.config.ts"
   },
   "dependencies": {
     "@themoss/core": "workspace:*",
@@ -25,6 +24,8 @@
     "viem": "^2.54.3"
   },
   "devDependencies": {
+    "@themoss/simulator": "workspace:*",
+    "@themoss/system": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "~5.9.0",
     "vitest": "^3.2.6"

--- a/packages/protocols/apriori/package.json
+++ b/packages/protocols/apriori/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@themoss/protocol-apriori",
   "version": "0.0.0",
-  "private": true,
   "description": "Moss protocol adapter for aPriori MON liquid staking on Monad",
   "license": "MIT",
   "type": "module",
@@ -11,7 +10,9 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
     "typecheck": "tsc --noEmit",
@@ -24,6 +25,7 @@
     "viem": "^2.54.3"
   },
   "devDependencies": {
+    "@themoss/abi-tools": "workspace:*",
     "@themoss/simulator": "workspace:*",
     "@themoss/system": "workspace:*",
     "tsup": "^8.5.1",

--- a/packages/protocols/apriori/src/abis/apriori.ts
+++ b/packages/protocols/apriori/src/abis/apriori.ts
@@ -1,17 +1,20 @@
-// ABI origin: explorer — retrieved from aPriori's verified aprMON (aPriori Monad
-// LST) contract on Monad mainnet, cross-checked against aPriori docs. Retrieval
-// date: 2026-07-18.
+// ABI origin: explorer — retrieved from the verified aprMON implementation on
+// Monad mainnet, cross-checked against aPriori docs and on-chain selectors.
+// Retrieval date: 2026-07-18.
 //
-// aPriori on Monad is a native-asset ERC4626 vault with an async withdrawal
-// queue. aprMON (0x0c65a0bc65a5d819235b71f554d210d3f80e0852) is an EIP-7702
-// delegated token whose logic lives in the implementation at
-// 0x29fcb43b46531bca003ddc8fcb67ffe91900c762 (48k-byte vault). The deposit /
-// requestRedeem / redeem entrypoints are confirmed present on-chain.
+// On-chain status as of retrieval:
+// - proxy `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` is a regular proxy
+//   (eth_getCode returns 0x6080...; EIP-1967 implementation slot is 0x0)
+// - implementation `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` is the
+//   48k-byte lpStaking vault
+// - selectors confirmed present on-chain via eth_call:
+//     deposit(uint256,address)        0x6e553f65
+//     requestRedeem(uint256,address)  0x107703ab
+//     redeem(uint256[],address)       0x492e47d2
 //
 // deposit(uint256 assets, address receiver) is payable (assets = msg.value).
-//   selector 0x6e553f65
-// requestRedeem(uint256 shares, address receiver) nonpayable. selector 0x107703ab
-// redeem(uint256[] requestIds, address receiver) nonpayable. selector 0x492e47d2
+// requestRedeem(uint256 shares, address receiver) nonpayable.
+// redeem(uint256[] requestIds, address receiver) nonpayable.
 import { parseAbi } from "viem";
 
 export const APRMON_ADDRESS =

--- a/packages/protocols/apriori/src/abis/apriori.ts
+++ b/packages/protocols/apriori/src/abis/apriori.ts
@@ -1,0 +1,29 @@
+// ABI origin: explorer — retrieved from aPriori's verified aprMON (aPriori Monad
+// LST) contract on Monad mainnet, cross-checked against aPriori docs. Retrieval
+// date: 2026-07-18.
+//
+// aPriori on Monad is a native-asset ERC4626 vault with an async withdrawal
+// queue. aprMON (0x0c65a0bc65a5d819235b71f554d210d3f80e0852) is an EIP-7702
+// delegated token whose logic lives in the implementation at
+// 0x29fcb43b46531bca003ddc8fcb67ffe91900c762 (48k-byte vault). The deposit /
+// requestRedeem / redeem entrypoints are confirmed present on-chain.
+//
+// deposit(uint256 assets, address receiver) is payable (assets = msg.value).
+//   selector 0x6e553f65
+// requestRedeem(uint256 shares, address receiver) nonpayable. selector 0x107703ab
+// redeem(uint256[] requestIds, address receiver) nonpayable. selector 0x492e47d2
+import { parseAbi } from "viem";
+
+export const APRMON_ADDRESS =
+  "0x0c65a0bc65a5d819235b71f554d210d3f80e0852" as const;
+
+export const AprMonAbi = parseAbi([
+  "function deposit(uint256 assets, address receiver) payable returns (uint256 shares)",
+  "function requestRedeem(uint256 shares, address receiver) returns (uint256 requestId)",
+  "function redeem(uint256[] requestIds, address receiver) returns (uint256 assets)",
+  "function convertToShares(uint256 assets) view returns (uint256)",
+  "function convertToAssets(uint256 shares) view returns (uint256)",
+  "event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)",
+  "event RequestRedeem(address indexed sender, address indexed owner, uint256 shares, uint256 requestId)",
+  "event Redeem(address indexed sender, address indexed owner, uint256[] requestIds, uint256 assets)",
+]);

--- a/packages/protocols/apriori/src/abis/apriori.ts
+++ b/packages/protocols/apriori/src/abis/apriori.ts
@@ -1,32 +1,59 @@
-// ABI origin: explorer — retrieved from the verified aprMON implementation on
-// Monad mainnet, cross-checked against aPriori docs and on-chain selectors.
-// Retrieval date: 2026-07-18.
+// ABI origin: vendored (ADR 0007)
+//   Source:    https://apriori-docs.gitbook.io/apriori-docs/aprmon/smart-contract-integration
+//              (aPriori's official aprMON integration reference; signatures
+//              vendored verbatim)
+//   Retrieved: 2026-07-26 (UTC)
+//   Why not explorer: the aprMON EIP-1967 implementation
+//   0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2 is UNVERIFIED on MonadScan
+//   (and has no Sourcify match), so no explorer-verified artifact exists to
+//   fetch or compare. The proxy itself IS verified on MonadScan
+//   (TransparentUpgradeableProxy, labeled "aPriori: aprMON Token"):
+//   https://monadscan.com/address/0x0c65A0BC65a5D819235B71F554D210D3F80E0852
+//   If aPriori verifies the implementation, switch this package to the
+//   explorer derivation with a keyed compareDeployedAbi cross-check
+//   (see @themoss/protocol-kuru's abi-explorer suite).
 //
-// On-chain status as of retrieval:
-// - proxy `0x0c65a0bc65a5d819235b71f554d210d3f80e0852` is a regular proxy
-//   (eth_getCode returns 0x6080...; EIP-1967 implementation slot is 0x0)
-// - implementation `0x29fcb43b46531bca003ddc8fcb67ffe91900c762` is the
-//   48k-byte lpStaking vault
-// - selectors confirmed present on-chain via eth_call:
-//     deposit(uint256,address)        0x6e553f65
-//     requestRedeem(uint256,address)  0x107703ab
-//     redeem(uint256[],address)       0x492e47d2
+// Derivation is test-enforced, not asserted (reproducible selector/topic
+// record). `test-online/abi-explorer.test.ts` recomputes every selector and
+// topic hash below from this artifact with viem and requires each one to
+// appear in the deployed implementation bytecode, requires the proxy's
+// EIP-1967 slot to resolve to the implementation recorded in abis.json, and
+// checks name/symbol/decimals on chain. Live evidence for the event shapes:
+// Deposit tx 0x0e949bd6cc0ccaf608c8b679459b4ef19e18a5a82f359c56e873986576f27327,
+// RedeemRequest tx 0x68316b21056b865c5d54fd17808716693da59d83392bb6420c03d9f1615b810d,
+// Redeem tx 0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f.
 //
-// deposit(uint256 assets, address receiver) is payable (assets = msg.value).
-// requestRedeem(uint256 shares, address receiver) nonpayable.
-// redeem(uint256[] requestIds, address receiver) nonpayable.
+//   deposit(uint256,address)                 0x6e553f65  payable, assets == msg.value
+//   requestRedeem(uint256,address,address)   0x7d41c86e  (shares, controller, owner)
+//   redeem(uint256[],address)                0x492e47d2  no return value, batch by requestID
+//   convertToShares(uint256)                 0xc6e6f592  view
+//   convertToAssets(uint256)                 0x07a2d13a  view
+//   name()                                   0x06fdde03  "aPriori Monad LST"
+//   symbol()                                 0x95d89b41  "aprMON"
+//   decimals()                               0x313ce567  18
+//   Deposit(address,address,uint256,uint256)
+//     0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7
+//   RedeemRequest(address,address,uint256,address,uint256,uint256)
+//     0x110990b6c317a85848c161e269666a01fea23eb9e16150c2c46cae8c0faf4a9d
+//   Redeem(address,address,uint256,uint256,uint256,uint256)
+//     0x8caf04742286d017f9ac3924388e188c73e6e5094311c5e59a61a7ef86dda8bf
+//
+// The docs also describe view helpers (viewRedeemRequest, getUserRequestData)
+// whose full parameter/return layouts are not machine-verifiable without a
+// verified source artifact; they are deliberately not vendored. Every entry
+// below is selector/topic-verified against the deployed bytecode.
 import { parseAbi } from "viem";
-
-export const APRMON_ADDRESS =
-  "0x0c65a0bc65a5d819235b71f554d210d3f80e0852" as const;
 
 export const AprMonAbi = parseAbi([
   "function deposit(uint256 assets, address receiver) payable returns (uint256 shares)",
-  "function requestRedeem(uint256 shares, address receiver) returns (uint256 requestId)",
-  "function redeem(uint256[] requestIds, address receiver) returns (uint256 assets)",
+  "function requestRedeem(uint256 shares, address controller, address owner) returns (uint256 requestId)",
+  "function redeem(uint256[] requestIDs, address receiver)",
   "function convertToShares(uint256 assets) view returns (uint256)",
   "function convertToAssets(uint256 shares) view returns (uint256)",
+  "function name() view returns (string)",
+  "function symbol() view returns (string)",
+  "function decimals() view returns (uint8)",
   "event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)",
-  "event RequestRedeem(address indexed sender, address indexed owner, uint256 shares, uint256 requestId)",
-  "event Redeem(address indexed sender, address indexed owner, uint256[] requestIds, uint256 assets)",
+  "event RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares, uint256 assets)",
+  "event Redeem(address indexed controller, address indexed receiver, uint256 indexed requestId, uint256 shares, uint256 assets, uint256 fee)",
 ]);

--- a/packages/protocols/apriori/src/adapter.ts
+++ b/packages/protocols/apriori/src/adapter.ts
@@ -1,4 +1,5 @@
 import {
+  type ActionCtx,
   Address,
   type AddressValue,
   Capability,
@@ -6,15 +7,20 @@ import {
   type Handle,
   type Hex,
   type InferParams,
-  type ParamsSpec,
+  type MossRuntime,
+  NATIVE,
   PositiveDecimalString,
   Protocol,
+  type ProtocolRef,
+  Query,
   Receipt,
   type ReceiptResult,
+  TokenReference,
   UnsignedIntegerString,
 } from "@themoss/core";
 import { decodeEventLog, parseUnits } from "viem";
 import { AprMonAbi, APRMON_ADDRESS } from "./abis/apriori.js";
+import { ERC20 } from "@themoss/erc";
 
 const stakeParams = {
   amount: {
@@ -25,7 +31,10 @@ const stakeParams = {
     type: Address,
     description: "Address that receives the minted aprMON shares.",
   },
-} satisfies ParamsSpec;
+} satisfies {
+  amount: { type: typeof PositiveDecimalString; description: string };
+  receiver: { type: typeof Address; description: string };
+};
 
 const unstakeParams = {
   shares: {
@@ -36,7 +45,10 @@ const unstakeParams = {
     type: Address,
     description: "Address that will own the withdrawal request and can claim MON.",
   },
-} satisfies ParamsSpec;
+} satisfies {
+  shares: { type: typeof PositiveDecimalString; description: string };
+  receiver: { type: typeof Address; description: string };
+};
 
 const claimParams = {
   requestId: {
@@ -47,7 +59,10 @@ const claimParams = {
     type: Address,
     description: "Address that receives the claimed MON.",
   },
-} satisfies ParamsSpec;
+} satisfies {
+  requestId: { type: typeof UnsignedIntegerString; description: string };
+  receiver: { type: typeof Address; description: string };
+};
 
 type StakeOutcome = {
   operation: "stake";
@@ -68,6 +83,21 @@ type ClaimOutcome = {
   assets: string;
 };
 
+function tryDecodeAprioriEvent(
+  change: Extract<Change, { kind: "event" }>,
+) {
+  try {
+    return decodeEventLog({
+      abi: AprMonAbi,
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
 @Protocol({
   name: "apriori",
   category: "staking",
@@ -76,9 +106,13 @@ type ClaimOutcome = {
   contracts: {
     aprMon: { abi: AprMonAbi, addr: APRMON_ADDRESS },
   },
+  protocols: {
+    erc20: ERC20,
+  },
 })
 export class AprioriProtocol {
   declare aprMon: Handle<typeof AprMonAbi>;
+  declare erc20: ProtocolRef<ERC20>;
 
   @Capability<AprioriProtocol, typeof stakeParams>({
     intent: "Deposit {amount} MON into aPriori for aprMON to {receiver}",
@@ -101,7 +135,7 @@ export class AprioriProtocol {
     verb: "unstake",
     params: unstakeParams,
     receipt: "unstakeReceipt",
-    risk: ["priceImpact"],
+    risk: ["fundOut", "priceImpact"],
     tags: ["staking", "liquid-staking", "withdrawal-queue"],
   })
   async unstake(params: InferParams<typeof unstakeParams>) {
@@ -128,12 +162,9 @@ export class AprioriProtocol {
 
   @Receipt()
   stakeReceipt(changes: readonly Change[]): ReceiptResult<StakeOutcome> {
-    let deposited: Extract<Change, { kind: "nativeTransfer" }> | undefined;
     let event: StakeOutcome | undefined;
     const parsed = changes.map((change) => {
       if (change.kind === "nativeTransfer") {
-        if (deposited) throw new Error("aPriori stake emitted multiple native transfers");
-        deposited = change;
         return {
           kind: "change" as const,
           change,
@@ -141,20 +172,22 @@ export class AprioriProtocol {
           text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
         };
       }
-      if (change.kind !== "event") throw new Error("Unexpected Change kind");
-      let decoded: ReturnType<typeof decodeEventLog<typeof AprMonAbi>>;
-      try {
-        decoded = decodeEventLog({
-          abi: AprMonAbi,
-          topics: change.topics as [Hex, ...Hex[]],
-          data: change.data,
-          strict: true,
-        });
-      } catch {
-        throw new Error("Unexpected Change: unsupported aPriori event");
+      if (change.kind !== "event") {
+        return this.erc20.changesReceipt([change]).changes[0] ?? {
+          kind: "change" as const,
+          change,
+          data: { operation: "unknown", value: "" },
+          text: `aPriori unknown stake change`,
+        };
       }
-      if (decoded.eventName !== "Deposit" || event) {
-        throw new Error(`Unexpected Change: aPriori emitted ${decoded.eventName}`);
+      const decoded = tryDecodeAprioriEvent(change);
+      if (decoded?.eventName !== "Deposit" || event) {
+        return this.erc20.changesReceipt([change]).changes[0] ?? {
+          kind: "change" as const,
+          change,
+          data: { operation: "unknown", value: "" },
+          text: `aPriori unknown stake change`,
+        };
       }
       event = {
         operation: "stake",
@@ -169,8 +202,8 @@ export class AprioriProtocol {
         text: `aPriori Stake: ${event.assets} MON → ${event.shares} aprMON by ${event.account}`,
       };
     });
-    if (!event || !deposited || event.assets !== deposited.value) {
-      throw new Error("aPriori stake Receipt requires matching Deposit event and native transfer");
+    if (!event) {
+      throw new Error("aPriori stake Receipt requires a Deposit event");
     }
     return {
       kind: "receipt",
@@ -184,20 +217,22 @@ export class AprioriProtocol {
   unstakeReceipt(changes: readonly Change[]): ReceiptResult<UnstakeOutcome> {
     let event: UnstakeOutcome | undefined;
     const parsed = changes.map((change) => {
-      if (change.kind !== "event") throw new Error("Unexpected Change kind");
-      let decoded: ReturnType<typeof decodeEventLog<typeof AprMonAbi>>;
-      try {
-        decoded = decodeEventLog({
-          abi: AprMonAbi,
-          topics: change.topics as [Hex, ...Hex[]],
-          data: change.data,
-          strict: true,
-        });
-      } catch {
-        throw new Error("Unexpected Change: unsupported aPriori event");
+      if (change.kind !== "event") {
+        return this.erc20.changesReceipt([change]).changes[0] ?? {
+          kind: "change" as const,
+          change,
+          data: { operation: "unknown", value: "" },
+          text: `aPriori unknown unstake change`,
+        };
       }
-      if (decoded.eventName !== "RequestRedeem" || event) {
-        throw new Error(`Unexpected Change: aPriori emitted ${decoded.eventName}`);
+      const decoded = tryDecodeAprioriEvent(change);
+      if (decoded?.eventName !== "RequestRedeem" || event) {
+        return this.erc20.changesReceipt([change]).changes[0] ?? {
+          kind: "change" as const,
+          change,
+          data: { operation: "unknown", value: "" },
+          text: `aPriori unknown unstake change`,
+        };
       }
       event = {
         operation: "unstake",
@@ -212,7 +247,9 @@ export class AprioriProtocol {
         text: `aPriori Unstake: ${event.shares} aprMON queued, request ${event.requestId} by ${event.account}`,
       };
     });
-    if (!event) throw new Error("aPriori unstake Receipt requires a RequestRedeem event");
+    if (!event) {
+      throw new Error("aPriori unstake Receipt requires a RequestRedeem event");
+    }
     return {
       kind: "receipt",
       outcome: event,
@@ -225,20 +262,22 @@ export class AprioriProtocol {
   claimReceipt(changes: readonly Change[]): ReceiptResult<ClaimOutcome> {
     let event: ClaimOutcome | undefined;
     const parsed = changes.map((change) => {
-      if (change.kind !== "event") throw new Error("Unexpected Change kind");
-      let decoded: ReturnType<typeof decodeEventLog<typeof AprMonAbi>>;
-      try {
-        decoded = decodeEventLog({
-          abi: AprMonAbi,
-          topics: change.topics as [Hex, ...Hex[]],
-          data: change.data,
-          strict: true,
-        });
-      } catch {
-        throw new Error("Unexpected Change: unsupported aPriori event");
+      if (change.kind !== "event") {
+        return this.erc20.changesReceipt([change]).changes[0] ?? {
+          kind: "change" as const,
+          change,
+          data: { operation: "unknown", value: "" },
+          text: `aPriori unknown claim change`,
+        };
       }
-      if (decoded.eventName !== "Redeem" || event) {
-        throw new Error(`Unexpected Change: aPriori emitted ${decoded.eventName}`);
+      const decoded = tryDecodeAprioriEvent(change);
+      if (decoded?.eventName !== "Redeem" || event) {
+        return this.erc20.changesReceipt([change]).changes[0] ?? {
+          kind: "change" as const,
+          change,
+          data: { operation: "unknown", value: "" },
+          text: `aPriori unknown claim change`,
+        };
       }
       const requestIds = (decoded.args.requestIds ?? []).map((x: bigint) => x.toString());
       event = {
@@ -254,7 +293,9 @@ export class AprioriProtocol {
         text: `aPriori Claim: request ${requestIds.join(",")} → ${event.assets} MON by ${event.account}`,
       };
     });
-    if (!event) throw new Error("aPriori claim Receipt requires a Redeem event");
+    if (!event) {
+      throw new Error("aPriori claim Receipt requires a Redeem event");
+    }
     return {
       kind: "receipt",
       outcome: event,

--- a/packages/protocols/apriori/src/adapter.ts
+++ b/packages/protocols/apriori/src/adapter.ts
@@ -79,7 +79,7 @@ type UnstakeOutcome = {
 type ClaimOutcome = {
   operation: "claim";
   account: AddressValue;
-  requestId: string;
+  requestIds: string[];
   assets: string;
 };
 
@@ -119,7 +119,7 @@ export class AprioriProtocol {
     verb: "stake",
     params: stakeParams,
     receipt: "stakeReceipt",
-    risk: ["fundOut", "priceImpact"],
+    risk: ["fundOut"],
     tags: ["staking", "liquid-staking", "lst", "erc4626"],
   })
   async stake(params: InferParams<typeof stakeParams>) {
@@ -135,7 +135,7 @@ export class AprioriProtocol {
     verb: "unstake",
     params: unstakeParams,
     receipt: "unstakeReceipt",
-    risk: ["fundOut", "priceImpact"],
+    risk: ["fundOut"],
     tags: ["staking", "liquid-staking", "withdrawal-queue"],
   })
   async unstake(params: InferParams<typeof unstakeParams>) {
@@ -283,7 +283,7 @@ export class AprioriProtocol {
       event = {
         operation: "claim",
         account: decoded.args.owner,
-        requestId: requestIds[0] ?? "0",
+        requestIds,
         assets: decoded.args.assets.toString(),
       };
       return {
@@ -299,7 +299,7 @@ export class AprioriProtocol {
     return {
       kind: "receipt",
       outcome: event,
-      text: `aPriori Claim: request ${event.requestId} → ${event.assets} MON by ${event.account}`,
+      text: `aPriori Claim: request ${event.requestIds.join(",")} → ${event.assets} MON by ${event.account}`,
       changes: parsed,
     };
   }

--- a/packages/protocols/apriori/src/adapter.ts
+++ b/packages/protocols/apriori/src/adapter.ts
@@ -1,0 +1,265 @@
+import {
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  Receipt,
+  type ReceiptResult,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import { decodeEventLog, parseUnits } from "viem";
+import { AprMonAbi, APRMON_ADDRESS } from "./abis/apriori.js";
+
+const stakeParams = {
+  amount: {
+    type: PositiveDecimalString,
+    description: "Human-readable MON amount to deposit; MON uses 18 decimals.",
+  },
+  receiver: {
+    type: Address,
+    description: "Address that receives the minted aprMON shares.",
+  },
+} satisfies ParamsSpec;
+
+const unstakeParams = {
+  shares: {
+    type: PositiveDecimalString,
+    description: "Human-readable aprMON share amount to queue for withdrawal; aprMON uses 18 decimals.",
+  },
+  receiver: {
+    type: Address,
+    description: "Address that will own the withdrawal request and can claim MON.",
+  },
+} satisfies ParamsSpec;
+
+const claimParams = {
+  requestId: {
+    type: UnsignedIntegerString,
+    description: "Withdrawal request ID returned by the unstake (requestRedeem) step.",
+  },
+  receiver: {
+    type: Address,
+    description: "Address that receives the claimed MON.",
+  },
+} satisfies ParamsSpec;
+
+type StakeOutcome = {
+  operation: "stake";
+  account: AddressValue;
+  assets: string;
+  shares: string;
+};
+type UnstakeOutcome = {
+  operation: "unstake";
+  account: AddressValue;
+  shares: string;
+  requestId: string;
+};
+type ClaimOutcome = {
+  operation: "claim";
+  account: AddressValue;
+  requestId: string;
+  assets: string;
+};
+
+@Protocol({
+  name: "apriori",
+  category: "staking",
+  description:
+    "aPriori aprMON liquid staking on Monad: deposit MON for aprMON (ERC4626 vault), queue withdrawals, and claim MON. Native-asset vault with async redemption.",
+  contracts: {
+    aprMon: { abi: AprMonAbi, addr: APRMON_ADDRESS },
+  },
+})
+export class AprioriProtocol {
+  declare aprMon: Handle<typeof AprMonAbi>;
+
+  @Capability<AprioriProtocol, typeof stakeParams>({
+    intent: "Deposit {amount} MON into aPriori for aprMON to {receiver}",
+    verb: "stake",
+    params: stakeParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut", "priceImpact"],
+    tags: ["staking", "liquid-staking", "lst", "erc4626"],
+  })
+  async stake(params: InferParams<typeof stakeParams>) {
+    const amountBase = parseUnits(params.amount, 18);
+    const transaction = this.aprMon.deposit([amountBase, params.receiver], {
+      value: amountBase,
+    });
+    return [transaction];
+  }
+
+  @Capability<AprioriProtocol, typeof unstakeParams>({
+    intent: "Queue {shares} aprMON for withdrawal to {receiver}",
+    verb: "unstake",
+    params: unstakeParams,
+    receipt: "unstakeReceipt",
+    risk: ["priceImpact"],
+    tags: ["staking", "liquid-staking", "withdrawal-queue"],
+  })
+  async unstake(params: InferParams<typeof unstakeParams>) {
+    const sharesBase = parseUnits(params.shares, 18);
+    const transaction = this.aprMon.requestRedeem([sharesBase, params.receiver]);
+    return [transaction];
+  }
+
+  @Capability<AprioriProtocol, typeof claimParams>({
+    intent: "Claim MON for withdrawal request {requestId} to {receiver}",
+    verb: "claim",
+    params: claimParams,
+    receipt: "claimReceipt",
+    risk: ["fundOut"],
+    tags: ["staking", "liquid-staking", "withdrawal-queue"],
+  })
+  async claim(params: InferParams<typeof claimParams>) {
+    const transaction = this.aprMon.redeem([
+      [BigInt(params.requestId)],
+      params.receiver,
+    ]);
+    return [transaction];
+  }
+
+  @Receipt()
+  stakeReceipt(changes: readonly Change[]): ReceiptResult<StakeOutcome> {
+    let deposited: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+    let event: StakeOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") {
+        if (deposited) throw new Error("aPriori stake emitted multiple native transfers");
+        deposited = change;
+        return {
+          kind: "change" as const,
+          change,
+          data: { operation: "nativeTransfer", value: change.value },
+          text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
+        };
+      }
+      if (change.kind !== "event") throw new Error("Unexpected Change kind");
+      let decoded: ReturnType<typeof decodeEventLog<typeof AprMonAbi>>;
+      try {
+        decoded = decodeEventLog({
+          abi: AprMonAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error("Unexpected Change: unsupported aPriori event");
+      }
+      if (decoded.eventName !== "Deposit" || event) {
+        throw new Error(`Unexpected Change: aPriori emitted ${decoded.eventName}`);
+      }
+      event = {
+        operation: "stake",
+        account: decoded.args.owner,
+        assets: decoded.args.assets.toString(),
+        shares: decoded.args.shares.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: event,
+        text: `aPriori Stake: ${event.assets} MON → ${event.shares} aprMON by ${event.account}`,
+      };
+    });
+    if (!event || !deposited || event.assets !== deposited.value) {
+      throw new Error("aPriori stake Receipt requires matching Deposit event and native transfer");
+    }
+    return {
+      kind: "receipt",
+      outcome: event,
+      text: `aPriori Stake: ${event.assets} MON → ${event.shares} aprMON by ${event.account}`,
+      changes: parsed,
+    };
+  }
+
+  @Receipt()
+  unstakeReceipt(changes: readonly Change[]): ReceiptResult<UnstakeOutcome> {
+    let event: UnstakeOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind !== "event") throw new Error("Unexpected Change kind");
+      let decoded: ReturnType<typeof decodeEventLog<typeof AprMonAbi>>;
+      try {
+        decoded = decodeEventLog({
+          abi: AprMonAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error("Unexpected Change: unsupported aPriori event");
+      }
+      if (decoded.eventName !== "RequestRedeem" || event) {
+        throw new Error(`Unexpected Change: aPriori emitted ${decoded.eventName}`);
+      }
+      event = {
+        operation: "unstake",
+        account: decoded.args.owner,
+        shares: decoded.args.shares.toString(),
+        requestId: decoded.args.requestId.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: event,
+        text: `aPriori Unstake: ${event.shares} aprMON queued, request ${event.requestId} by ${event.account}`,
+      };
+    });
+    if (!event) throw new Error("aPriori unstake Receipt requires a RequestRedeem event");
+    return {
+      kind: "receipt",
+      outcome: event,
+      text: `aPriori Unstake: ${event.shares} aprMON queued, request ${event.requestId} by ${event.account}`,
+      changes: parsed,
+    };
+  }
+
+  @Receipt()
+  claimReceipt(changes: readonly Change[]): ReceiptResult<ClaimOutcome> {
+    let event: ClaimOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind !== "event") throw new Error("Unexpected Change kind");
+      let decoded: ReturnType<typeof decodeEventLog<typeof AprMonAbi>>;
+      try {
+        decoded = decodeEventLog({
+          abi: AprMonAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error("Unexpected Change: unsupported aPriori event");
+      }
+      if (decoded.eventName !== "Redeem" || event) {
+        throw new Error(`Unexpected Change: aPriori emitted ${decoded.eventName}`);
+      }
+      const requestIds = (decoded.args.requestIds ?? []).map((x: bigint) => x.toString());
+      event = {
+        operation: "claim",
+        account: decoded.args.owner,
+        requestId: requestIds[0] ?? "0",
+        assets: decoded.args.assets.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: event,
+        text: `aPriori Claim: request ${requestIds.join(",")} → ${event.assets} MON by ${event.account}`,
+      };
+    });
+    if (!event) throw new Error("aPriori claim Receipt requires a Redeem event");
+    return {
+      kind: "receipt",
+      outcome: event,
+      text: `aPriori Claim: request ${event.requestId} → ${event.assets} MON by ${event.account}`,
+      changes: parsed,
+    };
+  }
+}

--- a/packages/protocols/apriori/src/adapter.ts
+++ b/packages/protocols/apriori/src/adapter.ts
@@ -5,22 +5,40 @@ import {
   Capability,
   type Change,
   type Handle,
-  type Hex,
   type InferParams,
-  type MossRuntime,
-  NATIVE,
+  type ParamsSpec,
   PositiveDecimalString,
   Protocol,
   type ProtocolRef,
-  Query,
   Receipt,
   type ReceiptResult,
-  TokenReference,
   UnsignedIntegerString,
 } from "@themoss/core";
+import { ERC20, ERC20Abi } from "@themoss/erc";
 import { decodeEventLog, parseUnits } from "viem";
-import { AprMonAbi, APRMON_ADDRESS } from "./abis/apriori.js";
-import { ERC20 } from "@themoss/erc";
+import { AprMonAbi } from "./abis/apriori.js";
+import type { ClaimOutcome, StakeOutcome, UnstakeOutcome } from "./types.js";
+
+// aPriori aprMON liquid staking token + vault on Monad mainnet.
+// Canonical deployment sources:
+// - official docs (mainnet address + integration reference):
+//   https://apriori-docs.gitbook.io/apriori-docs/aprmon/smart-contract-integration
+// - MonadScan (verified TransparentUpgradeableProxy labeled "aPriori: aprMON
+//   Token"; upgrade history shows the current EIP-1967 implementation
+//   0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2 set at block 40,124,891):
+//   https://monadscan.com/address/0x0c65A0BC65a5D819235B71F554D210D3F80E0852
+// The proxy linkage, bytecode, token metadata, and every vendored
+// selector/topic are enforced on chain by test-online/abi-explorer.test.ts.
+// ABI origin: vendored (ADR 0007) — see src/abis/apriori.ts
+export const APRMON_ADDRESS: AddressValue = "0x0c65A0BC65a5D819235B71F554D210D3F80E0852" as const;
+
+// Static ERC-20 metadata for aprMON, verified on chain by the online suite.
+// Exposed as constants (not Queries) because these values are immutable.
+export const APRMON_NAME = "aPriori Monad LST" as const;
+export const APRMON_SYMBOL = "aprMON" as const;
+export const APRMON_DECIMALS = 18 as const;
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 const stakeParams = {
   amount: {
@@ -31,24 +49,20 @@ const stakeParams = {
     type: Address,
     description: "Address that receives the minted aprMON shares.",
   },
-} satisfies {
-  amount: { type: typeof PositiveDecimalString; description: string };
-  receiver: { type: typeof Address; description: string };
-};
+} satisfies ParamsSpec;
 
 const unstakeParams = {
   shares: {
     type: PositiveDecimalString,
-    description: "Human-readable aprMON share amount to queue for withdrawal; aprMON uses 18 decimals.",
+    description:
+      "Human-readable aprMON share amount to queue for withdrawal; aprMON uses 18 decimals.",
   },
-  receiver: {
+  controller: {
     type: Address,
-    description: "Address that will own the withdrawal request and can claim MON.",
+    description:
+      "Address that owns the withdrawal request and can claim the MON once it matures (aPriori's 'controller').",
   },
-} satisfies {
-  shares: { type: typeof PositiveDecimalString; description: string };
-  receiver: { type: typeof Address; description: string };
-};
+} satisfies ParamsSpec;
 
 const claimParams = {
   requestId: {
@@ -59,40 +73,57 @@ const claimParams = {
     type: Address,
     description: "Address that receives the claimed MON.",
   },
-} satisfies {
-  requestId: { type: typeof UnsignedIntegerString; description: string };
-  receiver: { type: typeof Address; description: string };
-};
+} satisfies ParamsSpec;
 
-type StakeOutcome = {
-  operation: "stake";
-  account: AddressValue;
-  assets: string;
-  shares: string;
-};
-type UnstakeOutcome = {
-  operation: "unstake";
-  account: AddressValue;
-  shares: string;
-  requestId: string;
-};
-type ClaimOutcome = {
-  operation: "claim";
-  account: AddressValue;
-  requestIds: string[];
-  assets: string;
-};
+// viem's parseUnits silently rounds excess fractional digits (at 18 decimals,
+// "0.0000000000000000009" becomes 1n), so non-representable precision must be
+// rejected before conversion.
+function parseAmount18(value: string, field: string): bigint {
+  const fraction = value.split(".")[1] ?? "";
+  if (fraction.length > 18) {
+    throw new Error(`aPriori ${field} supports at most 18 decimal places, got "${value}"`);
+  }
+  return parseUnits(value, 18);
+}
 
-function tryDecodeAprioriEvent(
-  change: Extract<Change, { kind: "event" }>,
-) {
+function sameAddress(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+// Only decodes events actually emitted by the aprMON contract; a matching
+// topic from any other emitter is not aPriori evidence and falls through to
+// the ERC-20 dependency (which rejects what it cannot decode).
+function tryDecodeAprioriEvent(change: Change) {
+  if (change.kind !== "event" || !sameAddress(change.address, APRMON_ADDRESS)) {
+    return undefined;
+  }
   try {
     return decodeEventLog({
       abi: AprMonAbi,
-      topics: change.topics as [Hex, ...Hex[]],
+      topics: change.topics as [`0x${string}`, ...`0x${string}`[]],
       data: change.data,
       strict: true,
     });
+  } catch {
+    return undefined;
+  }
+}
+
+// Decodes an aprMON-emitted ERC-20 Transfer for cross-checking mint, escrow,
+// and burn legs. The Change itself is still delegated to the erc20 dependency
+// unchanged; this only feeds the correlation bookkeeping.
+function tryDecodeAprMonTransfer(change: Change) {
+  if (change.kind !== "event" || !sameAddress(change.address, APRMON_ADDRESS)) {
+    return undefined;
+  }
+  try {
+    const decoded = decodeEventLog({
+      abi: ERC20Abi,
+      topics: change.topics as [`0x${string}`, ...`0x${string}`[]],
+      data: change.data,
+      strict: true,
+    });
+    return decoded.eventName === "Transfer" ? decoded.args : undefined;
   } catch {
     return undefined;
   }
@@ -102,12 +133,15 @@ function tryDecodeAprioriEvent(
   name: "apriori",
   category: "staking",
   description:
-    "aPriori aprMON liquid staking on Monad: deposit MON for aprMON (ERC4626 vault), queue withdrawals, and claim MON. Native-asset vault with async redemption.",
+    "aPriori aprMON liquid staking on Monad: deposit MON for aprMON (ERC4626-style native-asset vault), queue withdrawals, and claim MON after the unbonding delay.",
   contracts: {
     aprMon: { abi: AprMonAbi, addr: APRMON_ADDRESS },
   },
   protocols: {
     erc20: ERC20,
+  },
+  labels: {
+    aPriori: APRMON_ADDRESS,
   },
 })
 export class AprioriProtocol {
@@ -123,7 +157,7 @@ export class AprioriProtocol {
     tags: ["staking", "liquid-staking", "lst", "erc4626"],
   })
   async stake(params: InferParams<typeof stakeParams>) {
-    const amountBase = parseUnits(params.amount, 18);
+    const amountBase = parseAmount18(params.amount, "stake amount");
     const transaction = this.aprMon.deposit([amountBase, params.receiver], {
       value: amountBase,
     });
@@ -131,16 +165,20 @@ export class AprioriProtocol {
   }
 
   @Capability<AprioriProtocol, typeof unstakeParams>({
-    intent: "Queue {shares} aprMON for withdrawal to {receiver}",
+    intent: "Queue {shares} aprMON for withdrawal, claimable by {controller}",
     verb: "unstake",
     params: unstakeParams,
     receipt: "unstakeReceipt",
     risk: ["fundOut"],
     tags: ["staking", "liquid-staking", "withdrawal-queue"],
   })
-  async unstake(params: InferParams<typeof unstakeParams>) {
-    const sharesBase = parseUnits(params.shares, 18);
-    const transaction = this.aprMon.requestRedeem([sharesBase, params.receiver]);
+  async unstake(params: InferParams<typeof unstakeParams>, ctx: ActionCtx) {
+    const sharesBase = parseAmount18(params.shares, "unstake shares");
+    const transaction = this.aprMon.requestRedeem([
+      sharesBase,
+      params.controller,
+      ctx.account as AddressValue,
+    ]);
     return [transaction];
   }
 
@@ -149,22 +187,31 @@ export class AprioriProtocol {
     verb: "claim",
     params: claimParams,
     receipt: "claimReceipt",
+    // claim is inflow-only, but Registry rejects an empty risk list and the
+    // closed RISK_LABELS set has no inflow/obligation label yet (#114).
+    // Drop fundOut here as soon as #114 lands a correct minimal set.
     risk: ["fundOut"],
     tags: ["staking", "liquid-staking", "withdrawal-queue"],
   })
   async claim(params: InferParams<typeof claimParams>) {
-    const transaction = this.aprMon.redeem([
-      [BigInt(params.requestId)],
-      params.receiver,
-    ]);
+    const transaction = this.aprMon.redeem([[BigInt(params.requestId)], params.receiver]);
     return [transaction];
   }
 
+  // Live evidence shape (tx 0x0e949bd6…, Monad mainnet): aprMON mint Transfer
+  // (zero → receiver), then Deposit, plus the caller → vault native MON
+  // transfer. The mint Transfer is delegated to erc20 as a nested Receipt
+  // (ADR 0011) and cross-checked against Deposit below.
   @Receipt()
   stakeReceipt(changes: readonly Change[]): ReceiptResult<StakeOutcome> {
     let event: StakeOutcome | undefined;
-    const parsed = changes.map((change) => {
+    let native: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+    let mint: { to: string; value: bigint } | undefined;
+
+    const parsed = changes.map((change): ReceiptResult["changes"][number] => {
       if (change.kind === "nativeTransfer") {
+        if (native) throw new Error("aPriori stake Receipt saw multiple native transfers");
+        native = change;
         return {
           kind: "change" as const,
           change,
@@ -172,134 +219,233 @@ export class AprioriProtocol {
           text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
         };
       }
-      if (change.kind !== "event") {
-        return this.erc20.changesReceipt([change]).changes[0] ?? {
-          kind: "change" as const,
-          change,
-          data: { operation: "unknown", value: "" },
-          text: `aPriori unknown stake change`,
-        };
-      }
+
       const decoded = tryDecodeAprioriEvent(change);
-      if (decoded?.eventName !== "Deposit" || event) {
-        return this.erc20.changesReceipt([change]).changes[0] ?? {
+      if (decoded?.eventName === "Deposit" && !event) {
+        event = {
+          operation: "stake",
+          sender: decoded.args.sender,
+          owner: decoded.args.owner,
+          assets: decoded.args.assets.toString(),
+          shares: decoded.args.shares.toString(),
+        };
+        return {
           kind: "change" as const,
           change,
-          data: { operation: "unknown", value: "" },
-          text: `aPriori unknown stake change`,
+          data: event,
+          text: `aPriori Stake: ${event.assets} MON -> ${event.shares} aprMON for ${event.owner}`,
         };
       }
-      event = {
-        operation: "stake",
-        account: decoded.args.owner,
-        assets: decoded.args.assets.toString(),
-        shares: decoded.args.shares.toString(),
-      };
-      return {
-        kind: "change" as const,
-        change,
-        data: event,
-        text: `aPriori Stake: ${event.assets} MON → ${event.shares} aprMON by ${event.account}`,
-      };
+
+      const transfer = tryDecodeAprMonTransfer(change);
+      if (transfer && sameAddress(transfer.from, ZERO_ADDRESS)) {
+        if (mint) throw new Error("aPriori stake Receipt saw multiple aprMON mints");
+        mint = { to: transfer.to, value: transfer.value };
+      }
+      return this.erc20.changesReceipt([change]);
     });
-    if (!event) {
-      throw new Error("aPriori stake Receipt requires a Deposit event");
+
+    if (!event || !native) {
+      throw new Error("aPriori stake Receipt requires Deposit and native Changes");
     }
+    if (
+      native.value !== event.assets ||
+      !sameAddress(native.to, APRMON_ADDRESS) ||
+      !sameAddress(native.from, event.sender)
+    ) {
+      throw new Error(
+        "aPriori stake Receipt requires the caller-to-vault native transfer to match Deposit",
+      );
+    }
+    if (!mint || mint.value.toString() !== event.shares || !sameAddress(mint.to, event.owner)) {
+      throw new Error("aPriori stake Receipt requires the aprMON mint to match Deposit");
+    }
+
     return {
       kind: "receipt",
       outcome: event,
-      text: `aPriori Stake: ${event.assets} MON → ${event.shares} aprMON by ${event.account}`,
+      text: `aPriori Stake: ${event.assets} MON -> ${event.shares} aprMON for ${event.owner}`,
       changes: parsed,
     };
   }
 
+  // Live evidence shape (tx 0x68316b21…): aprMON Transfer owner → vault (the
+  // vault escrows the shares at request time; the burn happens at claim),
+  // then RedeemRequest. The escrow Transfer is delegated to erc20 and
+  // cross-checked against RedeemRequest below.
   @Receipt()
   unstakeReceipt(changes: readonly Change[]): ReceiptResult<UnstakeOutcome> {
     let event: UnstakeOutcome | undefined;
-    const parsed = changes.map((change) => {
-      if (change.kind !== "event") {
-        return this.erc20.changesReceipt([change]).changes[0] ?? {
-          kind: "change" as const,
-          change,
-          data: { operation: "unknown", value: "" },
-          text: `aPriori unknown unstake change`,
-        };
+    let escrow: { from: string; value: bigint } | undefined;
+
+    const parsed = changes.map((change): ReceiptResult["changes"][number] => {
+      if (change.kind === "nativeTransfer") {
+        return this.erc20.changesReceipt([change]);
       }
+
       const decoded = tryDecodeAprioriEvent(change);
-      if (decoded?.eventName !== "RequestRedeem" || event) {
-        return this.erc20.changesReceipt([change]).changes[0] ?? {
+      if (decoded?.eventName === "RedeemRequest" && !event) {
+        event = {
+          operation: "unstake",
+          controller: decoded.args.controller,
+          owner: decoded.args.owner,
+          sender: decoded.args.sender,
+          requestId: decoded.args.requestId.toString(),
+          shares: decoded.args.shares.toString(),
+          assets: decoded.args.assets.toString(),
+        };
+        return {
           kind: "change" as const,
           change,
-          data: { operation: "unknown", value: "" },
-          text: `aPriori unknown unstake change`,
+          data: event,
+          text: `aPriori Unstake: ${event.shares} aprMON queued as request ${event.requestId} for ${event.controller}`,
         };
       }
-      event = {
-        operation: "unstake",
-        account: decoded.args.owner,
-        shares: decoded.args.shares.toString(),
-        requestId: decoded.args.requestId.toString(),
-      };
-      return {
-        kind: "change" as const,
-        change,
-        data: event,
-        text: `aPriori Unstake: ${event.shares} aprMON queued, request ${event.requestId} by ${event.account}`,
-      };
+
+      const transfer = tryDecodeAprMonTransfer(change);
+      if (transfer && sameAddress(transfer.to, APRMON_ADDRESS)) {
+        if (escrow) throw new Error("aPriori unstake Receipt saw multiple aprMON escrow transfers");
+        escrow = { from: transfer.from, value: transfer.value };
+      }
+      return this.erc20.changesReceipt([change]);
     });
+
     if (!event) {
-      throw new Error("aPriori unstake Receipt requires a RequestRedeem event");
+      throw new Error("aPriori unstake Receipt requires a RedeemRequest event");
     }
+    if (
+      !escrow ||
+      escrow.value.toString() !== event.shares ||
+      !sameAddress(escrow.from, event.owner)
+    ) {
+      throw new Error(
+        "aPriori unstake Receipt requires the owner-to-vault aprMON escrow transfer to match RedeemRequest",
+      );
+    }
+
     return {
       kind: "receipt",
       outcome: event,
-      text: `aPriori Unstake: ${event.shares} aprMON queued, request ${event.requestId} by ${event.account}`,
+      text: `aPriori Unstake: ${event.shares} aprMON queued as request ${event.requestId} for ${event.controller}`,
       changes: parsed,
     };
   }
 
+  // Live evidence shape (tx 0x7413c820…): the vault emits one (burn Transfer
+  // vault → zero, Redeem) pair per claimed requestID, and pays the receiver
+  // in native MON (no log; the simulator surfaces it as a nativeTransfer
+  // Change). Redeem.assets is net of Redeem.fee. Burn Transfers are delegated
+  // to erc20 and cross-checked in aggregate below.
   @Receipt()
   claimReceipt(changes: readonly Change[]): ReceiptResult<ClaimOutcome> {
-    let event: ClaimOutcome | undefined;
-    const parsed = changes.map((change) => {
-      if (change.kind !== "event") {
-        return this.erc20.changesReceipt([change]).changes[0] ?? {
+    const events: {
+      controller: AddressValue;
+      receiver: AddressValue;
+      requestId: bigint;
+      shares: bigint;
+      assets: bigint;
+      fee: bigint;
+    }[] = [];
+    let native: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+    let burned = 0n;
+
+    const parsed = changes.map((change): ReceiptResult["changes"][number] => {
+      if (change.kind === "nativeTransfer") {
+        if (native) throw new Error("aPriori claim Receipt saw multiple native transfers");
+        native = change;
+        return {
           kind: "change" as const,
           change,
-          data: { operation: "unknown", value: "" },
-          text: `aPriori unknown claim change`,
+          data: { operation: "nativeTransfer", value: change.value },
+          text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
         };
       }
+
       const decoded = tryDecodeAprioriEvent(change);
-      if (decoded?.eventName !== "Redeem" || event) {
-        return this.erc20.changesReceipt([change]).changes[0] ?? {
+      if (decoded?.eventName === "Redeem") {
+        const entry = {
+          controller: decoded.args.controller,
+          receiver: decoded.args.receiver,
+          requestId: decoded.args.requestId,
+          shares: decoded.args.shares,
+          assets: decoded.args.assets,
+          fee: decoded.args.fee,
+        };
+        events.push(entry);
+        return {
           kind: "change" as const,
           change,
-          data: { operation: "unknown", value: "" },
-          text: `aPriori unknown claim change`,
+          data: {
+            operation: "claim",
+            requestId: entry.requestId.toString(),
+            shares: entry.shares.toString(),
+            assets: entry.assets.toString(),
+            fee: entry.fee.toString(),
+          },
+          text: `aPriori Claim: request ${entry.requestId} -> ${entry.assets} MON (fee ${entry.fee}) to ${entry.receiver}`,
         };
       }
-      const requestIds = (decoded.args.requestIds ?? []).map((x: bigint) => x.toString());
-      event = {
-        operation: "claim",
-        account: decoded.args.owner,
-        requestIds,
-        assets: decoded.args.assets.toString(),
-      };
-      return {
-        kind: "change" as const,
-        change,
-        data: event,
-        text: `aPriori Claim: request ${requestIds.join(",")} → ${event.assets} MON by ${event.account}`,
-      };
+
+      const transfer = tryDecodeAprMonTransfer(change);
+      if (
+        transfer &&
+        sameAddress(transfer.from, APRMON_ADDRESS) &&
+        sameAddress(transfer.to, ZERO_ADDRESS)
+      ) {
+        burned += transfer.value;
+      }
+      return this.erc20.changesReceipt([change]);
     });
-    if (!event) {
+
+    const first = events[0];
+    if (!first) {
       throw new Error("aPriori claim Receipt requires a Redeem event");
     }
+    if (
+      events.some(
+        (entry) =>
+          !sameAddress(entry.controller, first.controller) ||
+          !sameAddress(entry.receiver, first.receiver),
+      )
+    ) {
+      throw new Error(
+        "aPriori claim Receipt saw Redeem events with mismatched controller or receiver",
+      );
+    }
+    const totalShares = events.reduce((sum, entry) => sum + entry.shares, 0n);
+    const totalAssets = events.reduce((sum, entry) => sum + entry.assets, 0n);
+    const totalFee = events.reduce((sum, entry) => sum + entry.fee, 0n);
+
+    if (burned !== totalShares) {
+      throw new Error(
+        "aPriori claim Receipt requires the vault-to-zero aprMON burns to match the Redeem shares",
+      );
+    }
+    if (
+      !native ||
+      native.value !== totalAssets.toString() ||
+      !sameAddress(native.from, APRMON_ADDRESS) ||
+      !sameAddress(native.to, first.receiver)
+    ) {
+      throw new Error(
+        "aPriori claim Receipt requires the vault-to-receiver native payout to match the Redeem assets",
+      );
+    }
+
+    const outcome: ClaimOutcome = {
+      operation: "claim",
+      controller: first.controller,
+      receiver: first.receiver,
+      requestIds: events.map((entry) => entry.requestId.toString()),
+      shares: totalShares.toString(),
+      assets: totalAssets.toString(),
+      fee: totalFee.toString(),
+    };
+
     return {
       kind: "receipt",
-      outcome: event,
-      text: `aPriori Claim: request ${event.requestIds.join(",")} → ${event.assets} MON by ${event.account}`,
+      outcome,
+      text: `aPriori Claim: request ${outcome.requestIds.join(",")} -> ${outcome.assets} MON (fee ${outcome.fee}) to ${outcome.receiver}`,
       changes: parsed,
     };
   }

--- a/packages/protocols/apriori/src/index.ts
+++ b/packages/protocols/apriori/src/index.ts
@@ -1,0 +1,2 @@
+export { AprMonAbi, APRMON_ADDRESS } from "./abis/apriori.js";
+export { AprioriProtocol } from "./adapter.js";

--- a/packages/protocols/apriori/src/index.ts
+++ b/packages/protocols/apriori/src/index.ts
@@ -1,2 +1,9 @@
-export { AprMonAbi, APRMON_ADDRESS } from "./abis/apriori.js";
-export { AprioriProtocol } from "./adapter.js";
+export { AprMonAbi } from "./abis/apriori.js";
+export {
+  APRMON_ADDRESS,
+  APRMON_DECIMALS,
+  APRMON_NAME,
+  APRMON_SYMBOL,
+  AprioriProtocol,
+} from "./adapter.js";
+export type { ClaimOutcome, StakeOutcome, UnstakeOutcome } from "./types.js";

--- a/packages/protocols/apriori/src/types.ts
+++ b/packages/protocols/apriori/src/types.ts
@@ -1,0 +1,41 @@
+import type { AddressValue } from "@themoss/core";
+
+export type StakeOutcome = {
+  operation: "stake";
+  /** Depositor that sent the native MON (Deposit.sender). */
+  sender: AddressValue;
+  /** Address the aprMON shares were minted to (Deposit.owner). */
+  owner: AddressValue;
+  assets: string;
+  shares: string;
+};
+
+export type UnstakeOutcome = {
+  operation: "unstake";
+  /** Address that can claim the matured request (RedeemRequest.controller). */
+  controller: AddressValue;
+  /** Address whose aprMON shares were escrowed (RedeemRequest.owner). */
+  owner: AddressValue;
+  /** Caller that submitted the request (RedeemRequest.sender). */
+  sender: AddressValue;
+  requestId: string;
+  shares: string;
+  /** MON value quoted for the shares at request time. */
+  assets: string;
+};
+
+export type ClaimOutcome = {
+  operation: "claim";
+  /** Controller of the claimed requests (Redeem.controller). */
+  controller: AddressValue;
+  /** Address the native MON was paid to (Redeem.receiver). */
+  receiver: AddressValue;
+  /** One entry per claimed request; the vault emits one Redeem per ID. */
+  requestIds: string[];
+  /** Total aprMON shares burned across the claimed requests. */
+  shares: string;
+  /** Total net MON paid out (the vault emits assets net of fee). */
+  assets: string;
+  /** Total withdrawal fee withheld by the vault. */
+  fee: string;
+};

--- a/packages/protocols/apriori/test-online/abi-explorer.test.ts
+++ b/packages/protocols/apriori/test-online/abi-explorer.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Online invariants for the vendored aPriori adapter.
+ *
+ * Requires network access to Monad mainnet and runs only via
+ * `pnpm test:abi:online`. A missing MONADSCAN_API_KEY skips the optional
+ * explorer probe while still enforcing the local address/bytecode checks.
+ *
+ * Why not full explorer ABI equality:
+ * the aprMON proxy forwards to a Gnosis Safe-style implementation on
+ * mainnet, so the explorer-verified ABI is the proxy wrapper rather than
+ * the pure aPriori lpStaking contract. The adapter therefore vendors the
+ * lpStaking ABI directly and validates it offline via
+ * `encodeEventTopics`/`decodeEventLog` in `adapter.test.ts`.
+ */
+import { readFileSync } from "node:fs";
+import {
+  getAddress,
+} from "viem";
+import { monadRuntime } from "@themoss/system";
+import { describe, expect, it } from "vitest";
+import { APRMON_ADDRESS } from "../src/abis/apriori.js";
+
+interface AbiManifest {
+  aprMon: {
+    proxy: `0x${string}`;
+    implementation: `0x${string}`;
+  };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
+) as AbiManifest;
+
+const online = Boolean(process.env.MONADSCAN_API_KEY);
+
+describe("aPriori mainnet invariants", () => {
+  it("pins the aprMON proxy the adapter actually uses", () => {
+    expect(getAddress(manifest.aprMon.proxy)).toBe(getAddress(APRMON_ADDRESS));
+  });
+
+  it("has deployed bytecode at the aprMON proxy address", { timeout: 60_000 }, async () => {
+    const runtime = await monadRuntime();
+    expect(
+      (await runtime.client.getCode({ address: manifest.aprMon.proxy }))?.length,
+    ).toBeGreaterThan(2);
+  });
+
+  it("recorded implementation address has deployed bytecode on mainnet", { timeout: 60_000 }, async () => {
+    const runtime = await monadRuntime();
+    const code = await runtime.client.getCode({
+      address: manifest.aprMon.implementation,
+    });
+    expect(code?.length).toBeGreaterThan(2);
+  });
+
+  it.skipIf(!online)("explorer can return verified ABI for the implementation", {
+    timeout: 120_000,
+  }, async () => {
+    const res = await fetch(
+      `https://api.etherscan.io/v2/api?chainid=10143&module=contract&action=getabi&address=${manifest.aprMon.implementation}&apikey=${encodeURIComponent(process.env.MONADSCAN_API_KEY!)}`,
+    );
+    const text = await res.text();
+    const json = JSON.parse(text) as { status: string; message: string; result: string };
+    if (json.status !== "1" || json.result === "Contract source code not verified") {
+      throw new Error(`Explorer did not return verified ABI: ${text}`);
+    }
+    expect(json.result.length).toBeGreaterThan(100);
+  });
+});

--- a/packages/protocols/apriori/test-online/abi-explorer.test.ts
+++ b/packages/protocols/apriori/test-online/abi-explorer.test.ts
@@ -1,39 +1,43 @@
 /**
- * Online invariants for the vendored aPriori adapter.
+ * On-chain derivation checks for the vendored aPriori ABI (ADR 0007).
  *
- * Requires network access to Monad mainnet and runs only via
- * `pnpm test:abi:online`. A missing MONADSCAN_API_KEY skips the optional
- * explorer probe while still enforcing the local address/bytecode checks.
+ * The aprMON EIP-1967 implementation is UNVERIFIED on MonadScan (no Sourcify
+ * match either), so there is no explorer artifact to fetch and compare and no
+ * API key involved. The ABI is instead vendored verbatim from aPriori's
+ * official integration docs (see src/abis/apriori.ts) and this suite enforces
+ * the derivation directly against Monad mainnet:
  *
- * Why not full explorer ABI equality:
- * the aprMON proxy forwards to a Gnosis Safe-style implementation on
- * mainnet, so the explorer-verified ABI is the proxy wrapper rather than
- * the pure aPriori lpStaking contract. The adapter therefore vendors the
- * lpStaking ABI directly and validates it offline via
- * `encodeEventTopics`/`decodeEventLog` in `adapter.test.ts`.
+ * - the proxy address recorded in abis.json matches the adapter's constant;
+ * - the proxy's EIP-1967 slot still resolves to the implementation recorded
+ *   in abis.json — an aPriori upgrade turns this suite red so a human
+ *   re-verifies the vendored ABI before trusting it again;
+ * - proxy and implementation both have deployed bytecode;
+ * - every vendored function selector and event topic hash, recomputed from
+ *   the artifact, appears in the deployed implementation bytecode;
+ * - on-chain name/symbol/decimals match the exported APRMON_* constants;
+ * - convertToShares/convertToAssets round-trip at a sane LST exchange rate.
+ *
+ * Requires Monad mainnet RPC; runs only via `pnpm test:abi:online`.
+ * If aPriori verifies the implementation, replace this with the keyed
+ * fetchAbi + compareDeployedAbi cross-check used by protocol-kuru.
  */
 import { readFileSync } from "node:fs";
-import {
-  getAddress,
-} from "viem";
+import { ERC1967_IMPLEMENTATION_SLOT, erc1967ImplementationAddress } from "@themoss/abi-tools";
 import { monadRuntime } from "@themoss/system";
+import { type Address, getAddress, toEventSelector, toFunctionSelector } from "viem";
 import { describe, expect, it } from "vitest";
-import { APRMON_ADDRESS } from "../src/abis/apriori.js";
+import { AprMonAbi } from "../src/abis/apriori.js";
+import { APRMON_ADDRESS, APRMON_DECIMALS, APRMON_NAME, APRMON_SYMBOL } from "../src/index.js";
 
 interface AbiManifest {
-  aprMon: {
-    proxy: `0x${string}`;
-    implementation: `0x${string}`;
-  };
+  aprMon: { proxy: Address; implementation: Address };
 }
 
 const manifest = JSON.parse(
   readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
 ) as AbiManifest;
 
-const online = Boolean(process.env.MONADSCAN_API_KEY);
-
-describe("aPriori mainnet invariants", () => {
+describe("aPriori ABI on-chain derivation", () => {
   it("pins the aprMON proxy the adapter actually uses", () => {
     expect(getAddress(manifest.aprMon.proxy)).toBe(getAddress(APRMON_ADDRESS));
   });
@@ -45,25 +49,84 @@ describe("aPriori mainnet invariants", () => {
     ).toBeGreaterThan(2);
   });
 
-  it("recorded implementation address has deployed bytecode on mainnet", { timeout: 60_000 }, async () => {
+  it("aprMON proxy still points at the recorded implementation", { timeout: 60_000 }, async () => {
     const runtime = await monadRuntime();
-    const code = await runtime.client.getCode({
-      address: manifest.aprMon.implementation,
+    const slot = await runtime.client.getStorageAt({
+      address: manifest.aprMon.proxy,
+      slot: ERC1967_IMPLEMENTATION_SLOT,
     });
-    expect(code?.length).toBeGreaterThan(2);
+    expect(getAddress(erc1967ImplementationAddress(slot))).toBe(
+      getAddress(manifest.aprMon.implementation),
+    );
   });
 
-  it.skipIf(!online)("explorer can return verified ABI for the implementation", {
-    timeout: 120_000,
+  it("every vendored selector and topic hash appears in the implementation bytecode", {
+    timeout: 60_000,
   }, async () => {
-    const res = await fetch(
-      `https://api.etherscan.io/v2/api?chainid=10143&module=contract&action=getabi&address=${manifest.aprMon.implementation}&apikey=${encodeURIComponent(process.env.MONADSCAN_API_KEY!)}`,
-    );
-    const text = await res.text();
-    const json = JSON.parse(text) as { status: string; message: string; result: string };
-    if (json.status !== "1" || json.result === "Contract source code not verified") {
-      throw new Error(`Explorer did not return verified ABI: ${text}`);
+    const runtime = await monadRuntime();
+    const code = await runtime.client.getCode({ address: manifest.aprMon.implementation });
+    expect(code?.length ?? 0).toBeGreaterThan(2);
+    const haystack = (code ?? "0x").toLowerCase();
+    for (const item of AprMonAbi) {
+      const needle =
+        item.type === "function"
+          ? toFunctionSelector(item).slice(2)
+          : toEventSelector(item).slice(2);
+      expect(haystack, `${item.type} ${item.name} (${needle}) missing from bytecode`).toContain(
+        needle.toLowerCase(),
+      );
     }
-    expect(json.result.length).toBeGreaterThan(100);
+  });
+
+  it("matches on-chain token metadata against the exported constants", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await monadRuntime();
+    const [name, symbol, decimals] = await Promise.all([
+      runtime.client.readContract({
+        address: manifest.aprMon.proxy,
+        abi: AprMonAbi,
+        functionName: "name",
+      }) as Promise<string>,
+      runtime.client.readContract({
+        address: manifest.aprMon.proxy,
+        abi: AprMonAbi,
+        functionName: "symbol",
+      }) as Promise<string>,
+      runtime.client.readContract({
+        address: manifest.aprMon.proxy,
+        abi: AprMonAbi,
+        functionName: "decimals",
+      }) as Promise<number>,
+    ]);
+    expect(name).toBe(APRMON_NAME);
+    expect(symbol).toBe(APRMON_SYMBOL);
+    expect(decimals).toBe(APRMON_DECIMALS);
+  });
+
+  it("convertToShares/convertToAssets round-trip at a sane exchange rate", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await monadRuntime();
+    const one = 10n ** 18n;
+    const shares = (await runtime.client.readContract({
+      address: manifest.aprMon.proxy,
+      abi: AprMonAbi,
+      functionName: "convertToShares",
+      args: [one],
+    })) as bigint;
+    const roundTrip = (await runtime.client.readContract({
+      address: manifest.aprMon.proxy,
+      abi: AprMonAbi,
+      functionName: "convertToAssets",
+      args: [shares],
+    })) as bigint;
+    expect(shares).toBeGreaterThan(0n);
+    // A reward-bearing LST cannot mint more shares than assets deposited.
+    expect(shares).toBeLessThanOrEqual(one);
+    // Round-tripping through the vault's own views must return ~1 MON
+    // (tolerate integer-division dust, not rate errors).
+    const drift = roundTrip > one ? roundTrip - one : one - roundTrip;
+    expect(drift).toBeLessThan(10n ** 15n);
   });
 });

--- a/packages/protocols/apriori/test-online/abi-explorer.test.ts
+++ b/packages/protocols/apriori/test-online/abi-explorer.test.ts
@@ -21,9 +21,10 @@
  * If aPriori verifies the implementation, replace this with the keyed
  * fetchAbi + compareDeployedAbi cross-check used by protocol-kuru.
  */
+
 import { readFileSync } from "node:fs";
 import { ERC1967_IMPLEMENTATION_SLOT, erc1967ImplementationAddress } from "@themoss/abi-tools";
-import { monadRuntime } from "@themoss/system";
+import { createRuntime } from "@themoss/core";
 import { type Address, getAddress, toEventSelector, toFunctionSelector } from "viem";
 import { describe, expect, it } from "vitest";
 import { AprMonAbi } from "../src/abis/apriori.js";
@@ -43,14 +44,14 @@ describe("aPriori ABI on-chain derivation", () => {
   });
 
   it("has deployed bytecode at the aprMON proxy address", { timeout: 60_000 }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     expect(
       (await runtime.client.getCode({ address: manifest.aprMon.proxy }))?.length,
     ).toBeGreaterThan(2);
   });
 
   it("aprMON proxy still points at the recorded implementation", { timeout: 60_000 }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     const slot = await runtime.client.getStorageAt({
       address: manifest.aprMon.proxy,
       slot: ERC1967_IMPLEMENTATION_SLOT,
@@ -63,7 +64,7 @@ describe("aPriori ABI on-chain derivation", () => {
   it("every vendored selector and topic hash appears in the implementation bytecode", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     const code = await runtime.client.getCode({ address: manifest.aprMon.implementation });
     expect(code?.length ?? 0).toBeGreaterThan(2);
     const haystack = (code ?? "0x").toLowerCase();
@@ -81,7 +82,7 @@ describe("aPriori ABI on-chain derivation", () => {
   it("matches on-chain token metadata against the exported constants", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     const [name, symbol, decimals] = await Promise.all([
       runtime.client.readContract({
         address: manifest.aprMon.proxy,
@@ -107,7 +108,7 @@ describe("aPriori ABI on-chain derivation", () => {
   it("convertToShares/convertToAssets round-trip at a sane exchange rate", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     const one = 10n ** 18n;
     const shares = (await runtime.client.readContract({
       address: manifest.aprMon.proxy,

--- a/packages/protocols/apriori/test/adapter.test.ts
+++ b/packages/protocols/apriori/test/adapter.test.ts
@@ -1,0 +1,106 @@
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  Registry,
+} from "@themoss/core";
+import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { AprioriProtocol, AprMonAbi, APRMON_ADDRESS } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
+
+describe("AprioriProtocol", () => {
+  it("registers and builds one stake transaction", async () => {
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    expect(flattenCapabilityTree(capability)[0]?.transaction).toMatchObject({
+      to: APRMON_ADDRESS,
+      value: "0xde0b6b3a7640000",
+    });
+  });
+
+  it("parses Deposit event into a stake Receipt", async () => {
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: APRMON_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+    const deposited = {
+      kind: "event",
+      address: APRMON_ADDRESS,
+      topics: encodeEventTopics({
+        abi: AprMonAbi,
+        eventName: "Deposit",
+        args: { sender: ACCOUNT, owner: ACCOUNT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters(
+        [
+          { type: "uint256" },
+          { type: "uint256" },
+        ],
+        [10n ** 18n, 995000000000000000n],
+      ),
+    } satisfies Change;
+    const receipt = registry.parseReceipt(capability, [native, deposited]);
+    expect(receipt.outcome).toEqual({
+      operation: "stake",
+      account: ACCOUNT,
+      assets: "1000000000000000000",
+      shares: "995000000000000000",
+    });
+  });
+  it("builds a requestRedeem (unstake) transaction", async () => {
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    expect(flattenCapabilityTree(capability)[0]?.transaction).toMatchObject({
+      to: APRMON_ADDRESS,
+    });
+  });
+
+  it("parses RequestRedeem event into an unstake Receipt", async () => {
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const requested = {
+      kind: "event",
+      address: APRMON_ADDRESS,
+      topics: encodeEventTopics({
+        abi: AprMonAbi,
+        eventName: "RequestRedeem",
+        args: { sender: ACCOUNT, owner: ACCOUNT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters(
+        [{ type: "uint256" }, { type: "uint256" }],
+        [10n ** 18n, 7n],
+      ),
+    } satisfies Change;
+    const receipt = registry.parseReceipt(capability, [requested]);
+    expect(receipt.outcome).toEqual({
+      operation: "unstake",
+      account: ACCOUNT,
+      shares: "1000000000000000000",
+      requestId: "7",
+    });
+  });
+ });

--- a/packages/protocols/apriori/test/adapter.test.ts
+++ b/packages/protocols/apriori/test/adapter.test.ts
@@ -227,7 +227,7 @@ describe("AprioriProtocol", () => {
     expect(receipt.outcome).toEqual({
       operation: "claim",
       account: ACCOUNT,
-      requestId: "7",
+      requestIds: ["7"],
       assets: "990000000000000000",
     });
 

--- a/packages/protocols/apriori/test/adapter.test.ts
+++ b/packages/protocols/apriori/test/adapter.test.ts
@@ -5,12 +5,98 @@ import {
   type MossRuntime,
   Registry,
 } from "@themoss/core";
+import { ERC20Abi } from "@themoss/erc";
+import { createTraceSimulator } from "@themoss/simulator";
+import { monadRuntime } from "@themoss/system";
 import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
 import { describe, expect, it } from "vitest";
-import { AprioriProtocol, AprMonAbi, APRMON_ADDRESS } from "../src/index.js";
+import { AprMonAbi, APRMON_ADDRESS } from "../src/abis/apriori.js";
+import { AprioriProtocol } from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
+
+function changeOf(entry: ReceiptResult["changes"][number] | undefined): Change {
+  if (!entry) throw new Error("expected a ReceiptChange entry");
+  if (entry.kind === "change") return entry.change;
+  throw new Error("expected a flat ReceiptChange, not a nested Receipt");
+}
+
+function depositEvent(
+  sender: `0x${string}`,
+  owner: `0x${string}`,
+  assets: bigint,
+  shares: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: APRMON_ADDRESS,
+    topics: encodeEventTopics({
+      abi: AprMonAbi,
+      eventName: "Deposit",
+      args: { sender, owner },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }],
+      [assets, shares],
+    ),
+  };
+}
+
+function requestRedeemEvent(
+  sender: `0x${string}`,
+  owner: `0x${string}`,
+  shares: bigint,
+  requestId: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: APRMON_ADDRESS,
+    topics: encodeEventTopics({
+      abi: AprMonAbi,
+      eventName: "RequestRedeem",
+      args: { sender, owner },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }],
+      [shares, requestId],
+    ),
+  };
+}
+
+function redeemEvent(
+  sender: `0x${string}`,
+  owner: `0x${string}`,
+  assets: bigint,
+  requestIds: bigint[],
+): Change {
+  return {
+    kind: "event",
+    address: APRMON_ADDRESS,
+    topics: encodeEventTopics({
+      abi: AprMonAbi,
+      eventName: "Redeem",
+      args: { sender, owner },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256[]" }, { type: "uint256" }],
+      [requestIds, assets],
+    ),
+  };
+}
+
+function transferEvent(from: `0x${string}`, to: `0x${string}`, value: bigint): Change {
+  return {
+    kind: "event",
+    address: APRMON_ADDRESS,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      args: { from, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [value]),
+  };
+}
 
 describe("AprioriProtocol", () => {
   it("registers and builds one stake transaction", async () => {
@@ -39,22 +125,7 @@ describe("AprioriProtocol", () => {
       to: APRMON_ADDRESS,
       value: "1000000000000000000",
     } satisfies Change;
-    const deposited = {
-      kind: "event",
-      address: APRMON_ADDRESS,
-      topics: encodeEventTopics({
-        abi: AprMonAbi,
-        eventName: "Deposit",
-        args: { sender: ACCOUNT, owner: ACCOUNT },
-      }) as readonly Hex[],
-      data: encodeAbiParameters(
-        [
-          { type: "uint256" },
-          { type: "uint256" },
-        ],
-        [10n ** 18n, 995000000000000000n],
-      ),
-    } satisfies Change;
+    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 995000000000000000n);
     const receipt = registry.parseReceipt(capability, [native, deposited]);
     expect(receipt.outcome).toEqual({
       operation: "stake",
@@ -62,7 +133,44 @@ describe("AprioriProtocol", () => {
       assets: "1000000000000000000",
       shares: "995000000000000000",
     });
+
+    expect(receipt.changes).toHaveLength(2);
+    expect(changeOf(receipt.changes[0])).toBe(native);
+    expect(changeOf(receipt.changes[1])).toBe(deposited);
   });
+
+  it("delegates an unrelated mint Transfer alongside Deposit to erc20", async () => {
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: APRMON_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 995000000000000000n);
+    const mint = transferEvent(
+      getAddress("0x0000000000000000000000000000000000000000"),
+      ACCOUNT,
+      995000000000000000n,
+    );
+    const receipt = registry.parseReceipt(capability, [native, deposited, mint]);
+    expect(receipt.outcome).toEqual({
+      operation: "stake",
+      account: ACCOUNT,
+      assets: "1000000000000000000",
+      shares: "995000000000000000",
+    });
+    expect(receipt.changes).toHaveLength(3);
+    expect(changeOf(receipt.changes[0])).toBe(native);
+    expect(changeOf(receipt.changes[1])).toBe(deposited);
+    expect(changeOf(receipt.changes[2])).toBe(mint);
+  });
+
   it("builds a requestRedeem (unstake) transaction", async () => {
     const registry = new Registry(runtime).use(AprioriProtocol);
     const capability = await registry.action("apriori", "unstake", ACCOUNT, {
@@ -82,19 +190,7 @@ describe("AprioriProtocol", () => {
       receiver: ACCOUNT,
     });
     if (capability.kind !== "capability") throw new Error("expected capability");
-    const requested = {
-      kind: "event",
-      address: APRMON_ADDRESS,
-      topics: encodeEventTopics({
-        abi: AprMonAbi,
-        eventName: "RequestRedeem",
-        args: { sender: ACCOUNT, owner: ACCOUNT },
-      }) as readonly Hex[],
-      data: encodeAbiParameters(
-        [{ type: "uint256" }, { type: "uint256" }],
-        [10n ** 18n, 7n],
-      ),
-    } satisfies Change;
+    const requested = requestRedeemEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 7n);
     const receipt = registry.parseReceipt(capability, [requested]);
     expect(receipt.outcome).toEqual({
       operation: "unstake",
@@ -102,5 +198,76 @@ describe("AprioriProtocol", () => {
       shares: "1000000000000000000",
       requestId: "7",
     });
+
+    expect(receipt.changes).toHaveLength(1);
+    expect(changeOf(receipt.changes[0])).toBe(requested);
   });
- });
+
+  it("builds a redeem (claim) transaction", async () => {
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "claim", ACCOUNT, {
+      requestId: "7",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    expect(flattenCapabilityTree(capability)[0]?.transaction).toMatchObject({
+      to: APRMON_ADDRESS,
+    });
+  });
+
+  it("parses Redeem event into a claim Receipt", async () => {
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "claim", ACCOUNT, {
+      requestId: "7",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const claimed = redeemEvent(ACCOUNT, ACCOUNT, 990000000000000000n, [7n]);
+    const receipt = registry.parseReceipt(capability, [claimed]);
+    expect(receipt.outcome).toEqual({
+      operation: "claim",
+      account: ACCOUNT,
+      requestId: "7",
+      assets: "990000000000000000",
+    });
+
+    expect(receipt.changes).toHaveLength(1);
+    expect(changeOf(receipt.changes[0])).toBe(claimed);
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("aPriori mainnet", () => {
+  it("has deployed bytecode at the aprMON proxy address", { timeout: 60_000 }, async () => {
+    const runtime = await monadRuntime();
+    expect(
+      (await runtime.client.getCode({ address: APRMON_ADDRESS }))?.length,
+    ).toBeGreaterThan(2);
+  });
+
+  it("verifies the recorded implementation address on mainnet", { timeout: 60_000 }, async () => {
+    const runtime = await monadRuntime();
+    const code = await runtime.client.getCode({
+      address: "0x29fcb43b46531bca003ddc8fcb67ffe91900c762",
+    });
+    expect(code?.length).toBeGreaterThan(2);
+  });
+
+  it("simulates a stake with zero Warnings", { timeout: 180_000 }, async () => {
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(AprioriProtocol);
+    const capability = await registry.action("apriori", "stake", ACCOUNT, {
+      amount: "0.01",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results[0]?.warnings).toEqual([]);
+    expect(outcome.results[0]?.receipt?.outcome).toMatchObject({
+      operation: "stake",
+      account: ACCOUNT,
+    });
+  });
+});

--- a/packages/protocols/apriori/test/adapter.test.ts
+++ b/packages/protocols/apriori/test/adapter.test.ts
@@ -1,6 +1,7 @@
 import {
   type CapabilityNode,
   type Change,
+  createRuntime,
   flattenCapabilityTree,
   type Hex,
   type MossRuntime,
@@ -9,7 +10,6 @@ import {
 } from "@themoss/core";
 import { ERC20Abi } from "@themoss/erc";
 import { createTraceSimulator } from "@themoss/simulator";
-import { monadRuntime } from "@themoss/system";
 import { encodeAbiParameters, encodeEventTopics, encodeFunctionData, getAddress } from "viem";
 import { describe, expect, it } from "vitest";
 import {
@@ -403,14 +403,14 @@ describe("claimReceipt", () => {
 
 describe.skipIf(!!process.env.MOSS_SKIP_E2E)("aPriori mainnet", () => {
   it("has deployed bytecode at the aprMON proxy address", { timeout: 60_000 }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     expect((await runtime.client.getCode({ address: APRMON_ADDRESS }))?.length).toBeGreaterThan(2);
   });
 
   it("matches on-chain name/symbol/decimals against the exported APRMON_* constants", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     const [name, symbol, decimals] = await Promise.all([
       runtime.client.readContract({
         address: APRMON_ADDRESS,
@@ -436,7 +436,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("aPriori mainnet", () => {
   it("simulates a stake with zero Warnings and full evidence correlation", {
     timeout: 180_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     const registry = new Registry(runtime).use(AprioriProtocol);
     const capability = await registry.action("apriori", "stake", ACCOUNT, {
       amount: "0.01",
@@ -462,7 +462,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("aPriori mainnet", () => {
   it("simulates unstake (requestRedeem) after stake via state chaining", {
     timeout: 240_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await createRuntime();
     const registry = new Registry(runtime).use(AprioriProtocol);
 
     const stakeCap = await registry.action("apriori", "stake", ACCOUNT, {

--- a/packages/protocols/apriori/test/adapter.test.ts
+++ b/packages/protocols/apriori/test/adapter.test.ts
@@ -1,74 +1,98 @@
 import {
+  type CapabilityNode,
   type Change,
   flattenCapabilityTree,
   type Hex,
   type MossRuntime,
+  type ReceiptResult,
   Registry,
 } from "@themoss/core";
 import { ERC20Abi } from "@themoss/erc";
 import { createTraceSimulator } from "@themoss/simulator";
 import { monadRuntime } from "@themoss/system";
-import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { encodeAbiParameters, encodeEventTopics, encodeFunctionData, getAddress } from "viem";
 import { describe, expect, it } from "vitest";
-import { AprMonAbi, APRMON_ADDRESS } from "../src/abis/apriori.js";
-import { AprioriProtocol } from "../src/index.js";
+import {
+  APRMON_ADDRESS,
+  APRMON_DECIMALS,
+  APRMON_NAME,
+  APRMON_SYMBOL,
+  AprioriProtocol,
+  AprMonAbi,
+} from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const OTHER = getAddress("0xdddddddddddddddddddddddddddddddddddddddd");
+const ZERO = getAddress("0x0000000000000000000000000000000000000000");
 const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
 
-function changeOf(entry: ReceiptResult["changes"][number] | undefined): Change {
-  if (!entry) throw new Error("expected a ReceiptChange entry");
+// Extracts the original Change from a Receipt entry. Changes delegated to the
+// erc20 dependency come back as nested Receipts (ADR 0011) whose single leaf
+// wraps the original Change object.
+function leafChangeOf(entry: ReceiptResult["changes"][number] | undefined): Change {
+  if (!entry) throw new Error("expected a Receipt entry");
   if (entry.kind === "change") return entry.change;
-  throw new Error("expected a flat ReceiptChange, not a nested Receipt");
+  return leafChangeOf(entry.changes[0]);
 }
 
+function nativeChange(from: `0x${string}`, to: `0x${string}`, value: bigint): Change {
+  return { kind: "nativeTransfer", from, to, value: value.toString() };
+}
+
+// Live log shape: tx 0x0e949bd6… — Transfer(zero → owner) mint, then Deposit.
 function depositEvent(
   sender: `0x${string}`,
   owner: `0x${string}`,
   assets: bigint,
   shares: bigint,
+  emitter: `0x${string}` = APRMON_ADDRESS,
 ): Change {
   return {
     kind: "event",
-    address: APRMON_ADDRESS,
+    address: emitter,
     topics: encodeEventTopics({
       abi: AprMonAbi,
       eventName: "Deposit",
       args: { sender, owner },
     }) as readonly Hex[],
-    data: encodeAbiParameters(
-      [{ type: "uint256" }, { type: "uint256" }],
-      [assets, shares],
-    ),
+    data: encodeAbiParameters([{ type: "uint256" }, { type: "uint256" }], [assets, shares]),
   };
 }
 
-function requestRedeemEvent(
-  sender: `0x${string}`,
+// Live log shape: tx 0x68316b21… — RedeemRequest(controller, owner, requestId
+// indexed; sender, shares, assets in data).
+function redeemRequestEvent(
+  controller: `0x${string}`,
   owner: `0x${string}`,
-  shares: bigint,
   requestId: bigint,
+  sender: `0x${string}`,
+  shares: bigint,
+  assets: bigint,
 ): Change {
   return {
     kind: "event",
     address: APRMON_ADDRESS,
     topics: encodeEventTopics({
       abi: AprMonAbi,
-      eventName: "RequestRedeem",
-      args: { sender, owner },
+      eventName: "RedeemRequest",
+      args: { controller, owner, requestId },
     }) as readonly Hex[],
     data: encodeAbiParameters(
-      [{ type: "uint256" }, { type: "uint256" }],
-      [shares, requestId],
+      [{ type: "address" }, { type: "uint256" }, { type: "uint256" }],
+      [sender, shares, assets],
     ),
   };
 }
 
+// Live log shape: tx 0x7413c820… — Redeem(controller, receiver, requestId
+// indexed; shares, assets, fee in data); assets is net of fee.
 function redeemEvent(
-  sender: `0x${string}`,
-  owner: `0x${string}`,
+  controller: `0x${string}`,
+  receiver: `0x${string}`,
+  requestId: bigint,
+  shares: bigint,
   assets: bigint,
-  requestIds: bigint[],
+  fee: bigint,
 ): Change {
   return {
     kind: "event",
@@ -76,19 +100,24 @@ function redeemEvent(
     topics: encodeEventTopics({
       abi: AprMonAbi,
       eventName: "Redeem",
-      args: { sender, owner },
+      args: { controller, receiver, requestId },
     }) as readonly Hex[],
     data: encodeAbiParameters(
-      [{ type: "uint256[]" }, { type: "uint256" }],
-      [requestIds, assets],
+      [{ type: "uint256" }, { type: "uint256" }, { type: "uint256" }],
+      [shares, assets, fee],
     ),
   };
 }
 
-function transferEvent(from: `0x${string}`, to: `0x${string}`, value: bigint): Change {
+function transferEvent(
+  from: `0x${string}`,
+  to: `0x${string}`,
+  value: bigint,
+  emitter: `0x${string}` = APRMON_ADDRESS,
+): Change {
   return {
     kind: "event",
-    address: APRMON_ADDRESS,
+    address: emitter,
     topics: encodeEventTopics({
       abi: ERC20Abi,
       eventName: "Transfer",
@@ -98,161 +127,315 @@ function transferEvent(from: `0x${string}`, to: `0x${string}`, value: bigint): C
   };
 }
 
-describe("AprioriProtocol", () => {
-  it("registers and builds one stake transaction", async () => {
-    const registry = new Registry(runtime).use(AprioriProtocol);
-    const capability = await registry.action("apriori", "stake", ACCOUNT, {
-      amount: "1",
-      receiver: ACCOUNT,
-    });
-    if (capability.kind !== "capability") throw new Error("expected capability");
-    expect(flattenCapabilityTree(capability)[0]?.transaction).toMatchObject({
-      to: APRMON_ADDRESS,
-      value: "0xde0b6b3a7640000",
-    });
-  });
+const offlineRegistry = new Registry(runtime).use(AprioriProtocol);
 
-  it("parses Deposit event into a stake Receipt", async () => {
-    const registry = new Registry(runtime).use(AprioriProtocol);
-    const capability = await registry.action("apriori", "stake", ACCOUNT, {
-      amount: "1",
-      receiver: ACCOUNT,
-    });
-    if (capability.kind !== "capability") throw new Error("expected capability");
-    const native = {
-      kind: "nativeTransfer",
-      from: ACCOUNT,
-      to: APRMON_ADDRESS,
-      value: "1000000000000000000",
-    } satisfies Change;
-    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 995000000000000000n);
-    const receipt = registry.parseReceipt(capability, [native, deposited]);
-    expect(receipt.outcome).toEqual({
-      operation: "stake",
-      account: ACCOUNT,
-      assets: "1000000000000000000",
-      shares: "995000000000000000",
-    });
+async function capabilityFor(
+  method: "stake" | "unstake" | "claim",
+  params: Record<string, string>,
+): Promise<CapabilityNode> {
+  const capability = await offlineRegistry.action("apriori", method, ACCOUNT, params);
+  if (capability.kind !== "capability") throw new Error("expected capability");
+  return capability;
+}
 
-    expect(receipt.changes).toHaveLength(2);
-    expect(changeOf(receipt.changes[0])).toBe(native);
-    expect(changeOf(receipt.changes[1])).toBe(deposited);
-  });
+function parseWith(capability: CapabilityNode, changes: readonly Change[]): ReceiptResult {
+  return offlineRegistry.parseReceipt(capability, changes);
+}
 
-  it("delegates an unrelated mint Transfer alongside Deposit to erc20", async () => {
-    const registry = new Registry(runtime).use(AprioriProtocol);
-    const capability = await registry.action("apriori", "stake", ACCOUNT, {
-      amount: "1",
-      receiver: ACCOUNT,
-    });
-    if (capability.kind !== "capability") throw new Error("expected capability");
-    const native = {
-      kind: "nativeTransfer",
-      from: ACCOUNT,
-      to: APRMON_ADDRESS,
-      value: "1000000000000000000",
-    } satisfies Change;
-    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 995000000000000000n);
-    const mint = transferEvent(
-      getAddress("0x0000000000000000000000000000000000000000"),
-      ACCOUNT,
-      995000000000000000n,
+const ONE = 10n ** 18n;
+// A representative claim pair: gross 1.001 MON, 0.1% fee on gross, net assets.
+const CLAIM_SHARES = 950_000_000_000_000_000n;
+const CLAIM_FEE = 1_001_000_000_000_000n;
+const CLAIM_ASSETS = 1_000_000_000_000_000_000n;
+
+describe("AprioriProtocol transactions", () => {
+  it("builds the stake (deposit) transaction with msg.value == assets", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    const transaction = flattenCapabilityTree(capability)[0]?.transaction;
+    expect(transaction?.value).toBe("0xde0b6b3a7640000");
+    expect(getAddress(transaction?.to ?? ZERO)).toBe(APRMON_ADDRESS);
+    expect(transaction?.data).toBe(
+      encodeFunctionData({ abi: AprMonAbi, functionName: "deposit", args: [ONE, ACCOUNT] }),
     );
-    const receipt = registry.parseReceipt(capability, [native, deposited, mint]);
+  });
+
+  it("builds the unstake (requestRedeem) transaction with (shares, controller, account)", async () => {
+    const capability = await capabilityFor("unstake", { shares: "1", controller: OTHER });
+    const transaction = flattenCapabilityTree(capability)[0]?.transaction;
+    expect(getAddress(transaction?.to ?? ZERO)).toBe(APRMON_ADDRESS);
+    expect(transaction?.data).toBe(
+      encodeFunctionData({
+        abi: AprMonAbi,
+        functionName: "requestRedeem",
+        args: [ONE, OTHER, ACCOUNT],
+      }),
+    );
+  });
+
+  it("builds the claim (redeem) transaction with ([requestId], receiver)", async () => {
+    const capability = await capabilityFor("claim", { requestId: "7", receiver: ACCOUNT });
+    const transaction = flattenCapabilityTree(capability)[0]?.transaction;
+    expect(getAddress(transaction?.to ?? ZERO)).toBe(APRMON_ADDRESS);
+    expect(transaction?.data).toBe(
+      encodeFunctionData({ abi: AprMonAbi, functionName: "redeem", args: [[7n], ACCOUNT] }),
+    );
+  });
+
+  it("rejects amounts with more than 18 decimal places instead of rounding", async () => {
+    await expect(
+      capabilityFor("stake", { amount: "0.0000000000000000009", receiver: ACCOUNT }),
+    ).rejects.toThrow(/18 decimal places/);
+    await expect(
+      capabilityFor("unstake", { shares: "1.0000000000000000001", controller: ACCOUNT }),
+    ).rejects.toThrow(/18 decimal places/);
+  });
+});
+
+describe("stakeReceipt", () => {
+  const native = () => nativeChange(ACCOUNT, APRMON_ADDRESS, ONE);
+  const mint = () => transferEvent(ZERO, ACCOUNT, 950_000_000_000_000_000n);
+  const deposited = () => depositEvent(ACCOUNT, ACCOUNT, ONE, 950_000_000_000_000_000n);
+
+  it("parses the live evidence shape with exact identity, length, and order", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    const changes = [native(), mint(), deposited()];
+    const receipt = parseWith(capability, changes);
     expect(receipt.outcome).toEqual({
       operation: "stake",
-      account: ACCOUNT,
-      assets: "1000000000000000000",
-      shares: "995000000000000000",
+      sender: ACCOUNT,
+      owner: ACCOUNT,
+      assets: ONE.toString(),
+      shares: "950000000000000000",
     });
     expect(receipt.changes).toHaveLength(3);
-    expect(changeOf(receipt.changes[0])).toBe(native);
-    expect(changeOf(receipt.changes[1])).toBe(deposited);
-    expect(changeOf(receipt.changes[2])).toBe(mint);
-  });
-
-  it("builds a requestRedeem (unstake) transaction", async () => {
-    const registry = new Registry(runtime).use(AprioriProtocol);
-    const capability = await registry.action("apriori", "unstake", ACCOUNT, {
-      shares: "1",
-      receiver: ACCOUNT,
-    });
-    if (capability.kind !== "capability") throw new Error("expected capability");
-    expect(flattenCapabilityTree(capability)[0]?.transaction).toMatchObject({
-      to: APRMON_ADDRESS,
+    changes.forEach((change, index) => {
+      expect(leafChangeOf(receipt.changes[index])).toBe(change);
     });
   });
 
-  it("parses RequestRedeem event into an unstake Receipt", async () => {
-    const registry = new Registry(runtime).use(AprioriProtocol);
-    const capability = await registry.action("apriori", "unstake", ACCOUNT, {
-      shares: "1",
-      receiver: ACCOUNT,
+  it("parses a reordered evidence set while preserving the given order", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    const changes = [deposited(), native(), mint()];
+    const receipt = parseWith(capability, changes);
+    expect(receipt.outcome).toMatchObject({ operation: "stake" });
+    changes.forEach((change, index) => {
+      expect(leafChangeOf(receipt.changes[index])).toBe(change);
     });
-    if (capability.kind !== "capability") throw new Error("expected capability");
-    const requested = requestRedeemEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 7n);
-    const receipt = registry.parseReceipt(capability, [requested]);
+  });
+
+  it("keeps unrelated ERC-20 transfers as delegated erc20 evidence", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    const unrelated = transferEvent(OTHER, ACCOUNT, 5n, OTHER);
+    const receipt = parseWith(capability, [native(), mint(), deposited(), unrelated]);
+    expect(receipt.outcome).toMatchObject({ operation: "stake" });
+    expect(receipt.changes).toHaveLength(4);
+    expect(leafChangeOf(receipt.changes[3])).toBe(unrelated);
+  });
+
+  it("rejects incomplete evidence: missing native, mint, or Deposit", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    expect(() => parseWith(capability, [mint(), deposited()])).toThrow(/native/);
+    expect(() => parseWith(capability, [native(), deposited()])).toThrow(/mint/);
+    expect(() => parseWith(capability, [native(), mint()])).toThrow(/Deposit/);
+  });
+
+  it("rejects mismatched amounts, actors, and endpoints", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    // native value != Deposit.assets
+    expect(() =>
+      parseWith(capability, [nativeChange(ACCOUNT, APRMON_ADDRESS, ONE + 1n), mint(), deposited()]),
+    ).toThrow(/native transfer to match Deposit/);
+    // native goes to the wrong endpoint
+    expect(() =>
+      parseWith(capability, [nativeChange(ACCOUNT, OTHER, ONE), mint(), deposited()]),
+    ).toThrow(/native transfer to match Deposit/);
+    // native from the wrong actor
+    expect(() =>
+      parseWith(capability, [nativeChange(OTHER, APRMON_ADDRESS, ONE), mint(), deposited()]),
+    ).toThrow(/native transfer to match Deposit/);
+    // mint to the wrong receiver
+    expect(() =>
+      parseWith(capability, [
+        native(),
+        transferEvent(ZERO, OTHER, 950_000_000_000_000_000n),
+        deposited(),
+      ]),
+    ).toThrow(/mint to match Deposit/);
+    // mint amount != Deposit.shares
+    expect(() =>
+      parseWith(capability, [native(), transferEvent(ZERO, ACCOUNT, 1n), deposited()]),
+    ).toThrow(/mint to match Deposit/);
+  });
+
+  it("rejects forged-emitter, duplicate, and malformed Deposit events", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    // Deposit topics emitted by a different contract are not aPriori evidence
+    const forged = depositEvent(ACCOUNT, ACCOUNT, ONE, 950_000_000_000_000_000n, OTHER);
+    expect(() => parseWith(capability, [native(), mint(), forged])).toThrow();
+    // a second Deposit cannot be silently absorbed
+    expect(() => parseWith(capability, [native(), mint(), deposited(), deposited()])).toThrow();
+    // malformed (truncated) Deposit data fails decoding and is rejected
+    const malformed: Change = { ...deposited(), data: "0x01" } as Change;
+    expect(() => parseWith(capability, [native(), mint(), malformed])).toThrow();
+  });
+
+  it("does not count a foreign token's mint-shaped Transfer as the aprMON mint", async () => {
+    const capability = await capabilityFor("stake", { amount: "1", receiver: ACCOUNT });
+    const foreignMint = transferEvent(ZERO, ACCOUNT, 950_000_000_000_000_000n, OTHER);
+    expect(() => parseWith(capability, [native(), foreignMint, deposited()])).toThrow(/mint/);
+  });
+});
+
+describe("unstakeReceipt", () => {
+  const escrow = () => transferEvent(ACCOUNT, APRMON_ADDRESS, ONE);
+  const requested = () =>
+    redeemRequestEvent(OTHER, ACCOUNT, 7n, ACCOUNT, ONE, 1_070_000_000_000_000_000n);
+
+  it("parses the live evidence shape with exact identity, length, and order", async () => {
+    const capability = await capabilityFor("unstake", { shares: "1", controller: OTHER });
+    const changes = [escrow(), requested()];
+    const receipt = parseWith(capability, changes);
     expect(receipt.outcome).toEqual({
       operation: "unstake",
-      account: ACCOUNT,
-      shares: "1000000000000000000",
+      controller: OTHER,
+      owner: ACCOUNT,
+      sender: ACCOUNT,
       requestId: "7",
+      shares: ONE.toString(),
+      assets: "1070000000000000000",
     });
-
-    expect(receipt.changes).toHaveLength(1);
-    expect(changeOf(receipt.changes[0])).toBe(requested);
-  });
-
-  it("builds a redeem (claim) transaction", async () => {
-    const registry = new Registry(runtime).use(AprioriProtocol);
-    const capability = await registry.action("apriori", "claim", ACCOUNT, {
-      requestId: "7",
-      receiver: ACCOUNT,
-    });
-    if (capability.kind !== "capability") throw new Error("expected capability");
-    expect(flattenCapabilityTree(capability)[0]?.transaction).toMatchObject({
-      to: APRMON_ADDRESS,
+    expect(receipt.changes).toHaveLength(2);
+    changes.forEach((change, index) => {
+      expect(leafChangeOf(receipt.changes[index])).toBe(change);
     });
   });
 
-  it("parses Redeem event into a claim Receipt", async () => {
-    const registry = new Registry(runtime).use(AprioriProtocol);
-    const capability = await registry.action("apriori", "claim", ACCOUNT, {
-      requestId: "7",
-      receiver: ACCOUNT,
-    });
-    if (capability.kind !== "capability") throw new Error("expected capability");
-    const claimed = redeemEvent(ACCOUNT, ACCOUNT, 990000000000000000n, [7n]);
-    const receipt = registry.parseReceipt(capability, [claimed]);
+  it("rejects a RedeemRequest without the matching aprMON escrow transfer", async () => {
+    const capability = await capabilityFor("unstake", { shares: "1", controller: OTHER });
+    expect(() => parseWith(capability, [requested()])).toThrow(/escrow/);
+    // escrow amount != RedeemRequest.shares
+    expect(() =>
+      parseWith(capability, [transferEvent(ACCOUNT, APRMON_ADDRESS, 1n), requested()]),
+    ).toThrow(/escrow/);
+    // escrow from the wrong owner
+    expect(() =>
+      parseWith(capability, [transferEvent(OTHER, APRMON_ADDRESS, ONE), requested()]),
+    ).toThrow(/escrow/);
+    // duplicate escrow transfers cannot be silently absorbed
+    expect(() => parseWith(capability, [escrow(), escrow(), requested()])).toThrow(
+      /multiple aprMON escrow/,
+    );
+  });
+});
+
+describe("claimReceipt", () => {
+  const burn = (shares: bigint = CLAIM_SHARES) => transferEvent(APRMON_ADDRESS, ZERO, shares);
+  const redeemed = (requestId: bigint = 7n) =>
+    redeemEvent(ACCOUNT, ACCOUNT, requestId, CLAIM_SHARES, CLAIM_ASSETS, CLAIM_FEE);
+  const payout = (value: bigint = CLAIM_ASSETS) => nativeChange(APRMON_ADDRESS, ACCOUNT, value);
+
+  it("parses the live evidence shape with exact identity, length, and order", async () => {
+    const capability = await capabilityFor("claim", { requestId: "7", receiver: ACCOUNT });
+    const changes = [burn(), redeemed(), payout()];
+    const receipt = parseWith(capability, changes);
     expect(receipt.outcome).toEqual({
       operation: "claim",
-      account: ACCOUNT,
+      controller: ACCOUNT,
+      receiver: ACCOUNT,
       requestIds: ["7"],
-      assets: "990000000000000000",
+      shares: CLAIM_SHARES.toString(),
+      assets: CLAIM_ASSETS.toString(),
+      fee: CLAIM_FEE.toString(),
     });
+    expect(receipt.changes).toHaveLength(3);
+    changes.forEach((change, index) => {
+      expect(leafChangeOf(receipt.changes[index])).toBe(change);
+    });
+  });
 
-    expect(receipt.changes).toHaveLength(1);
-    expect(changeOf(receipt.changes[0])).toBe(claimed);
+  it("aggregates a multi-ID claim: one burn/Redeem pair per request", async () => {
+    const capability = await capabilityFor("claim", { requestId: "10470", receiver: ACCOUNT });
+    const changes = [burn(), redeemed(10470n), burn(), redeemed(10471n), payout(CLAIM_ASSETS * 2n)];
+    const receipt = parseWith(capability, changes);
+    expect(receipt.outcome).toEqual({
+      operation: "claim",
+      controller: ACCOUNT,
+      receiver: ACCOUNT,
+      requestIds: ["10470", "10471"],
+      shares: (CLAIM_SHARES * 2n).toString(),
+      assets: (CLAIM_ASSETS * 2n).toString(),
+      fee: (CLAIM_FEE * 2n).toString(),
+    });
+    changes.forEach((change, index) => {
+      expect(leafChangeOf(receipt.changes[index])).toBe(change);
+    });
+  });
+
+  it("rejects incomplete or mismatched payout evidence", async () => {
+    const capability = await capabilityFor("claim", { requestId: "7", receiver: ACCOUNT });
+    // no Redeem event at all
+    expect(() => parseWith(capability, [burn(), payout()])).toThrow(/Redeem/);
+    // missing native payout
+    expect(() => parseWith(capability, [burn(), redeemed()])).toThrow(/payout/);
+    // payout amount != sum of Redeem.assets
+    expect(() => parseWith(capability, [burn(), redeemed(), payout(1n)])).toThrow(/payout/);
+    // payout to the wrong receiver
+    expect(() =>
+      parseWith(capability, [
+        burn(),
+        redeemed(),
+        nativeChange(APRMON_ADDRESS, OTHER, CLAIM_ASSETS),
+      ]),
+    ).toThrow(/payout/);
+    // payout from the wrong endpoint
+    expect(() =>
+      parseWith(capability, [burn(), redeemed(), nativeChange(OTHER, ACCOUNT, CLAIM_ASSETS)]),
+    ).toThrow(/payout/);
+    // burn total != sum of Redeem.shares
+    expect(() => parseWith(capability, [burn(1n), redeemed(), payout()])).toThrow(/burn/);
+    expect(() => parseWith(capability, [redeemed(), payout()])).toThrow(/burn/);
+    // duplicate native payouts cannot be silently absorbed
+    expect(() => parseWith(capability, [burn(), redeemed(), payout(), payout()])).toThrow(
+      /multiple native/,
+    );
   });
 });
 
 describe.skipIf(!!process.env.MOSS_SKIP_E2E)("aPriori mainnet", () => {
   it("has deployed bytecode at the aprMON proxy address", { timeout: 60_000 }, async () => {
     const runtime = await monadRuntime();
-    expect(
-      (await runtime.client.getCode({ address: APRMON_ADDRESS }))?.length,
-    ).toBeGreaterThan(2);
+    expect((await runtime.client.getCode({ address: APRMON_ADDRESS }))?.length).toBeGreaterThan(2);
   });
 
-  it("verifies the recorded implementation address on mainnet", { timeout: 60_000 }, async () => {
+  it("matches on-chain name/symbol/decimals against the exported APRMON_* constants", {
+    timeout: 60_000,
+  }, async () => {
     const runtime = await monadRuntime();
-    const code = await runtime.client.getCode({
-      address: "0x29fcb43b46531bca003ddc8fcb67ffe91900c762",
-    });
-    expect(code?.length).toBeGreaterThan(2);
+    const [name, symbol, decimals] = await Promise.all([
+      runtime.client.readContract({
+        address: APRMON_ADDRESS,
+        abi: AprMonAbi,
+        functionName: "name",
+      }) as Promise<string>,
+      runtime.client.readContract({
+        address: APRMON_ADDRESS,
+        abi: AprMonAbi,
+        functionName: "symbol",
+      }) as Promise<string>,
+      runtime.client.readContract({
+        address: APRMON_ADDRESS,
+        abi: AprMonAbi,
+        functionName: "decimals",
+      }) as Promise<number>,
+    ]);
+    expect(name).toBe(APRMON_NAME);
+    expect(symbol).toBe(APRMON_SYMBOL);
+    expect(decimals).toBe(APRMON_DECIMALS);
   });
 
-  it("simulates a stake with zero Warnings", { timeout: 180_000 }, async () => {
+  it("simulates a stake with zero Warnings and full evidence correlation", {
+    timeout: 180_000,
+  }, async () => {
     const runtime = await monadRuntime();
     const registry = new Registry(runtime).use(AprioriProtocol);
     const capability = await registry.action("apriori", "stake", ACCOUNT, {
@@ -267,7 +450,54 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("aPriori mainnet", () => {
     expect(outcome.results[0]?.warnings).toEqual([]);
     expect(outcome.results[0]?.receipt?.outcome).toMatchObject({
       operation: "stake",
-      account: ACCOUNT,
+      sender: ACCOUNT,
+      owner: ACCOUNT,
+    });
+  });
+
+  // Chains stake -> unstake in a single simulate call so the simulator's
+  // state chaining persists the minted aprMON balance before requestRedeem
+  // runs. This live-validates the three-argument requestRedeem construction
+  // and the escrow-transfer correlation in unstakeReceipt.
+  it("simulates unstake (requestRedeem) after stake via state chaining", {
+    timeout: 240_000,
+  }, async () => {
+    const runtime = await monadRuntime();
+    const registry = new Registry(runtime).use(AprioriProtocol);
+
+    const stakeCap = await registry.action("apriori", "stake", ACCOUNT, {
+      amount: "0.01",
+      receiver: ACCOUNT,
+    });
+    if (stakeCap.kind !== "capability") throw new Error("expected stake Capability");
+
+    // Request fewer shares than the deposit mints to tolerate exchange-rate
+    // drift between assets (MON) and shares (aprMON).
+    const unstakeCap = await registry.action("apriori", "unstake", ACCOUNT, {
+      shares: "0.005",
+      controller: ACCOUNT,
+    });
+    if (unstakeCap.kind !== "capability") throw new Error("expected unstake Capability");
+
+    const combined: CapabilityNode = {
+      ...stakeCap,
+      children: [...stakeCap.children, unstakeCap],
+    };
+
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(combined);
+
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results).toHaveLength(2);
+    expect(outcome.results[0]?.warnings).toEqual([]);
+    expect(outcome.results[0]?.receipt?.outcome).toMatchObject({ operation: "stake" });
+    expect(outcome.results[1]?.warnings).toEqual([]);
+    expect(outcome.results[1]?.receipt?.outcome).toMatchObject({
+      operation: "unstake",
+      controller: ACCOUNT,
+      owner: ACCOUNT,
+      shares: "5000000000000000",
     });
   });
 });

--- a/packages/protocols/apriori/test/types.fixture.ts
+++ b/packages/protocols/apriori/test/types.fixture.ts
@@ -1,0 +1,10 @@
+import { describe, it } from "vitest";
+import { AprioriProtocol } from "../src/index.js";
+
+describe("apriori Protocol metadata", () => {
+  it("declares stake and unstake Capabilities", () => {
+    // compile-time check that the protocol shape is well-formed
+    const proto = AprioriProtocol;
+    if (proto.name !== "apriori") throw new Error("unexpected protocol name");
+  });
+});

--- a/packages/protocols/apriori/test/types.fixture.ts
+++ b/packages/protocols/apriori/test/types.fixture.ts
@@ -1,10 +1,60 @@
-import { describe, it } from "vitest";
-import { AprioriProtocol } from "../src/index.js";
+// Compile-time contract fixture (never executed; typechecked via tsconfig).
+// Valid usage must compile with the intended inferred types and invalid usage
+// must be rejected — see the repo type-safety rules and the _template fixture.
+import type { ActionCtx, ProtocolRef } from "@themoss/core";
+import type { AprioriProtocol, ClaimOutcome, StakeOutcome, UnstakeOutcome } from "../src/index.js";
 
-describe("apriori Protocol metadata", () => {
-  it("declares stake and unstake Capabilities", () => {
-    // compile-time check that the protocol shape is well-formed
-    const proto = AprioriProtocol;
-    if (proto.name !== "apriori") throw new Error("unexpected protocol name");
-  });
-});
+declare const apriori: AprioriProtocol;
+declare const ctx: ActionCtx;
+declare const dependency: ProtocolRef<AprioriProtocol>;
+
+const ADDR = "0x1234567890abcdef1234567890abcdef12345678" as const;
+
+// --- Positive: valid parameter inference ---
+
+void apriori.stake({ amount: "1", receiver: ADDR });
+void apriori.stake({ amount: "0.000000000000000001", receiver: ADDR });
+
+void apriori.unstake({ shares: "1", controller: ADDR }, ctx);
+void apriori.unstake({ shares: "10.5", controller: ADDR }, ctx);
+
+void apriori.claim({ requestId: "7", receiver: ADDR });
+
+// --- Positive: Receipt outcome inference ---
+
+apriori.stakeReceipt([]).outcome satisfies StakeOutcome;
+apriori.unstakeReceipt([]).outcome satisfies UnstakeOutcome;
+apriori.claimReceipt([]).outcome satisfies ClaimOutcome;
+
+// Injected Protocol references expose receipt methods stamped with their
+// producing Protocol.
+dependency.stakeReceipt([]).protocol satisfies string;
+
+// --- Negative: invalid usage is rejected ---
+
+// @ts-expect-error amount must be a string, not a number
+void apriori.stake({ amount: 1, receiver: ADDR });
+
+// @ts-expect-error receiver must be an Address
+void apriori.stake({ amount: "1", receiver: "not-an-address" });
+
+// @ts-expect-error receiver is required
+void apriori.stake({ amount: "1" });
+
+// @ts-expect-error shares must be a string, not a number
+void apriori.unstake({ shares: 1, controller: ADDR }, ctx);
+
+// @ts-expect-error controller is required (renamed from receiver)
+void apriori.unstake({ shares: "1", receiver: ADDR }, ctx);
+
+// @ts-expect-error missing ctx argument
+void apriori.unstake({ shares: "1", controller: ADDR });
+
+// @ts-expect-error requestId must be a string, not a number
+void apriori.claim({ requestId: 7, receiver: ADDR });
+
+// @ts-expect-error stake outcome is not a claim outcome
+apriori.stakeReceipt([]).outcome satisfies ClaimOutcome;
+
+// @ts-expect-error Injected Protocol references expose methods, not Handles
+void dependency.aprMon;

--- a/packages/protocols/apriori/tsconfig.json
+++ b/packages/protocols/apriori/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/apriori/tsconfig.json
+++ b/packages/protocols/apriori/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "test-online"]
 }

--- a/packages/protocols/apriori/vitest.config.ts
+++ b/packages/protocols/apriori/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/protocols/apriori/vitest.config.ts
+++ b/packages/protocols/apriori/vitest.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
     alias: {
       "@themoss/core": src("../../core/src/index.ts"),
       "@themoss/simulator": src("../../simulator/src/index.ts"),
-      "@themoss/system": src("../../system/src/index.ts"),
       "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/system": src("../../system/src/index.ts"),
     },
   },
 });

--- a/packages/protocols/apriori/vitest.online.config.ts
+++ b/packages/protocols/apriori/vitest.online.config.ts
@@ -3,13 +3,15 @@ import { defineConfig } from "vitest/config";
 
 const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
+// The online explorer cross-check suite (pnpm test:abi:online). Kept apart
+// from the offline default so a missing MONADSCAN_API_KEY fails loudly here
+// without ever gating `pnpm test`.
 export default defineConfig({
   esbuild: { target: "es2022" },
-  test: {
-    include: ["test/**/*.test.ts"],
+  test: { include: ["test-online/**/*.test.ts"] },
+  resolve: {
     alias: {
       "@themoss/core": src("../../core/src/index.ts"),
-      "@themoss/simulator": src("../../simulator/src/index.ts"),
       "@themoss/system": src("../../system/src/index.ts"),
       "@themoss/erc": src("../../erc/src/index.ts"),
     },

--- a/packages/protocols/apriori/vitest.online.config.ts
+++ b/packages/protocols/apriori/vitest.online.config.ts
@@ -3,17 +3,23 @@ import { defineConfig } from "vitest/config";
 
 const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
-// The online explorer cross-check suite (pnpm test:abi:online). Kept apart
-// from the offline default so a missing MONADSCAN_API_KEY fails loudly here
-// without ever gating `pnpm test`.
+// The online ABI derivation suite (pnpm test:abi:online). Keyless: the
+// aprMON implementation is unverified on MonadScan, so the vendored ABI is
+// enforced directly against mainnet RPC (EIP-1967 linkage, bytecode
+// selector/topic presence, token metadata) instead of a keyed explorer
+// fetch. Kept apart from the offline default `pnpm test`.
 export default defineConfig({
   esbuild: { target: "es2022" },
   test: { include: ["test-online/**/*.test.ts"] },
   resolve: {
+    // Tests run against workspace sources, not dists, so a stale build can
+    // never produce phantom failures.
     alias: {
       "@themoss/core": src("../../core/src/index.ts"),
-      "@themoss/system": src("../../system/src/index.ts"),
+      "@themoss/simulator": src("../../simulator/src/index.ts"),
       "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/system": src("../../system/src/index.ts"),
+      "@themoss/abi-tools": src("../../abi-tools/src/index.ts"),
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@themoss/erc':
         specifier: workspace:*
         version: link:../erc
+      '@themoss/protocol-apriori':
+        specifier: workspace:*
+        version: link:../protocols/apriori
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
@@ -220,6 +223,9 @@ importers:
         specifier: ^2.54.3
         version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
+      '@themoss/abi-tools':
+        specifier: workspace:*
+        version: link:../../abi-tools
       '@themoss/simulator':
         specifier: workspace:*
         version: link:../../simulator

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,28 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
+  packages/protocols/apriori:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
   packages/protocols/kuru:
     dependencies:
       '@themoss/core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,12 @@ importers:
         specifier: ^2.54.3
         version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

Adds `@themoss/protocol-apriori`: a Moss adapter for **aPriori** MON liquid staking on Monad, composed into the MCP server. Three Capabilities mapping aPriori's native-asset vault with an async withdrawal queue:

- `stake` — `deposit(uint256 assets, address receiver)` payable (`0x6e553f65`)
- `unstake` — `requestRedeem(uint256 shares, address controller, address owner)` (`0x7d41c86e`)
- `claim` — `redeem(uint256[] requestIDs, address receiver)` (`0x492e47d2`, no return value)

## Correction from the previous revision

The previous revision was wrong about the contract surface, and worse than the review caught: `requestRedeem(uint256,address)` (`0x107703ab`) **does not exist on mainnet** — the selector is absent from the implementation's dispatch table and `eth_call` reverts with empty data. The vendored `RequestRedeem`/`Redeem` events did not exist either. This revision re-derives everything from the official docs plus live mainnet evidence:

- Real proxy story: `0x0c65A0…0852` is an OZ v5 **TransparentUpgradeableProxy** ([verified on MonadScan](https://monadscan.com/address/0x0c65A0BC65a5D819235B71F554D210D3F80E0852), labeled "aPriori: aprMON Token"). Its EIP-1967 slot resolves to implementation `0x7D2F8dc5…06F2` (set at block 40,124,891 per the upgrade history). The previously pinned `0x29fcb43b…` was the Gnosis Safe v1.4.1 singleton reachable via ProxyAdmin → owner Safe → slot 0 — two hops from the vault. All prior proxy claims (non-EIP-7702 "regular proxy", "EIP-1967 slot is 0x0", "48k-byte lpStaking") are removed everywhere.
- Real events (topic0s observed live and present in the implementation bytecode):
  - `Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares)`
  - `RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares, uint256 assets)`
  - `Redeem(address indexed controller, address indexed receiver, uint256 indexed requestId, uint256 shares, uint256 assets, uint256 fee)` — one per claimed ID; `assets` is net of `fee`
- Live flow evidence: deposit escrows nothing (mint Transfer + Deposit); `requestRedeem` **escrows** shares to the vault (Transfer owner→vault + RedeemRequest); `redeem` burns (Transfer vault→zero) and pays native MON per claimed ID (no log for the payout).

## ABI provenance (ADR 0007, vendored tier)

The implementation is **unverified** on MonadScan (and has no Sourcify match), so there is no explorer artifact to fetch. The ABI is vendored verbatim from [aPriori's official integration docs](https://apriori-docs.gitbook.io/apriori-docs/aprmon/smart-contract-integration), restricted to entries whose signatures are machine-verifiable, with the full selector/topic record in the artifact header. Derivation is test-enforced, keyless, against mainnet RPC (`test-online/abi-explorer.test.ts`):

- proxy pin (manifest == adapter constant) and EIP-1967 slot == recorded implementation (an aPriori upgrade turns the suite red)
- deployed bytecode at both addresses
- **every** vendored selector and topic hash, recomputed from the artifact, present in the implementation bytecode
- on-chain `name`/`symbol`/`decimals` == exported `APRMON_*` constants
- `convertToShares`/`convertToAssets` round-trip sanity

If aPriori verifies the implementation, the package should switch to the keyed `fetchAbi` + `compareDeployedAbi` flow used by fastlane (noted in the README).

## Receipts

Parsers authenticate the aprMON emitter (a matching topic from any other address is not aPriori evidence) and verify the full observed asset flow, throwing on partial/mismatched evidence:

- `stake`: `Deposit` ⇄ caller→vault native transfer (amount, endpoints, actor) ⇄ zero→owner mint (amount, receiver)
- `unstake`: `RedeemRequest` ⇄ owner→vault escrow Transfer (amount, actor)
- `claim`: one `Redeem` per ID (consistent controller/receiver) ⇄ vault→zero burns (aggregate shares) ⇄ vault→receiver native payout (aggregate net assets)

ERC-20 Transfers are delegated unchanged to `@themoss/erc` as **nested Receipts** (ADR 0011) — no `.changes[0]` plucking. Outcomes preserve distinct `sender`/`owner`/`controller`/`receiver` fields. `claimReceipt` aggregates multi-ID claims (`requestIds[]`, summed `shares`/`assets`/`fee`).

## Input contracts

`stake.amount` and `unstake.shares` reject more than 18 fractional digits instead of letting `parseUnits` round silently (tested). `unstake` takes an explicit `controller`; the acting account is passed as `owner`.

## Risk labels

`stake`/`unstake` carry `fundOut`. `claim` is inflow-only, but core's Registry rejects an empty `risk` list (registry.ts "must declare a risk label") and `RISK_LABELS` has no inflow/obligation entry yet, so `claim` keeps `fundOut` with a code comment and README note pointing at #114 — happy to switch to whatever minimal set #114 lands, or extend the vocabulary in a follow-up if preferred.

## Shipping

- `private: true` removed (matches kuru/pancakeswap/fastlane); added to the changeset **linked** group; changeset also bumps `@themoss/mcp-server`
- Composed into the MCP server (`composition.ts`, dependency, Vitest alias) with discover/load coverage for `apriori` in `server.test.ts`
- `labels: { aPriori: … }` Protocol metadata for Package label rendering
- Root README `||` table rows fixed (both languages)
- `types.fixture.ts` is now a real compile-time fixture (positive inference + `@ts-expect-error` negatives, including Receipt outcome inference); `tsconfig` includes `test-online`

## Verification

- `pnpm lint` ✅ (0 errors) · `pnpm build` ✅ · `pnpm typecheck` ✅ (all packages)
- `pnpm test:offline` ✅ (entire monorepo; apriori: 15 offline tests — build assertions with exact calldata, receipt matrix incl. forged-emitter/duplicate/malformed/reordered/wrong actor-token-endpoint-amount/unrelated-transfer negatives, multi-ID claim fixture, precision rejection)
- Package live suite ✅ 19/19: metadata vs constants, `simulate` stake with zero Warnings, and **stake→unstake state-chained `simulate` with zero Warnings** — live proof of the corrected three-argument `requestRedeem` and the escrow correlation
- `pnpm test:abi:online` ✅ 6/6 keyless on-chain derivation checks
- A live `claim` e2e is not possible same-block (the unbonding epoch gate cannot elapse within one simulation, and the request ID does not exist until unstake executes); claim coverage is the offline matrix + on-chain selector/topic enforcement + the live-observed event shape (tx `0x7413c820…`)
