### PR TITLE
feat(erc): add ERC-721 collection interface inspection

### DIFF
--- a/.changeset/erc721-collection-inspection.md
+++ b/.changeset/erc721-collection-inspection.md
@@ -1,0 +1,5 @@
+---
+"@themoss/erc": minor
+---
+
+Add an ERC-721 collection inspection Query that reports the contract's direct ERC-165 declarations for ERC-721 and common optional interfaces.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | --- | --- | --- | --- |
 | WMON | `@themoss/system` | `wrap`, `unwrap` | `balanceOf` |
 | ERC-20 and native MON | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `allowance`, `metadata` |
-| ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
+| ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf`, `inspectCollection` |
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
+
+ERC-721 `inspectCollection` accepts a collection address and reports the contract's ERC-165 declarations for ERC-165, ERC-721, ERC-721 Metadata, ERC-721 Enumerable, and ERC-2981 royalties. The flags reproduce the contract's direct declarations and may therefore be inconsistent. This inspection is not a security audit and does not prove that the contract fully complies with any reported standard.
 
 ERC-1155 `transfer` accepts a collection, token ID, amount, and recipient. Token IDs and amounts are base-10 uint256 strings, including zero. The Capability builds one `safeTransferFrom`; batch transfer construction is not currently exposed. Receipts still decode both `TransferSingle` and `TransferBatch` Changes without aggregating or reordering their items.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,10 +21,12 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | --- | --- | --- | --- |
 | WMON | `@themoss/system` | `wrap`、`unwrap` | `balanceOf` |
 | ERC-20 与 native MON | `@themoss/erc` | `transfer`、`approve` | `balanceOf`、`allowance`、`metadata` |
-| ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
+| ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf`、`inspectCollection` |
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
+
+ERC-721 `inspectCollection` 接收 collection 地址，并报告合约通过 ERC-165 直接声明的 ERC-165、ERC-721、ERC-721 Metadata、ERC-721 Enumerable 与 ERC-2981 royalties 支持情况。这些标志原样反映合约的声明，因此可能彼此不一致。此检查不是安全审计，也不能证明合约完全符合其所报告的任何标准。
 
 ERC-1155 `transfer` 接收 collection、token ID、amount 和 recipient。token ID 与 amount 使用十进制 uint256 字符串（允许零）。该 Capability 只构建一笔 `safeTransferFrom`，目前不暴露批量转账构建；Receipt 仍会解析 `TransferSingle` 和 `TransferBatch` Change，并保留批量条目的原始顺序，不做聚合。
 

--- a/packages/erc/contracts/IERC165.sol
+++ b/packages/erc/contracts/IERC165.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice The ERC-165 standard interface consumed by Moss.
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/packages/erc/contracts/IERC721.sol
+++ b/packages/erc/contracts/IERC721.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import {IERC165} from "./IERC165.sol";
+
 /// @notice The ERC-721 interface Moss consumes: EIP-721 core plus the
 /// optional metadata extension. This file is the source of truth for the
 /// generated `src/abis/erc.ts` — regenerate with `pnpm gen:abis` (requires
 /// foundry).
-interface IERC721 {
+interface IERC721 is IERC165 {
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
     event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
     event ApprovalForAll(address indexed owner, address indexed operator, bool approved);

--- a/packages/erc/src/abis/erc.ts
+++ b/packages/erc/src/abis/erc.ts
@@ -374,6 +374,13 @@ export const ierc721Abi = [
   },
   {
     type: 'function',
+    inputs: [{ name: 'interfaceId', internalType: 'bytes4', type: 'bytes4' }],
+    name: 'supportsInterface',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     inputs: [],
     name: 'symbol',
     outputs: [{ name: '', internalType: 'string', type: 'string' }],

--- a/packages/erc/src/erc721.ts
+++ b/packages/erc/src/erc721.ts
@@ -18,9 +18,24 @@ import {
 import { decodeEventLog } from "viem";
 import { ierc721Abi } from "./abis/erc.js";
 
+const ERC721_INTERFACE_IDS = {
+  erc165: "0x01ffc9a7",
+  erc721: "0x80ac58cd",
+  metadata: "0x5b5e139f",
+  enumerable: "0x780e9d63",
+  erc2981: "0x2a55205a",
+} as const;
+
 const tokenParams = {
   collection: { type: Address, description: "Collection containing the requested token." },
   tokenId: { type: UnsignedIntegerString, description: "Token selected within the collection." },
+} satisfies ParamsSpec;
+
+const inspectCollectionParams = {
+  collection: {
+    type: Address,
+    description: "Collection whose ERC-165 interface declarations are inspected.",
+  },
 } satisfies ParamsSpec;
 
 const transferParams = {
@@ -41,10 +56,21 @@ export type ERC721TransferOutcome = {
   tokenId: string;
 };
 
+export type ERC721CollectionInspection = {
+  collection: AddressValue;
+  supports: {
+    erc165: boolean;
+    erc721: boolean;
+    erc721Metadata: boolean;
+    erc721Enumerable: boolean;
+    erc2981Royalties: boolean;
+  };
+};
+
 @Protocol({
   name: "erc721",
   category: "nft",
-  description: "Generic ERC-721 transfers, ownership, and balance queries.",
+  description: "Generic ERC-721 transfers, ownership, balances, and declared interface inspection.",
   contracts: {},
 })
 export class ERC721 {
@@ -86,6 +112,47 @@ export class ERC721 {
       params.owner,
     ]);
     return { ...params, balance: balance.toString() };
+  }
+
+  @Query({
+    intent: "Inspect an ERC-721 collection's declared interfaces",
+    params: inspectCollectionParams,
+  })
+  async inspectCollection(
+    params: InferParams<typeof inspectCollectionParams>,
+    ctx: ActionCtx,
+  ): Promise<ERC721CollectionInspection> {
+    const handle = this.#handle(params.collection, ctx.account);
+    const erc165 = await handle.read.supportsInterface([ERC721_INTERFACE_IDS.erc165]);
+    if (!erc165) {
+      return {
+        collection: params.collection,
+        supports: {
+          erc165: false,
+          erc721: false,
+          erc721Metadata: false,
+          erc721Enumerable: false,
+          erc2981Royalties: false,
+        },
+      };
+    }
+
+    const [erc721, erc721Metadata, erc721Enumerable, erc2981Royalties] = await Promise.all([
+      handle.read.supportsInterface([ERC721_INTERFACE_IDS.erc721]),
+      handle.read.supportsInterface([ERC721_INTERFACE_IDS.metadata]),
+      handle.read.supportsInterface([ERC721_INTERFACE_IDS.enumerable]),
+      handle.read.supportsInterface([ERC721_INTERFACE_IDS.erc2981]),
+    ]);
+    return {
+      collection: params.collection,
+      supports: {
+        erc165,
+        erc721,
+        erc721Metadata,
+        erc721Enumerable,
+        erc2981Royalties,
+      },
+    };
   }
 
   @Receipt()

--- a/packages/erc/src/index.ts
+++ b/packages/erc/src/index.ts
@@ -5,7 +5,11 @@ export {
   iweth9Abi as WETH9Abi,
 } from "./abis/erc.js";
 export { ERC20, type ERC20Outcome } from "./erc20.js";
-export { ERC721, type ERC721TransferOutcome } from "./erc721.js";
+export {
+  ERC721,
+  type ERC721CollectionInspection,
+  type ERC721TransferOutcome,
+} from "./erc721.js";
 export {
   ERC1155,
   type ERC1155ApprovalOutcome,

--- a/packages/erc/test/erc721.test.ts
+++ b/packages/erc/test/erc721.test.ts
@@ -13,8 +13,53 @@ import { ERC721 } from "../src/index.js";
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 const RECIPIENT = "0x1111111111111111111111111111111111111111";
 const COLLECTION = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa";
+const INTERFACE_IDS = [
+  "0x01ffc9a7",
+  "0x80ac58cd",
+  "0x5b5e139f",
+  "0x780e9d63",
+  "0x2a55205a",
+] as const;
 
 const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
+
+type InterfaceId = (typeof INTERFACE_IDS)[number];
+type InspectionCall = {
+  address: string;
+  functionName: string;
+  args?: readonly unknown[];
+};
+
+function inspectionRegistry(
+  responses: Partial<Record<InterfaceId, boolean>>,
+  errors: Partial<Record<InterfaceId, Error>> = {},
+) {
+  const calls: InspectionCall[] = [];
+  const inspectionRuntime: MossRuntime = {
+    rpcUrl: "http://offline",
+    client: {
+      readContract: async (call: InspectionCall) => {
+        calls.push(call);
+        if (call.functionName !== "supportsInterface") {
+          throw new Error(`unexpected read ${call.functionName}`);
+        }
+        const interfaceId = call.args?.[0];
+        if (!INTERFACE_IDS.includes(interfaceId as InterfaceId)) {
+          throw new Error(`unexpected interface ID ${String(interfaceId)}`);
+        }
+        const typedInterfaceId = interfaceId as InterfaceId;
+        const error = errors[typedInterfaceId];
+        if (error) throw error;
+        const response = responses[typedInterfaceId];
+        if (response === undefined) {
+          throw new Error(`missing response for ${typedInterfaceId}`);
+        }
+        return response;
+      },
+    } as unknown as MossRuntime["client"],
+  };
+  return { registry: new Registry(inspectionRuntime).use(ERC721), calls };
+}
 
 describe("ERC721", () => {
   it("registers directly and builds safeTransferFrom", async () => {
@@ -55,5 +100,146 @@ describe("ERC721", () => {
     });
     expect(receipt.changes[0]).toMatchObject({ kind: "change", change });
     expect(receipt.text).toContain("ERC721 Transfer:");
+  });
+
+  it("inspects all five declared interfaces at the exact collection address", async () => {
+    const responses = Object.fromEntries(INTERFACE_IDS.map((interfaceId) => [interfaceId, true]));
+    const { registry, calls } = inspectionRegistry(responses);
+
+    await expect(
+      registry.action("erc721", "inspectCollection", ACCOUNT, { collection: COLLECTION }),
+    ).resolves.toEqual({
+      kind: "query",
+      protocol: "erc721",
+      method: "inspectCollection",
+      data: {
+        collection: COLLECTION,
+        supports: {
+          erc165: true,
+          erc721: true,
+          erc721Metadata: true,
+          erc721Enumerable: true,
+          erc2981Royalties: true,
+        },
+      },
+    });
+
+    expect(calls).toHaveLength(INTERFACE_IDS.length);
+    expect(calls.every(({ address }) => address === COLLECTION)).toBe(true);
+    expect(calls.every(({ functionName }) => functionName === "supportsInterface")).toBe(true);
+    expect(calls.map(({ args }) => args?.[0])).toEqual(INTERFACE_IDS);
+    for (const interfaceId of INTERFACE_IDS) {
+      expect(calls.filter(({ args }) => args?.[0] === interfaceId)).toHaveLength(1);
+    }
+  });
+
+  it("returns the collection's direct mixed declarations without inferring consistency", async () => {
+    const { registry } = inspectionRegistry({
+      "0x01ffc9a7": true,
+      "0x80ac58cd": false,
+      "0x5b5e139f": true,
+      "0x780e9d63": false,
+      "0x2a55205a": true,
+    });
+
+    await expect(
+      registry.action("erc721", "inspectCollection", ACCOUNT, { collection: COLLECTION }),
+    ).resolves.toMatchObject({
+      data: {
+        collection: COLLECTION,
+        supports: {
+          erc165: true,
+          erc721: false,
+          erc721Metadata: true,
+          erc721Enumerable: false,
+          erc2981Royalties: true,
+        },
+      },
+    });
+  });
+
+  it("stops after one read and returns all false when ERC-165 is not declared", async () => {
+    const { registry, calls } = inspectionRegistry({ "0x01ffc9a7": false });
+
+    await expect(
+      registry.action("erc721", "inspectCollection", ACCOUNT, { collection: COLLECTION }),
+    ).resolves.toMatchObject({
+      data: {
+        collection: COLLECTION,
+        supports: {
+          erc165: false,
+          erc721: false,
+          erc721Metadata: false,
+          erc721Enumerable: false,
+          erc2981Royalties: false,
+        },
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      address: COLLECTION,
+      functionName: "supportsInterface",
+      args: ["0x01ffc9a7"],
+    });
+  });
+
+  it("propagates a revert from the first ERC-165 read", async () => {
+    const revert = new Error("supportsInterface reverted");
+    const { registry, calls } = inspectionRegistry({}, { "0x01ffc9a7": revert });
+
+    await expect(
+      registry.action("erc721", "inspectCollection", ACCOUNT, { collection: COLLECTION }),
+    ).rejects.toBe(revert);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("propagates a later interface read failure after starting all four checks", async () => {
+    const revert = new Error("ERC-721 Metadata check reverted");
+    const { registry, calls } = inspectionRegistry(
+      {
+        "0x01ffc9a7": true,
+        "0x80ac58cd": true,
+        "0x780e9d63": false,
+        "0x2a55205a": true,
+      },
+      { "0x5b5e139f": revert },
+    );
+
+    await expect(
+      registry.action("erc721", "inspectCollection", ACCOUNT, { collection: COLLECTION }),
+    ).rejects.toBe(revert);
+    expect(calls.map(({ args }) => args?.[0])).toEqual(INTERFACE_IDS);
+  });
+
+  it("rejects a malformed collection before reading the contract", async () => {
+    const { registry, calls } = inspectionRegistry({ "0x01ffc9a7": true });
+
+    await expect(
+      registry.action("erc721", "inspectCollection", ACCOUNT, {
+        collection: "not-an-address",
+      }),
+    ).rejects.toThrow("invalid parameters");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("propagates a valid-address decoding failure instead of returning false", async () => {
+    const decodingFailure = new Error("contract returned no data");
+    const { registry } = inspectionRegistry({}, { "0x01ffc9a7": decodingFailure });
+
+    await expect(
+      registry.action("erc721", "inspectCollection", ACCOUNT, { collection: COLLECTION }),
+    ).rejects.toBe(decodingFailure);
+  });
+
+  it("loads separate Address type and inspectCollection field descriptions", () => {
+    const { registry } = inspectionRegistry({ "0x01ffc9a7": false });
+    const [loaded] = registry.load([{ protocol: "erc721", method: "inspectCollection" }]);
+
+    expect(loaded?.params.collection).toMatchObject({
+      description: "Collection whose ERC-165 interface declarations are inspected.",
+      type: {
+        description: "A 20-byte EVM address encoded as a 0x-prefixed hexadecimal string.",
+      },
+    });
   });
 });

--- a/packages/erc/test/types.fixture.ts
+++ b/packages/erc/test/types.fixture.ts
@@ -1,7 +1,8 @@
-import type { Change, ReceiptResult } from "@themoss/core";
+import type { ActionCtx, Change, ReceiptResult } from "@themoss/core";
 import { Receipt } from "@themoss/core";
 import type { ERC20 } from "../src/erc20.js";
 import type { ERC1155, ERC1155Outcome } from "../src/erc1155.js";
+import type { ERC721, ERC721CollectionInspection } from "../src/index.js";
 
 type TransferOperation = ReturnType<ERC20["transferReceipt"]>["outcome"]["operation"];
 type ApprovalOperation = ReturnType<ERC20["approveReceipt"]>["outcome"]["operation"];
@@ -96,3 +97,35 @@ void directEvent;
 void invalidDirectEvent;
 void batchOutcome;
 void ERC1155CompileFixture;
+
+type InspectCollectionParams = Parameters<ERC721["inspectCollection"]>[0];
+const inspectCollectionParams: InspectCollectionParams = {
+  collection: "0x1111111111111111111111111111111111111111",
+};
+const invalidInspectCollectionParams: InspectCollectionParams = {
+  // @ts-expect-error ERC-721 collection inspection requires an EVM address.
+  collection: "not-an-address",
+};
+const erc721 = null as unknown as ERC721;
+const inspectionPromise = erc721.inspectCollection(
+  inspectCollectionParams,
+  null as unknown as ActionCtx,
+);
+type InspectCollectionResult = Awaited<typeof inspectionPromise>;
+const inspectionResult = null as unknown as InspectCollectionResult;
+const publicInspection: ERC721CollectionInspection = inspectionResult;
+const supportsErc165: boolean = inspectionResult.supports.erc165;
+const supportsErc721: boolean = inspectionResult.supports.erc721;
+const supportsMetadata: boolean = inspectionResult.supports.erc721Metadata;
+const supportsEnumerable: boolean = inspectionResult.supports.erc721Enumerable;
+const supportsRoyalties: boolean = inspectionResult.supports.erc2981Royalties;
+// @ts-expect-error ERC-721 inspection results do not contain ERC-1155 support.
+void inspectionResult.supports.erc1155;
+
+void invalidInspectCollectionParams;
+void publicInspection;
+void supportsErc165;
+void supportsErc721;
+void supportsMetadata;
+void supportsEnumerable;
+void supportsRoyalties;


### PR DESCRIPTION
## What and why

<!-- What does this PR change, and what user or Protocol problem does it solve? Link the issue when one exists. -->

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

<!-- Public types, package boundaries, Capability tree, Change/Receipt behavior, or "none". -->

## Verification

- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] User-facing package changes include a changeset
- [ ] Docs and examples match the implemented API

### Protocol changes

<!-- Mark N/A for non-Protocol PRs. -->

- [ ] Parameters separate reusable Zod value types from field-purpose descriptions
- [ ] Every Capability owns one direct TransactionNode and one typed Receipt
- [ ] Receipt tests preserve every original Change object in exact length and order
- [ ] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [ ] Fixed addresses and ABIs include sources and verification
- [ ] A live Monad happy path returns zero Warnings

## Evidence

<!-- Relevant output, structured Receipt Outcomes, screenshots, or reproduction steps. -->
