### PR TITLE
fix(erc): make the ERC-1155 approve flag a typed boolean

### DIFF
--- a/.changeset/boolean-flag-param-type.md
+++ b/.changeset/boolean-flag-param-type.md
@@ -1,0 +1,6 @@
+---
+"@themoss/core": minor
+"@themoss/erc": minor
+---
+
+Add the reusable `BooleanFlag` parameter value type to core semantics, and change the ERC-1155 `approve` Capability's `approved` parameter from a `"1"`/`"0"` string to a JSON boolean.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export { createRuntime, type MossRuntime } from "./runtime.js";
 export {
   Address,
   BasisPoints,
+  BooleanFlag,
   describeParams,
   type InferParams,
   type ParameterDeclaration,

--- a/packages/core/src/semantics.ts
+++ b/packages/core/src/semantics.ts
@@ -51,6 +51,8 @@ export const BasisPoints = z
   .max(10_000)
   .describe("An integer basis-point count from 0 through 10000; 1 bps equals 0.01%.");
 
+export const BooleanFlag = z.boolean().describe("A JSON boolean: true or false.");
+
 export async function parseParams<S extends ParamsSpec>(
   spec: S,
   raw: Record<string, unknown>,

--- a/packages/erc/src/erc1155.ts
+++ b/packages/erc/src/erc1155.ts
@@ -2,6 +2,7 @@ import {
   type ActionCtx,
   Address,
   type AddressValue,
+  BooleanFlag,
   Capability,
   type Change,
   createHandle,
@@ -52,11 +53,9 @@ const erc1155ApprovalParams = {
   collection: { type: Address, description: "Collection to manage operator approval for." },
   operator: { type: Address, description: "Address authorized to manage the caller's tokens." },
   approved: {
-    type: UnsignedIntegerString.refine(
-      (v) => v === "1" || v === "0",
-      'Expected "1" (approve) or "0" (revoke).',
-    ).describe('Pass "1" to approve the operator or "0" to revoke.'),
-    description: '"1" to approve the operator, "0" to revoke.',
+    type: BooleanFlag,
+    description:
+      "true to grant the operator approval over the caller's tokens, false to revoke it.",
   },
 } satisfies ParamsSpec;
 
@@ -176,7 +175,7 @@ export class ERC1155 {
     return [
       this.#handle(params.collection, ctx.account).setApprovalForAll([
         params.operator,
-        params.approved === "1",
+        params.approved,
       ]),
     ];
   }

--- a/packages/erc/test/erc1155.test.ts
+++ b/packages/erc/test/erc1155.test.ts
@@ -185,6 +185,13 @@ describe("ERC1155", () => {
       }),
     ).rejects.toThrow("invalid parameters");
     await expect(
+      registry().action("erc1155", "approve", ACCOUNT, {
+        collection: COLLECTION,
+        operator: OPERATOR,
+        approved: "1",
+      }),
+    ).rejects.toThrow("invalid parameters");
+    await expect(
       registry().action("erc1155", "uri", ACCOUNT, {
         collection: COLLECTION,
         tokenId: overflow,
@@ -321,13 +328,13 @@ describe("ERC1155", () => {
     ).toThrow("original object");
   });
 
-  it("builds setApprovalForAll calldata for approve (1) and revoke (0)", async () => {
+  it("builds setApprovalForAll calldata for approve (true) and revoke (false)", async () => {
     const instance = registry();
 
     const approve = await instance.action("erc1155", "approve", ACCOUNT, {
       collection: COLLECTION,
       operator: OPERATOR,
-      approved: "1",
+      approved: true,
     });
     if (approve.kind !== "capability") throw new Error("expected capability");
     const [approveTx] = flattenCapabilityTree(approve);
@@ -340,7 +347,7 @@ describe("ERC1155", () => {
     const revoke = await instance.action("erc1155", "approve", ACCOUNT, {
       collection: COLLECTION,
       operator: OPERATOR,
-      approved: "0",
+      approved: false,
     });
     if (revoke.kind !== "capability") throw new Error("expected capability");
     const [revokeTx] = flattenCapabilityTree(revoke);

--- a/packages/erc/test/types.fixture.ts
+++ b/packages/erc/test/types.fixture.ts
@@ -37,6 +37,27 @@ const missingRecipient: ERC1155TransferParams = {
   amount: "3",
 };
 
+type ERC1155ApprovalParams = Parameters<ERC1155["approve"]>[0];
+const erc1155ApprovalParams: ERC1155ApprovalParams = {
+  collection: "0x1111111111111111111111111111111111111111",
+  operator: "0x2222222222222222222222222222222222222222",
+  approved: true,
+};
+const erc1155RevokeParams: ERC1155ApprovalParams = {
+  ...erc1155ApprovalParams,
+  approved: false,
+};
+const invalidApprovedString: ERC1155ApprovalParams = {
+  ...erc1155ApprovalParams,
+  // @ts-expect-error The approved flag is a JSON boolean, not a string.
+  approved: "1",
+};
+const invalidApprovedNumber: ERC1155ApprovalParams = {
+  ...erc1155ApprovalParams,
+  // @ts-expect-error The approved flag is a JSON boolean, not a number.
+  approved: 1,
+};
+
 type ERC1155DirectOutcome = ReturnType<ERC1155["transferReceipt"]>["outcome"];
 const directEvent: ERC1155DirectOutcome["event"] = "TransferSingle";
 // @ts-expect-error The direct transfer Receipt cannot report a TransferBatch event.
@@ -67,6 +88,10 @@ class ERC1155CompileFixture {
 void erc1155Params;
 void invalidTokenId;
 void missingRecipient;
+void erc1155ApprovalParams;
+void erc1155RevokeParams;
+void invalidApprovedString;
+void invalidApprovedNumber;
 void directEvent;
 void invalidDirectEvent;
 void batchOutcome;


### PR DESCRIPTION
## What and why

Audit of `feat/erc1155` (post main sync) found one public-API problem that must be fixed before the branch merges back to `main`: the `approve` Capability's `approved` parameter used a bespoke `"1"`/`"0"` string convention.

- JSON and MCP express booleans natively; the string form forced Agents through a protocol-specific encoding for no benefit (the string convention exists for *amounts*, to avoid number-precision loss — booleans have no such problem).
- Its type description ("Pass \"1\" to approve the operator…") embedded the field's use-site role, violating the rule that a Parameter type describes only the value's representation while the declaration describes its purpose.
- Once merged to `main` this becomes a public contract, so it has to be right the first time.

## Changes

- `@themoss/core`: add the reusable `BooleanFlag` parameter value type to semantics (pattern-matches `BasisPoints`, the existing non-string primitive).
- `@themoss/erc`: `approved` is now a JSON boolean; the declaration's description carries the field purpose.
- Tests: calldata construction for `true`/`false`; runtime rejection of the old `"1"` string form.
- Compile-time fixtures both directions: valid boolean params infer correctly; string and number forms are rejected with `@ts-expect-error`.
- Changeset for both packages.

## Verification

- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `NODE_USE_ENV_PROXY=1 pnpm test` ✅ (including the ERC-1155 live Monad mainnet e2e, zero Warnings)
