### PR TITLE
feat(core): add debt risk label

### DIFF
--- a/.changeset/core-debt-risk-label.md
+++ b/.changeset/core-debt-risk-label.md
@@ -1,0 +1,5 @@
+---
+"@themoss/core": minor
+---
+
+Add the `debt` RiskLabel for Capabilities that increase an account's repayment obligations, even when no asset leaves the account in the transaction.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,7 +43,7 @@ A reusable, context-free value contract carrying validation, transformation, def
 A Capability or Query input field pairing a Parameter type with a separate description of that field's specific role.
 
 **Risk label**:
-A Capability tag naming a category of danger, such as `fundOut`, `approval`, or `priceImpact`. It is authoring metadata, not runtime evidence.
+A Core-defined closed-set category of danger declared by a Capability, such as `fundOut`, `approval`, `priceImpact`, or `debt`. `debt` means the Capability increases the account's repayment obligations, even when no asset leaves the account in the transaction. It is authoring metadata, not runtime evidence.
 _Avoid_: warning, flag
 
 **Protocol trust boundary**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,7 +43,7 @@ A reusable, context-free value contract carrying validation, transformation, def
 A Capability or Query input field pairing a Parameter type with a separate description of that field's specific role.
 
 **Risk label**:
-A Core-defined closed-set category of danger declared by a Capability, such as `fundOut`, `approval`, `priceImpact`, or `debt`. `debt` means the Capability increases the account's repayment obligations, even when no asset leaves the account in the transaction. It is authoring metadata, not runtime evidence.
+A Core-defined closed-set category of danger declared by a Capability, such as `fundOut`, `approval`, `priceImpact`, or `debt`. `fundOut` means assets leave the account in the current transaction and does not include future repayment obligations. `debt` means the Capability increases the account's repayment obligations, even when no asset leaves the account in the transaction. It is authoring metadata, not runtime evidence.
 _Avoid_: warning, flag
 
 **Protocol trust boundary**:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -88,6 +88,8 @@ type Stub = {
 };
 ```
 
+`risk` uses Core's closed set. `fundOut` means assets leave the account in the current transaction and does not cover future repayment obligations. `debt` means the Capability increases the account's repayment obligations, even when no asset leaves the account in the transaction. Free-form `tags` may add description, but do not replace risk classification.
+
 Each parameter contains two independent explanations:
 
 - `type` is generated JSON Schema plus the reusable representation, units, constraints, conversion, and examples;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,7 +22,7 @@ export type Verb = (typeof VERBS)[number];
 export const CATEGORIES = ["dex", "lending", "staking", "rewards", "token", "nft"] as const;
 export type Category = (typeof CATEGORIES)[number];
 
-export const RISK_LABELS = ["fundOut", "approval", "priceImpact"] as const;
+export const RISK_LABELS = ["fundOut", "approval", "priceImpact", "debt"] as const;
 export type RiskLabel = (typeof RISK_LABELS)[number];
 
 export const NATIVE = "native" as const;

--- a/packages/core/test/framework.test.ts
+++ b/packages/core/test/framework.test.ts
@@ -111,6 +111,30 @@ class ApprovalProtocol {
 const noParams = {} satisfies ParamsSpec;
 
 @Protocol({
+  name: "debt-fixture",
+  category: "lending",
+  description: "Fixture debt Protocol.",
+  contracts: {},
+})
+class DebtProtocol {
+  @Capability<DebtProtocol, typeof noParams>({
+    intent: "Increase fixture debt",
+    verb: "borrow",
+    params: noParams,
+    receipt: "borrowReceipt",
+    risk: ["debt"],
+  })
+  async borrow(_: InferParams<typeof noParams>, ctx: { account: AddressValue }) {
+    return [transaction(ctx.account, VAULT)];
+  }
+
+  @Receipt()
+  borrowReceipt(changes: readonly Change[]): MossReceipt<{ operation: "borrow" }> {
+    return receiptFor("borrow", changes);
+  }
+}
+
+@Protocol({
   name: "composed",
   category: "dex",
   description: "Fixture composed Protocol.",
@@ -298,7 +322,7 @@ class UndescribedParameterProtocol {
   }
 }
 
-function receiptFor<T extends "approve" | "swap">(
+function receiptFor<T extends "approve" | "borrow" | "swap">(
   operation: T,
   changes: readonly Change[],
 ): MossReceipt<{ operation: T }> {
@@ -322,6 +346,13 @@ const runtime: MossRuntime = {
 };
 
 describe("framework core seam", () => {
+  it("loads the debt risk label through Registry", () => {
+    const registry = new Registry(runtime).use(DebtProtocol);
+    const [loaded] = registry.load([{ protocol: "debt-fixture", method: "borrow" }]);
+
+    expect(loaded?.risk).toEqual(["debt"]);
+  });
+
   it("registers a Protocol directly and builds its one-transaction Capability", async () => {
     const registry = new Registry(runtime);
     registry.use(TestVault);

--- a/packages/core/test/types.fixture.ts
+++ b/packages/core/test/types.fixture.ts
@@ -1,4 +1,10 @@
-import { type MossRuntime, Protocol, Registry, tokenMetadata } from "../src/index.js";
+import {
+  type MossRuntime,
+  Protocol,
+  Registry,
+  type RiskLabel,
+  tokenMetadata,
+} from "../src/index.js";
 
 const ADDRESS = "0x1111111111111111111111111111111111111111" as const;
 
@@ -28,6 +34,10 @@ new Registry(runtime, {
   trustedTokens: [{ address: "not-an-address", label: "Token" }],
 });
 
+const debtRisk: RiskLabel = "debt";
+// @ts-expect-error RiskLabel remains a closed set.
+const invalidRisk: RiskLabel = "not-a-risk";
+
 const metadataResult = tokenMetadata(
   { kind: "metadata" as const, decimals: 18 as const },
   { address: ADDRESS, symbol: "TOKEN", name: "Token" },
@@ -43,5 +53,7 @@ tokenMetadata("metadata", { address: ADDRESS });
 
 void LabeledFixture;
 void InvalidLabeledFixture;
+void debtRisk;
+void invalidRisk;
 void metadataKind;
 void metadataDecimals;


### PR DESCRIPTION
## What and why

Add `debt` to Core's closed `RiskLabel` set for Capabilities that increase an account's repayment obligations, even when no asset leaves the account in the transaction.

This distinguishes debt increases from `fundOut`, which only describes assets leaving the account in the current transaction. The glossary and MCP `load` documentation now make that boundary explicit, while free-form tags remain descriptive rather than formal risk classification.

Closes #114.

## Type of change

- [ ] Protocol / Capability / Query
- [x] Core / simulator / MCP server
- [ ] Bug fix
- [x] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

Widens the exported Core `RiskLabel` union with the additive `"debt"` literal. Existing Registry validation and `load` output accept the new label through the Core-owned `RISK_LABELS` set.

No package-boundary, Capability-tree, Simulator, Change, or Receipt behavior changes.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

### Protocol changes

N/A — this PR does not add or modify a Protocol.

## Evidence

- Added a positive compile-time fixture proving `"debt"` is accepted as a `RiskLabel`.
- Added an `@ts-expect-error` fixture proving arbitrary strings remain invalid.
- Added a decorated `DebtProtocol` runtime fixture proving Registry accepts `risk: ["debt"]` and `load()` returns exactly `["debt"]`.
- Before the Core change, the positive fixture failed with TS2322 because `"debt"` was not assignable to the existing union.
- After the Core change, focused and full typechecks passed.
- Full verification completed in the requested order: `pnpm lint` → `pnpm build` → `pnpm typecheck` → `pnpm test`.
- The complete test suite passed with 186 tests, including Monad-mainnet paths.
- Added a minor changeset for `@themoss/core`.
