### PR TITLE
docs: add post-simulation intent alignment checklist

### DIFF
--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -12,6 +12,25 @@ These rules apply to every Agent that uses the Moss MCP tools.
 6. **Align ordered texts with intent.** Compare every Receipt text returned by MCP, in order, with the user's original request. These texts are exposed only after the underlying complete Receipt passes coverage verification.
 7. **Present before signing.** Explain actual assets, amounts, recipients, approvals, protocol semantics, uncertainty, and every Warning. Moss itself never signs or sends.
 
+## Post-simulation intent-alignment checklist
+
+After `simulate` returns with no Warnings, do not treat the result as safe to sign automatically. A clean simulation proves that Moss parsed every observed Change; it does not prove the result matches the user's original request.
+
+Before handing transactions to a signer, compare the ordered Receipt texts and structured Outcomes against the recorded intent:
+
+- Operation: the operation matches the user's requested verb, such as `swap`, `transfer`, `approve`, `wrap`, or `unwrap`.
+- Protocol: the protocol matches the user's explicit or selected protocol constraint.
+- Sender: every transaction sender matches the account authorized by the user.
+- Assets: input, output, approved, transferred, wrapped, or unwrapped assets match explicit token identities, not only symbols.
+- Amounts: input amounts, output amounts, approval amounts, and native values match the request and loaded parameter units.
+- Recipients: every recipient, spender, pool, router, or protocol address is expected.
+- Limits: slippage, minimum output, maximum input, deadline, allowance, and other safety limits are preserved.
+- Ordering: nested Capability effects appear in the expected order, especially approvals before protocol actions.
+- Extra effects: no unexpected transfer, approval, wrap, unwrap, refund, fee, or protocol action appears.
+- Warnings: any Warning, halted simulation, missing Receipt, or ambiguous Outcome stops the flow.
+
+If any item cannot be confirmed from the recorded intent and loaded contract, ask the user or stop. Never infer approval from a successful simulation alone.
+
 ## Hard rules
 
 - Never request or handle a private key.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -189,6 +189,8 @@ A revert, trace failure, state-chaining failure, Receipt error, or coverage mism
 
 ## 9. Align structured Outcomes with intent
 
+Use the reusable checklist in [Agent safety rules](./agent-skill.md#post-simulation-intent-alignment-checklist), then apply the Kuru-specific checks below.
+
 Zero Warnings means every observed Change was parsed. It does not mean the result matches the user's request.
 
 For this swap, check the final structured Outcome for:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -229,7 +229,7 @@ type TransactionSimulation = {
 };
 ```
 
-Core produces the MCP texts only after the complete recursive Receipt retains every exact input Change object with identical length and order. After a clean simulation, compare every ordered text with the user's original operation, assets, amounts, recipients, limits, approvals, and Protocol choice.
+Core produces the MCP texts only after the complete recursive Receipt retains every exact input Change object with identical length and order.A clean `simulate` response proves Receipt coverage, not user-intent alignment. Agents must run the post-simulation intent-alignment checklist before handing transactions to a signer. After a clean simulation, compare every ordered text with the user's original operation, assets, amounts, recipients, limits, approvals, and Protocol choice.
 
 ## Warnings
 


### PR DESCRIPTION
## What and why

Closes #97

This PR adds a reusable post-simulation intent-alignment checklist for Agents.

A clean simulation proves that Moss parsed every observed Change, but it does not prove that the result matches the user's original request or is safe to sign. The checklist makes that safety boundary easier to apply across Capabilities, not only in the Getting Started Kuru swap example.

Changes:
- Adds a reusable checklist to `docs/agent-skill.md`.
- Links the Getting Started intent-alignment section to the checklist.
- Adds a short MCP `simulate` note clarifying that Receipt coverage is not user-intent alignment.

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [x] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

<!-- Public types, package boundaries, Capability tree, Change/Receipt behavior, or "none". -->

## Verification

- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [x] `pnpm test`
- [ ] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

### Protocol changes

<!-- Mark N/A for non-Protocol PRs. -->

- [ ] Parameters separate reusable Zod value types from field-purpose descriptions
- [ ] Every Capability owns one direct TransactionNode and one typed Receipt
- [ ] Receipt tests preserve every original Change object in exact length and order
- [ ] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [ ] Fixed addresses and ABIs include sources and verification
- [ ] A live Monad happy path returns zero Warnings

## Evidence

Ran `TMPDIR="$PWD/.tmp" pnpm test:offline`.

Result: passed.

`TMPDIR` was set because the default macOS temp directory returned an `EACCES: permission denied, mkdir '/var/folders/zz/...'` error when Vitest tried to create worker/cache files.
