### PR TITLE
fix(core): freeze delegated receipt evidence

### DIFF
--- a/.changeset/freeze-delegated-receipts.md
+++ b/.changeset/freeze-delegated-receipts.md
@@ -1,0 +1,5 @@
+---
+"@themoss/core": patch
+---
+
+Recursively freeze Registry-assigned Receipt-owned structures so callers cannot mutate delegated Receipt evidence before embedding it.

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -139,6 +139,38 @@ function hasProtocol(receipt: ReceiptResult): receipt is Receipt {
   return "protocol" in receipt && typeof receipt.protocol === "string";
 }
 
+function freezeReceiptOwnedStructure(root: Receipt): Receipt {
+  const receipts = new WeakSet<object>();
+  const jsonValues = new WeakSet<object>();
+  const freezeJson = (value: JsonSafeValue): void => {
+    if (value === null || typeof value !== "object" || jsonValues.has(value)) return;
+    jsonValues.add(value);
+    if (Array.isArray(value)) {
+      for (const entry of value) freezeJson(entry);
+    } else {
+      for (const entry of Object.values(value)) freezeJson(entry);
+    }
+    Object.freeze(value);
+  };
+  const freezeReceipt = (receipt: Receipt): void => {
+    if (receipts.has(receipt)) return;
+    receipts.add(receipt);
+    freezeJson(receipt.outcome);
+    for (const child of receipt.changes) {
+      if (child.kind === "receipt") {
+        freezeReceipt(child);
+      } else {
+        freezeJson(child.data);
+        Object.freeze(child);
+      }
+    }
+    Object.freeze(receipt.changes);
+    Object.freeze(receipt);
+  };
+  freezeReceipt(root);
+  return root;
+}
+
 export class Registry {
   #protocols = new Map<string, Registered>();
   #assignedReceiptProtocols = new WeakMap<object, string>();
@@ -400,7 +432,7 @@ export class Registry {
     // biome-ignore lint/suspicious/noExplicitAny: registration validates Receipt dispatch
     const result = (instance as any)[receiptName](changes) as ReceiptResult;
     verifyReceiptCoverage(changes, result);
-    return this.#attachProtocol(result, protocol);
+    return freezeReceiptOwnedStructure(this.#attachProtocol(result, protocol));
   }
 
   #attachProtocol(result: ReceiptResult, protocol: string): Receipt {

--- a/packages/core/test/receipt-immutability.test.ts
+++ b/packages/core/test/receipt-immutability.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AddressValue,
+  Capability,
+  type Change,
+  type InferParams,
+  type MossRuntime,
+  type ParamsSpec,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  Registry,
+  transaction,
+} from "../src/index.js";
+
+const ACCOUNT = "0x1111111111111111111111111111111111111111" as const;
+const TARGET = "0x2222222222222222222222222222222222222222" as const;
+const noParams = {} satisfies ParamsSpec;
+
+type EvidenceOutcome = {
+  operation: "child";
+  details: { amount: string };
+};
+
+type GroupOutcome = {
+  operation: "group";
+  details: { count: number };
+};
+
+type LeafData = {
+  operation: "leaf";
+  details: { amount: string };
+};
+
+@Protocol({
+  name: "evidence",
+  category: "token",
+  description: "Delegated Receipt immutability fixture.",
+  contracts: {},
+  labels: { Target: TARGET },
+})
+class EvidenceProtocol {
+  @Query({ intent: "Inspect the evidence fixture", params: noParams })
+  async inspect() {
+    return null;
+  }
+
+  @Receipt()
+  evidenceReceipt(changes: readonly Change[]): ReceiptResult<EvidenceOutcome> {
+    const [change] = changes;
+    if (!change || changes.length !== 1) throw new Error("expected one Change");
+    return {
+      kind: "receipt",
+      outcome: { operation: "child", details: { amount: "1" } },
+      text: `child ${TARGET}`,
+      changes: [
+        {
+          kind: "receipt",
+          outcome: { operation: "group", details: { count: 1 } } satisfies GroupOutcome,
+          text: "group",
+          changes: [
+            {
+              kind: "change",
+              change,
+              data: {
+                operation: "leaf",
+                details: { amount: "1" },
+              } satisfies LeafData,
+              text: "leaf",
+            },
+          ],
+        },
+      ],
+    };
+  }
+}
+
+type DelegatedReceipt = ReturnType<ProtocolRef<EvidenceProtocol>["evidenceReceipt"]>;
+type ReceiptMutation = (receipt: DelegatedReceipt) => void;
+let mutateDelegatedReceipt: ReceiptMutation = () => undefined;
+
+@Protocol({
+  name: "receipt-caller",
+  category: "token",
+  description: "Protocol attempting to mutate a delegated Receipt.",
+  contracts: {},
+  protocols: { evidence: EvidenceProtocol },
+})
+class ReceiptCallerProtocol {
+  declare evidence: ProtocolRef<EvidenceProtocol>;
+
+  @Capability<ReceiptCallerProtocol, typeof noParams>({
+    intent: "Exercise delegated Receipt ownership",
+    verb: "transfer",
+    params: noParams,
+    receipt: "executeReceipt",
+    risk: ["fundOut"],
+  })
+  async execute(_: InferParams<typeof noParams>, ctx: { account: AddressValue }) {
+    return transaction(ctx.account, TARGET);
+  }
+
+  @Receipt()
+  executeReceipt(changes: readonly Change[]): ReceiptResult<{ operation: "parent" }> {
+    const child = this.evidence.evidenceReceipt(changes);
+    mutateDelegatedReceipt(child);
+    return {
+      kind: "receipt",
+      outcome: { operation: "parent" },
+      text: "parent",
+      changes: [child],
+    };
+  }
+}
+
+const runtime: MossRuntime = {
+  rpcUrl: "http://offline",
+  // biome-ignore lint/suspicious/noExplicitAny: no RPC methods are used by this fixture
+  client: {} as any,
+};
+
+function group(receipt: DelegatedReceipt) {
+  const child = receipt.changes[0];
+  if (child?.kind !== "receipt") throw new Error("expected grouped Receipt");
+  return child;
+}
+
+function leaf(receipt: DelegatedReceipt) {
+  const child = group(receipt).changes[0];
+  if (child?.kind !== "change") throw new Error("expected ReceiptChange");
+  return child;
+}
+
+const mutations = [
+  {
+    name: "delegated Receipt protocol",
+    mutate: (receipt) => {
+      (receipt as { protocol: string }).protocol = "forged";
+    },
+  },
+  {
+    name: "delegated Receipt text",
+    mutate: (receipt) => {
+      (receipt as { text: string }).text = "forged child";
+    },
+  },
+  {
+    name: "delegated Receipt outcome",
+    mutate: (receipt) => {
+      (receipt.outcome as { operation: string }).operation = "forged";
+    },
+  },
+  {
+    name: "delegated Receipt changes property",
+    mutate: (receipt) => {
+      (receipt as unknown as { changes: readonly unknown[] }).changes = [];
+    },
+  },
+  {
+    name: "delegated Receipt changes array",
+    mutate: (receipt) => {
+      (receipt.changes as unknown as unknown[]).pop();
+    },
+  },
+  {
+    name: "nested Receipt text",
+    mutate: (receipt) => {
+      (group(receipt) as { text: string }).text = "forged group";
+    },
+  },
+  {
+    name: "nested Receipt outcome",
+    mutate: (receipt) => {
+      (group(receipt).outcome as { operation: string }).operation = "forged";
+    },
+  },
+  {
+    name: "nested Receipt changes array",
+    mutate: (receipt) => {
+      (group(receipt).changes as unknown as unknown[]).pop();
+    },
+  },
+  {
+    name: "ReceiptChange text",
+    mutate: (receipt) => {
+      (leaf(receipt) as { text: string }).text = "forged leaf";
+    },
+  },
+  {
+    name: "ReceiptChange data",
+    mutate: (receipt) => {
+      (leaf(receipt).data as unknown as LeafData).details.amount = "999";
+    },
+  },
+] satisfies readonly { name: string; mutate: ReceiptMutation }[];
+
+function change(): Change {
+  return {
+    kind: "nativeTransfer",
+    from: ACCOUNT,
+    to: TARGET,
+    value: "1",
+  };
+}
+
+async function capability(registry: Registry) {
+  const result = await registry.action("receipt-caller", "execute", ACCOUNT, {});
+  if (result.kind !== "capability") throw new Error("expected Capability");
+  return result;
+}
+
+describe("delegated Receipt immutability", () => {
+  it.each(mutations)("rejects mutation of $name", async ({ mutate }) => {
+    const registry = new Registry(runtime).use(ReceiptCallerProtocol);
+    const node = await capability(registry);
+    mutateDelegatedReceipt = mutate;
+
+    expect(() => registry.parseReceipt(node, [change()])).toThrow(TypeError);
+  });
+
+  it("freezes Receipt-owned data while preserving Change identity and label rendering", async () => {
+    const registry = new Registry(runtime).use(ReceiptCallerProtocol);
+    const node = await capability(registry);
+    const originalChange = change();
+    let delegated: DelegatedReceipt | undefined;
+    mutateDelegatedReceipt = (receipt) => {
+      delegated = receipt;
+    };
+
+    const rendered = registry.parseReceipt(node, [originalChange]);
+    if (!delegated) throw new Error("missing delegated Receipt");
+    const nested = group(delegated);
+    const receiptChange = leaf(delegated);
+
+    expect(Object.isFrozen(delegated)).toBe(true);
+    expect(Object.isFrozen(delegated.outcome)).toBe(true);
+    expect(Object.isFrozen(delegated.outcome.details)).toBe(true);
+    expect(Object.isFrozen(delegated.changes)).toBe(true);
+    expect(Object.isFrozen(nested)).toBe(true);
+    expect(Object.isFrozen(nested.outcome)).toBe(true);
+    expect(Object.isFrozen((nested.outcome as GroupOutcome).details)).toBe(true);
+    expect(Object.isFrozen(nested.changes)).toBe(true);
+    expect(Object.isFrozen(receiptChange)).toBe(true);
+    expect(Object.isFrozen(receiptChange.data)).toBe(true);
+    expect(Object.isFrozen((receiptChange.data as unknown as LeafData).details)).toBe(true);
+    expect(receiptChange.change).toBe(originalChange);
+    expect(Object.isFrozen(originalChange)).toBe(false);
+
+    const renderedChild = rendered.changes[0];
+    if (renderedChild?.kind !== "receipt") throw new Error("expected rendered child Receipt");
+    expect(renderedChild.text).toBe("child Package(Evidence:Target)");
+  });
+});

--- a/packages/core/test/receipt-labels.test.ts
+++ b/packages/core/test/receipt-labels.test.ts
@@ -250,8 +250,8 @@ class ForgedReceiptProtocol {
   @Receipt()
   forgedReceipt(changes: readonly Change[]): ReceiptResult<null> {
     const child = this.deep.renderReceipt(changes);
-    child.protocol = "unrelated";
-    return { kind: "receipt", outcome: null, text: "root", changes: [child] };
+    const forged = { ...child, protocol: "unrelated" };
+    return { kind: "receipt", outcome: null, text: "root", changes: [forged] };
   }
 }
 
@@ -396,7 +396,7 @@ describe("Registry Receipt labels", () => {
     );
   });
 
-  it("rejects mutation of a Registry-assigned child Receipt Protocol", () => {
+  it("rejects a cloned child Receipt with a forged Protocol", () => {
     const registry = new Registry(runtime).use(ForgedReceiptProtocol, UnrelatedProtocol);
     const node = {
       kind: "capability",
@@ -413,7 +413,7 @@ describe("Registry Receipt labels", () => {
     } satisfies Change;
 
     expect(() => registry.parseReceipt(node, [change])).toThrow(
-      'Receipt protocol "unrelated" does not match Registry-assigned "deep-token"',
+      'Receipt protocol "unrelated" was not assigned by Registry',
     );
   });
 });


### PR DESCRIPTION
## Problem

A dependency Protocol's Receipt is validated and assigned by Registry before it
is passed to the caller Protocol's Receipt parser. However, the delegated
Receipt-owned structure remained mutable.

This allowed the caller Protocol to modify evidence produced by its dependency,
including:

- `text`
- `outcome`
- `changes`
- nested Receipts
- ReceiptChange text and data

That conflicts with the Receipt ownership invariant in ADR 0011: a caller
Protocol may compose a dependency's interpretation, but must not rewrite it.

This is the focused follow-up discussed in #98.

## Changes

- Recursively freeze Registry-assigned Receipt-owned structures before returning
  them to the caller Protocol's parser.
- Freeze Receipt objects and their `changes` arrays, nested Receipts, Outcomes,
  and ReceiptChange wrappers and their `data`.
- Preserve the exact identity of original simulation `Change` objects.
- Do not freeze caller- or Simulator-owned `Change` objects.
- Keep the existing label projection behavior unchanged.
- Retain separate provenance coverage for cloned or forged Receipts.
- Add a patch changeset for `@themoss/core`.

## Why the freeze happens here

The freeze is applied only after Registry has:

1. executed the dependency Receipt parser;
2. verified exact Change identity, length, and order;
3. assigned the producing Protocol identity.

It happens before the resulting Receipt is exposed to the caller Protocol's
Receipt parser.

This makes Registry the enforcement boundary for delegated Receipt ownership,
without changing Protocol APIs or requiring individual Protocols to implement
their own defensive copying or freezing.

## Security properties

After this change, a caller Protocol cannot mutate a dependency Receipt's
Protocol identity, text, Outcome, changes array, nested Receipt tree,
ReceiptChange explanation, or ReceiptChange data.

The implementation intentionally does not recursively freeze
`ReceiptChange.change`. Those objects are original simulation evidence owned
outside the Receipt parser. Their identity is preserved and verified by Core.

Label rendering remains functional because it produces a later presentation
projection instead of mutating the delegated Receipt.

## Tests

The new focused test suite verifies:

- all supported mutation attempts fail with `TypeError`;
- Receipt-owned structures are recursively frozen;
- original Change object identity is preserved;
- supplied Change objects are not frozen by Registry;
- nested Receipt trees are protected;
- label projection still renders the expected package label;
- cloned Receipts with forged Protocol identity are still rejected by the
  existing provenance mechanism.

## Verification

Run against current `main`:

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `NODE_USE_ENV_PROXY=1 pnpm test` - 133/133 passed
- `pnpm audit --prod` - no known vulnerabilities
- `git diff --check`

The live Monad WMON and Kuru quote/simulation tests passed as part of
`pnpm test`.

The keyed ABI explorer suite was not run because the repository secret reported
in #108 is currently unavailable.

## Scope

This PR changes only `@themoss/core` and adds focused tests and a changeset. It
does not change exported APIs, Protocol contracts, Simulator Change ownership,
or Receipt rendering semantics.

Receipt tree complexity limits remain the responsibility of #91. This PR
enforces immutability at the existing delegated Receipt boundary and does not
attempt to introduce a second complexity policy.

Closes the Receipt mutability follow-up identified in #98.
