### PR TITLE
refactor(erc): parse ApprovalForAll through the shared ERC-1155 change path

### DIFF
--- a/packages/erc/src/erc1155.ts
+++ b/packages/erc/src/erc1155.ts
@@ -65,13 +65,6 @@ const erc1155ApprovalCheckParams = {
   operator: { type: Address, description: "Address whose operator status is checked." },
 } satisfies ParamsSpec;
 
-export type ERC1155ApprovalOutcome = {
-  operation: "approvalForAll";
-  collection: AddressValue;
-  account: AddressValue;
-  operator: AddressValue;
-  approved: boolean;
-};
 export type ERC1155TransferItem = {
   tokenId: string;
   amount: string;
@@ -96,9 +89,17 @@ export type ERC1155Outcome =
       from: AddressValue;
       to: AddressValue;
       items: readonly ERC1155TransferItem[];
+    }
+  | {
+      operation: "approvalForAll";
+      collection: AddressValue;
+      account: AddressValue;
+      operator: AddressValue;
+      approved: boolean;
     };
 
 export type ERC1155TransferOutcome = Extract<ERC1155Outcome, { event: "TransferSingle" }>;
+export type ERC1155ApprovalOutcome = Extract<ERC1155Outcome, { operation: "approvalForAll" }>;
 
 @Protocol({
   name: "erc1155",
@@ -194,11 +195,15 @@ export class ERC1155 {
   @Receipt()
   transferReceipt(changes: readonly Change[]): MossReceipt<ERC1155TransferOutcome> {
     const receipt = this.changesReceipt(changes);
-    const [outcome] = receipt.outcome;
-    if (!outcome || receipt.outcome.length !== 1 || outcome.event !== "TransferSingle") {
+    const transfers = receipt.outcome.filter(
+      (outcome): outcome is ERC1155TransferOutcome =>
+        outcome.operation === "transfer" && outcome.event === "TransferSingle",
+    );
+    const [transfer] = transfers;
+    if (!transfer || transfers.length !== 1 || receipt.outcome.length !== 1) {
       throw new Error("ERC1155 transfer Receipt requires exactly one TransferSingle Change");
     }
-    return { ...receipt, outcome, text: receipt.changes[0]?.text ?? receipt.text };
+    return { ...receipt, outcome: transfer, text: receipt.changes[0]?.text ?? receipt.text };
   }
 
   @Receipt()
@@ -224,40 +229,15 @@ export class ERC1155 {
 
   @Receipt()
   approvalReceipt(changes: readonly Change[]): MossReceipt<ERC1155ApprovalOutcome> {
-    const first = changes[0];
-    if (changes.length !== 1 || !first || first.kind !== "event") {
-      throw new Error("ERC1155 approval Receipt requires exactly one event Change");
+    const receipt = this.changesReceipt(changes);
+    const approvals = receipt.outcome.filter(
+      (outcome): outcome is ERC1155ApprovalOutcome => outcome.operation === "approvalForAll",
+    );
+    const [approval] = approvals;
+    if (!approval || approvals.length !== 1 || receipt.outcome.length !== 1) {
+      throw new Error("ERC1155 approval Receipt requires exactly one ApprovalForAll Change");
     }
-    let decoded: ReturnType<typeof decodeEventLog<typeof ierc1155Abi>>;
-    try {
-      decoded = decodeEventLog({
-        abi: ierc1155Abi,
-        topics: first.topics as [Hex, ...Hex[]],
-        data: first.data,
-        strict: true,
-      });
-    } catch {
-      throw new Error(`Unexpected Change: ${first.address} emitted an unsupported event`);
-    }
-    if (decoded.eventName !== "ApprovalForAll") {
-      throw new Error(
-        `Unexpected Change: ${first.address} emitted ${decoded.eventName}, expected ApprovalForAll`,
-      );
-    }
-    const outcome: ERC1155ApprovalOutcome = {
-      operation: "approvalForAll",
-      collection: first.address,
-      account: decoded.args.account,
-      operator: decoded.args.operator,
-      approved: decoded.args.approved,
-    };
-    const text = `ERC1155 ApprovalForAll: ${outcome.account} ${outcome.approved ? "approved" : "revoked"} ${outcome.operator} for ${outcome.collection}`;
-    return {
-      kind: "receipt",
-      outcome,
-      text,
-      changes: [{ kind: "change" as const, change: first, data: outcome, text }],
-    };
+    return { ...receipt, outcome: approval, text: receipt.changes[0]?.text ?? receipt.text };
   }
 }
 
@@ -291,6 +271,16 @@ function parseERC1155Change(change: Change): ERC1155Outcome {
     };
   }
 
+  if (decoded.eventName === "ApprovalForAll") {
+    return {
+      operation: "approvalForAll",
+      collection: change.address,
+      account: decoded.args.account,
+      operator: decoded.args.operator,
+      approved: decoded.args.approved,
+    };
+  }
+
   if (decoded.eventName === "TransferBatch") {
     if (decoded.args.ids.length !== decoded.args.values.length) {
       throw new Error("Unexpected Change: ERC1155 TransferBatch ids and values lengths differ");
@@ -316,6 +306,9 @@ function parseERC1155Change(change: Change): ERC1155Outcome {
 }
 
 function describeERC1155Outcome(outcome: ERC1155Outcome): string {
+  if (outcome.operation === "approvalForAll") {
+    return `ERC1155 ApprovalForAll: ${outcome.account} ${outcome.approved ? "approved" : "revoked"} ${outcome.operator} for ${outcome.collection}`;
+  }
   if (outcome.event === "TransferSingle") {
     return `ERC1155 TransferSingle: ${outcome.amount} of ${outcome.collection} #${outcome.tokenId} from ${outcome.from} to ${outcome.to} by ${outcome.operator}`;
   }

--- a/packages/erc/test/erc1155.test.ts
+++ b/packages/erc/test/erc1155.test.ts
@@ -199,11 +199,21 @@ describe("ERC1155", () => {
     ).rejects.toThrow("uint256 max");
   });
 
-  it("parses single, batch, and single Changes exhaustively in original order", () => {
+  it("parses single, batch, approval, and single Changes exhaustively in original order", () => {
     const first = transferSingle(7n, 0n, { operator: ACCOUNT, from: ACCOUNT, to: ACCOUNT });
     const batch = transferBatch([9n, 9n, 2n], [3n, 0n, 4n]);
+    const approval: Change = {
+      kind: "event",
+      address: COLLECTION,
+      topics: encodeEventTopics({
+        abi: ierc1155Abi,
+        eventName: "ApprovalForAll",
+        args: { account: ACCOUNT, operator: OPERATOR },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "bool", name: "approved" }], [true]),
+    };
     const last = transferSingle(11n, 5n);
-    const changes = [first, batch, last] as const;
+    const changes = [first, batch, approval, last] as const;
     const receipt = (Object.create(ERC1155.prototype) as ERC1155).changesReceipt(changes);
 
     expect(receipt.outcome).toEqual([
@@ -231,6 +241,13 @@ describe("ERC1155", () => {
         ],
       },
       {
+        operation: "approvalForAll",
+        collection: COLLECTION,
+        account: ACCOUNT,
+        operator: OPERATOR,
+        approved: true,
+      },
+      {
         operation: "transfer",
         event: "TransferSingle",
         collection: COLLECTION,
@@ -249,6 +266,7 @@ describe("ERC1155", () => {
     expect(() => verifyReceiptCoverage(changes, receipt)).not.toThrow();
     expect(receipt.text).toContain("TransferSingle");
     expect(receipt.text).toContain("TransferBatch");
+    expect(receipt.text).toContain("ApprovalForAll");
   });
 
   it("narrows a direct transfer Receipt to exactly one TransferSingle", () => {
@@ -280,17 +298,17 @@ describe("ERC1155", () => {
     } satisfies Change;
     expect(() => protocol.changesReceipt([native])).toThrow("only accept contract events");
 
-    const approval = {
+    const uriEvent = {
       kind: "event",
       address: COLLECTION,
       topics: encodeEventTopics({
         abi: ierc1155Abi,
-        eventName: "ApprovalForAll",
-        args: { account: ACCOUNT, operator: OPERATOR },
+        eventName: "URI",
+        args: { id: 1n },
       }) as readonly Hex[],
-      data: encodeAbiParameters([{ type: "bool", name: "approved" }], [true]),
+      data: encodeAbiParameters([{ type: "string", name: "value" }], ["ipfs://item"]),
     } satisfies Change;
-    expect(() => protocol.changesReceipt([approval])).toThrow("unsupported ERC-1155 event");
+    expect(() => protocol.changesReceipt([uriEvent])).toThrow("unsupported ERC-1155 event");
 
     const malformed = { ...transferSingle(1n, 1n), data: "0x" as Hex } satisfies Change;
     expect(() => protocol.changesReceipt([malformed])).toThrow("unsupported ERC-1155 event");
@@ -409,8 +427,11 @@ describe("ERC1155", () => {
   it("approvalReceipt rejects non-ApprovalForAll events", () => {
     const transfer = transferSingle(1n, 1n);
     const protocol = Object.create(ERC1155.prototype) as ERC1155;
-    expect(() => protocol.approvalReceipt([transfer])).toThrow("expected ApprovalForAll");
-    expect(() => protocol.approvalReceipt([])).toThrow("exactly one event");
+    expect(() => protocol.approvalReceipt([transfer])).toThrow("exactly one ApprovalForAll Change");
+    expect(() => protocol.approvalReceipt([])).toThrow("exactly one ApprovalForAll Change");
+    expect(() => protocol.transferReceipt([transfer, transfer])).toThrow(
+      "exactly one TransferSingle Change",
+    );
   });
 });
 


### PR DESCRIPTION
## What and why

Final-audit refactor of the ERC-1155 module that was pushed to `feat/erc1155` moments after #123 was merged, so it missed the merge-back. Cherry-picked onto current `main` unchanged.

Aligns the module with the erc20 sibling pattern:

- `ERC1155Outcome` gains the `approvalForAll` variant; `ERC1155ApprovalOutcome` becomes an `Extract` of the union (same shape as before).
- `parseERC1155Change` decodes `ApprovalForAll`, so the module has one decode path and one describe function.
- `approvalReceipt` narrows from `changesReceipt` exactly like `transferReceipt` (and like erc20's `approveReceipt`), deleting the hand-rolled second `decodeEventLog` path (~30 duplicated lines).
- Net effect beyond cleanliness: the `changesReceipt` delegation surface now covers approval events, so protocol packages delegating ERC-1155 evidence no longer fail on an `ApprovalForAll` Change they semantically understand.

No changeset: the narrower union never shipped in a release — the pending `@themoss/erc` minors cover the feature as it will first be published.

## Verification

- `pnpm lint` / `pnpm build` / `pnpm typecheck` ✅
- `NODE_USE_ENV_PROXY=1 pnpm test` ✅ including the ERC-1155 live Monad mainnet e2e (zero Warnings, exhaustive coverage)
- Tests updated: the exhaustive-order test interleaves an `ApprovalForAll` Change between transfers; the fails-closed test uses the `URI` event as its genuinely unsupported case
