### PR TITLE
feat(protocols): add shMONAD liquid staking adapter

### DIFF
--- a/packages/protocols/shmonad/README.md
+++ b/packages/protocols/shmonad/README.md
@@ -1,0 +1,46 @@
+# @themoss/protocol-shmonad
+
+This package contains the self-describing `ShMonad` Protocol for FastLane liquid
+staking on Monad mainnet. Staking MON mints shMON, an ERC-4626 vault share that
+accrues staking and MEV rewards. The default MCP CLI selects the module
+namespace, so `discover` and `load` expose it without import-time registration.
+
+## Capabilities and Queries
+
+- `stake`: deposits native MON and mints shMON to the receiver. MON is forwarded
+  as `msg.value` to the ERC-4626 `deposit`; no pre-wrap is needed.
+- `unstake`: redeems shMON for MON through ERC-4626 `redeem`.
+- `balanceOf`: reads a shMON balance.
+- `exchangeRate`: reads the current shMON-to-MON rate from `convertToAssets`.
+
+Amounts are human-readable decimal strings; MON and shMON both use 18 decimals.
+The request/complete unbonding flow (`requestUnstake` and related methods) is out
+of scope for this version.
+
+## Receipt evidence
+
+`stake` owns `stakeReceipt` and `unstake` owns `unstakeReceipt`. Each parses the
+transaction's ordered Changes, retains every input Change by identity and order,
+and cross-checks the ERC-4626 event against the native transfer: the Deposit or
+Withdraw `assets` must equal the native MON value. ERC-20 Transfer and Approval
+events are delegated to the `erc20` dependency. The parsers derive the outcome
+only from this evidence and do not call RPC.
+
+## Deployment and ABI origin
+
+`SHMONAD_ADDRESS` is the shMON proxy on Monad mainnet, a
+TransparentUpgradeableProxy. Live tests verify its deployed bytecode and the
+shMON symbol and decimals.
+
+The ABI is a full explorer-tier artifact (ADR 0007). `getabi` on a proxy returns
+the proxy's own ABI, so the ABI is fetched from the ERC-1967 implementation
+recorded in `SHMONAD_IMPLEMENTATION_ADDRESS`:
+
+```bash
+pnpm --filter @themoss/protocol-shmonad update:abis
+```
+
+The command uses `@themoss/abi-tools` and requires `MONADSCAN_API_KEY`.
+`test/abis.test.ts` checks the committed artifact against the shared renderer,
+and the live e2e reads the proxy's ERC-1967 slot to confirm it still matches the
+recorded implementation, so a proxy upgrade turns the suite red.

--- a/packages/protocols/shmonad/package.json
+++ b/packages/protocols/shmonad/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@themoss/protocol-shmonad",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Moss protocol adapter for FastLane shMONAD liquid staking on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "update:abis": "tsx scripts/update-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/abi-tools": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6",
+    "@themoss/simulator": "workspace:*",
+    "@themoss/system": "workspace:*"
+  }
+}

--- a/packages/protocols/shmonad/scripts/abis.ts
+++ b/packages/protocols/shmonad/scripts/abis.ts
@@ -1,0 +1,35 @@
+/**
+ * The OFFLINE half of the ABI pipeline: the source-of-truth table mapping the
+ * shMONAD contract to its generated module under src/abis/.
+ *
+ * shMONAD is a TransparentUpgradeableProxy (ERC-1967). Explorer `getabi` on the
+ * proxy returns the proxy's own ABI, so the staking surface is fetched from the
+ * verified *implementation* address recorded here, while the adapter binds it to
+ * the proxy at SHMONAD_ADDRESS.
+ *
+ * scripts/update-abis.ts fetches this verified ABI from the explorer;
+ * test/abis.test.ts enforces that the committed module is byte-exact
+ * renderAbiModule output for this entry, and that the address equals the
+ * protocol's exported SHMONAD_IMPLEMENTATION_ADDRESS. The live e2e additionally
+ * pins that constant to the proxy's ERC-1967 implementation slot, so a proxy
+ * upgrade turns the suite red instead of silently shipping a stale ABI.
+ */
+export interface AbiSource {
+  /** TypeScript identifier prefix: the module exports `<exportName>Abi`. */
+  exportName: string;
+  /** Generated module filename under src/abis/. */
+  file: string;
+  /** Verified Monad mainnet address the ABI is fetched from. */
+  address: `0x${string}`;
+}
+
+export const SOURCES: readonly AbiSource[] = [
+  {
+    // The ShMonad implementation behind the SHMONAD_ADDRESS proxy. Fetching the
+    // proxy address would yield the proxy's own ABI, not the ERC-4626 staking
+    // surface the adapter calls.
+    exportName: "ShMonad",
+    file: "shmonad.ts",
+    address: "0x856A4019228c265DEE336DF705277607c4A18e1B",
+  },
+];

--- a/packages/protocols/shmonad/scripts/update-abis.ts
+++ b/packages/protocols/shmonad/scripts/update-abis.ts
@@ -1,0 +1,30 @@
+/**
+ * The NETWORK half of the ABI pipeline (ADR 0007 "explorer" tier): fetch each
+ * verified ABI in SOURCES from the official Etherscan V2 endpoint for Monad
+ * mainnet (chainid=143) and rewrite src/abis/ deterministically via
+ * @themoss/abi-tools. test/abis.test.ts pins the committed modules to this
+ * renderer's exact output.
+ *
+ * shMONAD is a proxy: SOURCES records the verified implementation address, so
+ * this fetches the ERC-4626 staking ABI rather than the proxy's own surface.
+ *
+ * Usage: MONADSCAN_API_KEY=... pnpm update:abis
+ */
+import { writeFileSync } from "node:fs";
+import { fetchAbi, renderAbiModule } from "@themoss/abi-tools";
+import { SOURCES } from "./abis.js";
+
+const key = process.env.MONADSCAN_API_KEY;
+if (!key) {
+  throw new Error(
+    "MONADSCAN_API_KEY is not set; create one at https://info.monadscan.com/myapikey/ and export it.",
+  );
+}
+
+const abisDir = new URL("../src/abis/", import.meta.url);
+const retrievedAt = new Date();
+for (const { exportName, file, address } of SOURCES) {
+  const abi = await fetchAbi(address, key);
+  writeFileSync(new URL(file, abisDir), renderAbiModule({ exportName, address, abi, retrievedAt }));
+  console.log(`src/abis/${file}: ${abi.length} ABI entries from ${address}`);
+}

--- a/packages/protocols/shmonad/src/abis/shmonad.ts
+++ b/packages/protocols/shmonad/src/abis/shmonad.ts
@@ -1,0 +1,6113 @@
+// ABI origin: explorer (ADR 0007)
+//   Source:    https://monadscan.com/address/0x856A4019228c265DEE336DF705277607c4A18e1B
+//   Endpoint:  Etherscan V2 (chainid=143, module=contract, action=getabi)
+//   Retrieved: 2026-07-23 (UTC)
+
+export const ShMonadAbi = [
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "AgentInstantUncommittingDisallowed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountsLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountsLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "BatchHoldAccountAmountLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountsLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountsLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "BatchReleaseAccountAmountLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotUnstakeZeroShares",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "name": "CoinbaseAlreadyDeployed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CommissionMustBeBelow100Percent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CommitRecipientCannotBeZeroAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "currentEpoch",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "completionEpoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "CompletionEpochNotReached",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Create2Failed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      }
+    ],
+    "name": "CustomCoinbaseCantBeContract",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allowance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientAllowance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSpender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC2612ExpiredSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "ERC2612InvalidSigner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxDeposit",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxMint",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxRedeem",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxWithdraw",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netAssets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minNetAssets",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626RedeemSlippageExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sharesRequired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxBurntShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626WithdrawSlippageExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeeCurveFullUtilizationExceedsRay",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "IncorrectNativeTokenAmountSent",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientAccumulatedCommission",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "requestedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "availableAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientBalanceAtomicUnstakingPool",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientBalanceForUnstake",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "committed",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "holdRequested",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientCommittedForHold",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "committed",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "uncommitting",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "held",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "requested",
+        "type": "uint128"
+      }
+    ],
+    "name": "InsufficientFunds",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientPoolLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "requestedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "availableReserved",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientReservedLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "approved",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientUncommitApproval",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientUncommittedBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientUncommittingBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "committed",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "held",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "requested",
+        "type": "uint128"
+      }
+    ],
+    "name": "InsufficientUnheldCommittedBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientZeroYieldBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "currentNonce",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidAccountNonce",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "feeRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidFeeRate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidUncommitCompletor",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidValidatorAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvalidValidatorId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LegacyAtomicStateDetected",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LegacyDelegationsDetected",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LegacyDelegationsPaginationIncomplete",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LegacyLiabilitiesDetected",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LegacyStakeDetected",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoUnstakeRequestFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "NotPolicyAgent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotWhenClosed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotWhenFrozen",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "OnlyCoinbaseAuth",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PercentageMustBeBelow100Percent",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "PolicyAgentAlreadyExists",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "PolicyAgentNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      }
+    ],
+    "name": "PolicyInactive",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      }
+    ],
+    "name": "PolicyNeedsAtLeastOneAgent",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "bits",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeCastOverflowedUintDowncast",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SlopeRateExceedsRay",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TargetLiquidityCannotExceed100Percent",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "requestedPeriodDuration",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "minPeriodDuration",
+        "type": "uint32"
+      }
+    ],
+    "name": "TopUpPeriodDurationTooShort",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnauthorizedInitializer",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "uncommittingCompleteBlock",
+        "type": "uint256"
+      }
+    ],
+    "name": "UncommittingPeriodIncomplete",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ValidatorAlreadyAdded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ValidatorAlreadyDeactivated",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "availableMON",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "targetStakeMON",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorAvailableExceedsTargetStake",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ValidatorDeactivationNotQueued",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ValidatorDeactivationQueuedIncomplete",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "ValidatorNotFoundInPrecompile",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ValidatorNotFullyRemoved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WillOverflowOnBitshift",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "YInterceptExceedsRay",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "AddPolicyAgent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "AdminCommissionClaimedAsShares",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "payor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "msgValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "gasLimit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actualPayorCost",
+        "type": "uint256"
+      }
+    ],
+    "name": "AgentExecuteWithSponsor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "AgentTransferFromCommitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "AgentTransferToUncommitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "AgentWithdrawFromCommitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "yieldOriginator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "sharesBurned",
+        "type": "bool"
+      }
+    ],
+    "name": "BoostYield",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldCoinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newCoinbase",
+        "type": "address"
+      }
+    ],
+    "name": "CoinbaseContractUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Commit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "CompleteUncommit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountMon",
+        "type": "uint256"
+      }
+    ],
+    "name": "CompleteUnstake",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "name": "CrankSkippedOnValidatorIdZero",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint48",
+        "name": "escrowDuration",
+        "type": "uint48"
+      }
+    ],
+    "name": "CreatePolicy",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "vShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Delegate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositToZeroYieldTranche",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      }
+    ],
+    "name": "DisablePolicy",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldSlopeRateRay",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldYInterceptRay",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newSlopeRateRay",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newYInterceptRay",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeeCurveUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "InactiveValidatorRewardsRedirected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "globalEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedWithdrawAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actualWithdrawAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientActiveDelegatedBalance",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actualAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientLocalBalance",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "globalEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "targetStakeAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "netAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inActiveSetCurrent",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inActiveSetLast",
+        "type": "bool"
+      }
+    ],
+    "name": "LowValidatorStakeDeltaNetZero",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "globalEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "targetStakeAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "netAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inActiveSetCurrent",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inActiveSetLast",
+        "type": "bool"
+      }
+    ],
+    "name": "LowValidatorStakeDeltaOnDecrease",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "globalEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "targetStakeAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "netAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inActiveSetCurrent",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inActiveSetLast",
+        "type": "bool"
+      }
+    ],
+    "name": "LowValidatorStakeDeltaOnIncrease",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountRequested",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountUnstaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "ManualUnstakeInitiation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "redeemedAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ManualUnstakeRedemption",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "epochNumber",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "requestedUnstakeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "redeemedUnstakeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewEpoch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint120",
+        "name": "amountSent",
+        "type": "uint120"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint120",
+        "name": "amountRequested",
+        "type": "uint120"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "name": "PartialValidatorRewardsPayment",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "currentLiquidity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "targetLiquidity",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolLiquidityUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldPercentage",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolTargetLiquidityPercentageSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "offsetAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "globalUnstakableAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueForUnstake",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "globalStakableAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueToStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "QueuesOffsetViaNet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "RemovePolicyAgent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedUncommitCompleteBlock",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestUncommit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountMon",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "completionEpoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestUnstake",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netToReserves",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReservesIncreasedByExcessQueueCapacity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netToReserves",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReservesIncreasedBySurplusDeposits",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorPayout",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeTaken",
+        "type": "uint256"
+      }
+    ],
+    "name": "SendValidatorRewards",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "minCommitted",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "maxTopUpPerPeriod",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "topUpPeriodDuration",
+        "type": "uint32"
+      }
+    ],
+    "name": "SetTopUp",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountRequested",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountStaked",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "poolLiquidityRemaining",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeFromPoolLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueToStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakeUnassignableNoGlobalRevenue",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueToStake",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stakableAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingQueueExceedsStakableAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "completor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "shares",
+        "type": "uint96"
+      }
+    ],
+    "name": "UncommitApprovalUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "vShares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Undelegate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "shMonEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "activeExpected",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "activeActual",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedActiveStakeExpectedIsNotActual",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "shMonEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netUnavailable",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stakeIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "unstakeOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueToStake",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueForUnstake",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "distributedAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldAllocatedAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAllocatedAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedAtomicSettlementUnavailableAssets",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actualAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedDeficitOnUnstakeSettle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "nextTargetStakeAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "netAmount",
+        "type": "uint128"
+      }
+    ],
+    "name": "UnexpectedFailureInitiateStake",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "nextTargetStakeAmount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "netAmount",
+        "type": "uint128"
+      }
+    ],
+    "name": "UnexpectedFailureInitiateUnstake",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "epoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "goodwillAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedGoodwill",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "epoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueToStakeRolled",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueForUnstakeRolled",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedNoValidators",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "shMonEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "pendingStake",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedTotalStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedPendingStakeExceedsExpectedActive",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "shMonEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "pendingExpected",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "pendingActual",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedPendingStakeExpectedIsNotActual",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amountReceived",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedStakeSettlementError",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "shMonEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawalsExpected",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawalsActual",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedStakeWithdrawalsExpectedIsNotActual",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actualAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedSurplusOnUnstakeSettle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "shMonEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalExpected",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalActual",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawalsExpected",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawalsActual",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositsExpected",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositsActual",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedTotalStakeExpectedIsNotActual",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "validatorRewardsPayable",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "addressThisBalance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedValidatorRewardsPayError",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "valId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amountRewarded",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "addressThisBalance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "actionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnexpectedYieldSettlementError",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "epoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rewardsSentToValidator",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "revenueToShMonad",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnregisteredValidatorRevenue",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "UnstakeFeeEnabledSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "queueForUnstake",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "unstakableAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnstakingQueueExceedsUnstakableAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "name": "ValidatorAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorDeactivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "internalEpoch",
+        "type": "uint64"
+      }
+    ],
+    "name": "ValidatorMarkedInactive",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "internalEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "detectionIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorNotFoundInActiveSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "authAddress",
+        "type": "address"
+      }
+    ],
+    "name": "ValidatorRegisteredByAuth",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorStakeAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorUnstakeCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "withdrawEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "withdrawId",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorUnstakeRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "validators",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16[]",
+        "name": "targetWeights",
+        "type": "uint16[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalWeight",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorWeightsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "globalEpoch",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedWithdrawAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "availableWithdrawAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "withdrawalId",
+        "type": "uint8"
+      }
+    ],
+    "name": "WithdrawSettlementDelayed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "ZeroYieldBalanceConvertedToShares",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "STAKING_PRECOMPILE",
+    "outputs": [
+      {
+        "internalType": "contract IMonadStaking",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "addPolicyAgent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "addValidator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "name": "addValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fromReleaseAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "inUnderlying",
+        "type": "bool"
+      }
+    ],
+    "name": "agentTransferFromCommitted",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fromReleaseAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "inUnderlying",
+        "type": "bool"
+      }
+    ],
+    "name": "agentTransferToUncommitted",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fromReleaseAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "amountSpecifiedInUnderlying",
+        "type": "bool"
+      }
+    ],
+    "name": "agentWithdrawFromCommitted",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "asset",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOfCommitted",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOfCommitted",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOfUncommitting",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOfZeroYieldTranche",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address[]",
+        "name": "accounts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchHold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address[]",
+        "name": "accounts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchRelease",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "yieldOriginator",
+        "type": "address"
+      }
+    ],
+    "name": "boostYield",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "yieldOriginator",
+        "type": "address"
+      }
+    ],
+    "name": "boostYield",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "claimOwnerCommissionAsShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "commitRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "commit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "committedTotalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "completeUncommit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "fromPolicyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "toPolicyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "sharesRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "completeUncommitAndRecommit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "completeUncommitAndRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "completeUncommitWithApproval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "completeUnstake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "convertZeroYieldTrancheToShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "crank",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "complete",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint48",
+        "name": "escrowDuration",
+        "type": "uint48"
+      }
+    ],
+    "name": "createPolicy",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "deactivateValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "sharesRecipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sharesToCommit",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositAndCommit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "sharesMinted",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "depositToZeroYieldTranche",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      }
+    ],
+    "name": "disablePolicy",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getActiveValidatorCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAdminValues",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "internalEpoch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint16",
+        "name": "targetLiquidityPercentage",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "incentiveAlignmentPercentage",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "stakingCommission",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "boostCommissionRate",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint128",
+        "name": "totalZeroYieldPayable",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAtomicCapital",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "allocatedAmount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "distributedAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAtomicPoolUtilization",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "utilized",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allocated",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "utilizationWad",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAtomicUtilizationWad",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "utilizationWad",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getCommittedData",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "committed",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "minCommitted",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentUnstakeFeeRateRay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "feeRateRay",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getEpochInfo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "epochNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "epochStartBlock",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFeeCurveParams",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "slopeRateRayOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "yInterceptRayOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getGlobalAmountAvailableToUnstake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "epochPointer",
+        "type": "int256"
+      }
+    ],
+    "name": "getGlobalCashFlows",
+    "outputs": [
+      {
+        "internalType": "uint120",
+        "name": "queueToStake",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "queueForUnstake",
+        "type": "uint120"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "epochPointer",
+        "type": "int256"
+      }
+    ],
+    "name": "getGlobalEpoch",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "epoch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint8",
+        "name": "withdrawalId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "hasWithdrawal",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "hasDeposit",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "crankedInBoundaryPeriod",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "wasCranked",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "frozen",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "closed",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint128",
+        "name": "targetStakeAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getGlobalPending",
+    "outputs": [
+      {
+        "internalType": "uint120",
+        "name": "pendingStaking",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "pendingUnstaking",
+        "type": "uint120"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getGlobalPendingLast",
+    "outputs": [
+      {
+        "internalType": "uint120",
+        "name": "pendingStaking",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "pendingUnstaking",
+        "type": "uint120"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "epochPointer",
+        "type": "int256"
+      }
+    ],
+    "name": "getGlobalRevenue",
+    "outputs": [
+      {
+        "internalType": "uint120",
+        "name": "allocatedRevenue",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "earnedRevenue",
+        "type": "uint120"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "epochPointer",
+        "type": "int256"
+      }
+    ],
+    "name": "getGlobalStatus",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "frozen",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "closed",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getHoldAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getInternalEpoch",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getNextValidatorToCrank",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPendingTargetLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      }
+    ],
+    "name": "getPolicy",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint48",
+            "name": "escrowDuration",
+            "type": "uint48"
+          },
+          {
+            "internalType": "bool",
+            "name": "active",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "primaryAgent",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct Policy",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      }
+    ],
+    "name": "getPolicyAgents",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getScaledTargetLiquidityPercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTargetLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getTopUpSettings",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "maxTopUpPerPeriod",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint32",
+        "name": "topUpPeriodDuration",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getUncommitApproval",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "completor",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "shares",
+            "type": "uint96"
+          }
+        ],
+        "internalType": "struct UncommitApproval",
+        "name": "approval",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getUncommittingData",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "uncommitting",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint48",
+        "name": "uncommitStartBlock",
+        "type": "uint48"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getUnstakeRequest",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "amountMon",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint64",
+        "name": "completionEpoch",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "validatorId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getValidatorCoinbase",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "getValidatorData",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "epoch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "id",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isPlaceholder",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isActive",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "inActiveSet_Current",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "inActiveSet_Last",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "getValidatorEpochs",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "lastEpoch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "lastTargetStakeAmount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint64",
+        "name": "currentEpoch",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "currentTargetStakeAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "name": "getValidatorIdForCoinbase",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "getValidatorNeighbors",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "previous",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "next",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "getValidatorPendingEscrow",
+    "outputs": [
+      {
+        "internalType": "uint120",
+        "name": "lastPendingStaking",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "lastPendingUnstaking",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "currentPendingStaking",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "currentPendingUnstaking",
+        "type": "uint120"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "getValidatorRewards",
+    "outputs": [
+      {
+        "internalType": "uint120",
+        "name": "lastRewardsPayable",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "lastEarnedRevenue",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "currentRewardsPayable",
+        "type": "uint120"
+      },
+      {
+        "internalType": "uint120",
+        "name": "currentEarnedRevenue",
+        "type": "uint120"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "getValidatorStats",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isActive",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "coinbase",
+            "type": "address"
+          },
+          {
+            "internalType": "uint64",
+            "name": "lastEpoch",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint128",
+            "name": "targetStakeAmount",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "rewardsPayableLast",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "earnedRevenueLast",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "rewardsPayableCurrent",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "earnedRevenueCurrent",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct ValidatorStats",
+        "name": "stats",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWorkingCapital",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "stakedAmount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "reservedAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "globalLiabilities",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "rewardsPayable",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "redemptionsPayable",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "totalZeroYieldPayable",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "hold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "deployer",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isGlobalCrankAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "isPolicyAgent",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "isValidatorActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "isValidatorCrankAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "listActiveValidators",
+    "outputs": [
+      {
+        "internalType": "uint64[]",
+        "name": "validatorIds",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "coinbases",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "inUnderlying",
+        "type": "bool"
+      }
+    ],
+    "name": "policyBalanceAvailable",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balanceAvailable",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "policyCount",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "previewCoinbaseAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "predicted",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewRedeemDetailed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "grossAssets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "feeAssets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "netAssets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewUnstake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "netAssets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewWithdrawDetailed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "grossAssets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "feeAssets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "name": "processCoinbaseByAuth",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "processCoinbaseByAuth",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "realTotalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "redeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAssetsOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "redeemWithSlippageProtection",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "release",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "agent",
+        "type": "address"
+      }
+    ],
+    "name": "removePolicyAgent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newMinBalance",
+        "type": "uint256"
+      }
+    ],
+    "name": "requestUncommit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uncommitCompleteBlock",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newMinBalance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "completor",
+        "type": "address"
+      }
+    ],
+    "name": "requestUncommitWithApprovedCompletor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "uncommitCompleteBlock",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "requestUnstake",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "completionEpoch",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint256",
+        "name": "feeRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "sendValidatorRewards",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "isClosed",
+        "type": "bool"
+      }
+    ],
+    "name": "setClosedStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "isFrozen",
+        "type": "bool"
+      }
+    ],
+    "name": "setFrozenStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "minCommitted",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "maxTopUpPerPeriod",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint32",
+        "name": "topUpPeriodDuration",
+        "type": "uint32"
+      }
+    ],
+    "name": "setMinCommittedBalance",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newPercentageScaled",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPoolTargetLiquidityPercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "completor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "setUncommitApproval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newSlopeRateRay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newYInterceptRay",
+        "type": "uint256"
+      }
+    ],
+    "name": "setUnstakeFeeCurve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "slopeRateRay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "inUnderlying",
+        "type": "bool"
+      }
+    ],
+    "name": "topUpAvailable",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountAvailable",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unclaimedOwnerCommission",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "policyID",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "uncommittingCompleteBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "feeInBps",
+        "type": "uint16"
+      }
+    ],
+    "name": "updateBoostCommission",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "validatorId",
+        "type": "uint64"
+      }
+    ],
+    "name": "updateCoinbaseForExistingValidator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "newCoinbase",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "percentageInBps",
+        "type": "uint16"
+      }
+    ],
+    "name": "updateIncentiveAlignmentPercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "feeInBps",
+        "type": "uint16"
+      }
+    ],
+    "name": "updateStakingCommission",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxBurntShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawWithSlippageProtection",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "yInterceptRay",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+] as const;

--- a/packages/protocols/shmonad/src/index.ts
+++ b/packages/protocols/shmonad/src/index.ts
@@ -1,0 +1,2 @@
+export { ShMonadAbi } from "./abis/shmonad.js";
+export { SHMONAD_ADDRESS, SHMONAD_IMPLEMENTATION_ADDRESS, ShMonad } from "./shmonad.js";

--- a/packages/protocols/shmonad/src/shmonad.ts
+++ b/packages/protocols/shmonad/src/shmonad.ts
@@ -1,0 +1,298 @@
+import {
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+} from "@themoss/core";
+import { ERC20 } from "@themoss/erc";
+import { decodeEventLog, formatUnits, parseUnits } from "viem";
+import { ShMonadAbi } from "./abis/shmonad.js";
+
+export const SHMONAD_ADDRESS: AddressValue = "0x1B68626dCa36c7fE922fD2d55E4f631d962dE19c";
+
+/**
+ * The ShMonad implementation behind the SHMONAD_ADDRESS proxy
+ * (TransparentUpgradeableProxy, ERC-1967). The committed ABI is fetched from
+ * this address because explorer `getabi` on the proxy returns the proxy's own
+ * ABI, not the staking surface. scripts/abis.ts records it as the fetch source
+ * and the live e2e pins it to the proxy's ERC-1967 implementation slot, so an
+ * upgrade is caught instead of silently shipping a stale ABI.
+ */
+export const SHMONAD_IMPLEMENTATION_ADDRESS: AddressValue =
+  "0x856A4019228c265DEE336DF705277607c4A18e1B";
+
+const stakeParams = {
+  amount: {
+    type: PositiveDecimalString,
+    description: "Quantity of native MON to stake; MON uses 18 decimals.",
+  },
+  receiver: {
+    type: Address,
+    description: "Account that receives the minted shMON tokens.",
+  },
+} satisfies ParamsSpec;
+
+const unstakeParams = {
+  shares: {
+    type: PositiveDecimalString,
+    description: "Quantity of shMON to redeem; shMON uses 18 decimals.",
+  },
+  receiver: {
+    type: Address,
+    description: "Account that receives the redeemed MON.",
+  },
+  owner: {
+    type: Address,
+    description: "Account whose shMON is redeemed.",
+  },
+} satisfies ParamsSpec;
+
+const balanceParams = {
+  owner: {
+    type: Address,
+    description: "Address whose shMON balance is read.",
+  },
+} satisfies ParamsSpec;
+
+type StakeOutcome = {
+  operation: "stake";
+  depositor: AddressValue;
+  receiver: AddressValue;
+  assets: string;
+  shares: string;
+};
+
+type UnstakeOutcome = {
+  operation: "unstake";
+  owner: AddressValue;
+  receiver: AddressValue;
+  assets: string;
+  shares: string;
+};
+
+@Protocol({
+  name: "shmonad",
+  category: "staking",
+  description: "FastLane liquid staking: stake MON for shMON, earn staking and MEV rewards.",
+  contracts: { shmonad: { abi: ShMonadAbi, addr: SHMONAD_ADDRESS } },
+  protocols: { erc20: ERC20 },
+})
+export class ShMonad {
+  declare shmonad: Handle<typeof ShMonadAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  @Capability<ShMonad, typeof stakeParams>({
+    intent: "Stake {amount} MON into shMON",
+    verb: "stake",
+    params: stakeParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+    tags: ["staking"],
+  })
+  async stake(params: InferParams<typeof stakeParams>) {
+    const amount = parseUnits(params.amount, 18);
+    return [this.shmonad.deposit([amount, params.receiver], { value: amount })];
+  }
+
+  @Capability<ShMonad, typeof unstakeParams>({
+    intent: "Redeem {shares} shMON for MON",
+    verb: "unstake",
+    params: unstakeParams,
+    receipt: "unstakeReceipt",
+    risk: ["fundOut"],
+    tags: ["staking"],
+  })
+  async unstake(params: InferParams<typeof unstakeParams>) {
+    return [this.shmonad.redeem([parseUnits(params.shares, 18), params.receiver, params.owner])];
+  }
+
+  @Query({
+    intent: "Read a shMON balance",
+    params: balanceParams,
+    tags: ["balance"],
+  })
+  async balanceOf(params: InferParams<typeof balanceParams>) {
+    const balance = await this.shmonad.read.balanceOf([params.owner]);
+    return {
+      token: SHMONAD_ADDRESS,
+      symbol: "shMON",
+      decimals: 18,
+      balance: balance.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Read the current shMON-to-MON exchange rate",
+    params: {},
+    tags: ["rate"],
+  })
+  async exchangeRate() {
+    const oneShare = 10n ** 18n;
+    const assets = await this.shmonad.read.convertToAssets([oneShare]);
+    return {
+      sharesUnit: "1000000000000000000",
+      assetsPerShare: assets.toString(),
+      humanRate: formatUnits(assets, 18),
+    };
+  }
+
+  @Receipt()
+  stakeReceipt(changes: readonly Change[]): ReceiptResult<StakeOutcome> {
+    let depositEvent:
+      | { depositor: AddressValue; receiver: AddressValue; assets: string; shares: string }
+      | undefined;
+    let nativeTransfer: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") {
+        if (nativeTransfer) throw new Error("shMONAD stake emitted multiple native transfers");
+        nativeTransfer = change;
+        return {
+          kind: "change" as const,
+          change,
+          data: { operation: "nativeTransfer", ...change },
+          text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
+        };
+      }
+
+      let event: ReturnType<typeof decodeEventLog<typeof ShMonadAbi>>;
+      try {
+        event = decodeEventLog({
+          abi: ShMonadAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error(
+          `Unexpected Change: ${change.address} emitted an unsupported shMONAD event`,
+        );
+      }
+
+      if (event.eventName === "Transfer" || event.eventName === "Approval") {
+        return this.erc20.changesReceipt([change]);
+      }
+
+      if (event.eventName !== "Deposit") {
+        throw new Error(`Unexpected Change: shMONAD stake received ${event.eventName}`);
+      }
+      if (depositEvent) {
+        throw new Error("shMONAD stake emitted multiple Deposit events");
+      }
+
+      depositEvent = {
+        depositor: event.args.sender,
+        receiver: event.args.owner,
+        assets: event.args.assets.toString(),
+        shares: event.args.shares.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: { operation: "deposit", ...depositEvent },
+        text: `shMONAD Stake: ${depositEvent.assets} MON → ${depositEvent.shares} shMON for ${depositEvent.receiver}`,
+      };
+    });
+
+    if (!depositEvent || !nativeTransfer) {
+      throw new Error("shMONAD stake Receipt requires both a Deposit event and a native transfer");
+    }
+    if (depositEvent.assets !== nativeTransfer.value) {
+      throw new Error("shMONAD stake assets differ between Deposit event and native transfer");
+    }
+
+    const outcome: StakeOutcome = { operation: "stake", ...depositEvent };
+    return {
+      kind: "receipt",
+      outcome,
+      text: `shMONAD Stake: ${outcome.assets} MON → ${outcome.shares} shMON for ${outcome.receiver}`,
+      changes: parsed,
+    };
+  }
+
+  @Receipt()
+  unstakeReceipt(changes: readonly Change[]): ReceiptResult<UnstakeOutcome> {
+    let withdrawEvent:
+      | { owner: AddressValue; receiver: AddressValue; assets: string; shares: string }
+      | undefined;
+    let nativeTransfer: Extract<Change, { kind: "nativeTransfer" }> | undefined;
+
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer") {
+        if (nativeTransfer) throw new Error("shMONAD unstake emitted multiple native transfers");
+        nativeTransfer = change;
+        return {
+          kind: "change" as const,
+          change,
+          data: { operation: "nativeTransfer", ...change },
+          text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
+        };
+      }
+
+      let event: ReturnType<typeof decodeEventLog<typeof ShMonadAbi>>;
+      try {
+        event = decodeEventLog({
+          abi: ShMonadAbi,
+          topics: change.topics as [Hex, ...Hex[]],
+          data: change.data,
+          strict: true,
+        });
+      } catch {
+        throw new Error(
+          `Unexpected Change: ${change.address} emitted an unsupported shMONAD event`,
+        );
+      }
+
+      if (event.eventName === "Transfer" || event.eventName === "Approval") {
+        return this.erc20.changesReceipt([change]);
+      }
+
+      if (event.eventName !== "Withdraw") {
+        throw new Error(`Unexpected Change: shMONAD unstake received ${event.eventName}`);
+      }
+      if (withdrawEvent) {
+        throw new Error("shMONAD unstake emitted multiple Withdraw events");
+      }
+
+      withdrawEvent = {
+        owner: event.args.owner,
+        receiver: event.args.receiver,
+        assets: event.args.assets.toString(),
+        shares: event.args.shares.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: { operation: "withdraw", ...withdrawEvent },
+        text: `shMONAD Unstake: ${withdrawEvent.shares} shMON → ${withdrawEvent.assets} MON to ${withdrawEvent.receiver}`,
+      };
+    });
+
+    if (!withdrawEvent || !nativeTransfer) {
+      throw new Error(
+        "shMONAD unstake Receipt requires both a Withdraw event and a native transfer",
+      );
+    }
+    if (withdrawEvent.assets !== nativeTransfer.value) {
+      throw new Error("shMONAD unstake assets differ between Withdraw event and native transfer");
+    }
+
+    const outcome: UnstakeOutcome = { operation: "unstake", ...withdrawEvent };
+    return {
+      kind: "receipt",
+      outcome,
+      text: `shMONAD Unstake: ${outcome.shares} shMON → ${outcome.assets} MON to ${outcome.receiver}`,
+      changes: parsed,
+    };
+  }
+}

--- a/packages/protocols/shmonad/test/abis.test.ts
+++ b/packages/protocols/shmonad/test/abis.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { type RenderAbiModuleOptions, renderAbiModule } from "@themoss/abi-tools";
+import { describe, expect, it } from "vitest";
+import { SOURCES } from "../scripts/abis.js";
+import { SHMONAD_IMPLEMENTATION_ADDRESS } from "../src/shmonad.js";
+
+// The provenance chain, enforced: the committed src/abis module must be
+// byte-exact renderAbiModule output for its SOURCES entry — same address, same
+// recorded retrieval date, same embedded ABI. Any hand edit to the generated
+// module breaks this equality; regenerate with `pnpm update:abis`.
+describe("explorer ABI derivation (ADR 0007)", () => {
+  for (const source of SOURCES) {
+    it(`src/abis/${source.file} is exactly renderAbiModule output`, () => {
+      const committed = readFileSync(
+        new URL(`../src/abis/${source.file}`, import.meta.url),
+        "utf8",
+      );
+
+      const retrieved = /^\/\/ {3}Retrieved: (\d{4}-\d{2}-\d{2}) \(UTC\)$/m.exec(committed)?.[1];
+      expect(retrieved).toBeDefined();
+
+      const literal = /^export const \w+Abi = (\[[\s\S]*\]) as const;$/m.exec(committed)?.[1];
+      expect(literal).toBeDefined();
+      const abi = JSON.parse(literal as string) as RenderAbiModuleOptions["abi"];
+
+      expect(committed).toBe(
+        renderAbiModule({
+          exportName: source.exportName,
+          address: source.address,
+          abi,
+          retrievedAt: new Date(`${retrieved}T00:00:00Z`),
+        }),
+      );
+    });
+  }
+
+  // The ABI is fetched from the implementation behind the proxy; that address is
+  // an exported, reviewable constant. The live e2e pins it to the proxy's
+  // ERC-1967 slot so an upgrade is caught rather than silently accepted.
+  it("SOURCES address matches the protocol's verified implementation constant", () => {
+    expect(SOURCES.map((s) => s.address)).toEqual([SHMONAD_IMPLEMENTATION_ADDRESS]);
+  });
+});

--- a/packages/protocols/shmonad/test/adapter.test.ts
+++ b/packages/protocols/shmonad/test/adapter.test.ts
@@ -1,0 +1,263 @@
+import { ERC1967_IMPLEMENTATION_SLOT, erc1967ImplementationAddress } from "@themoss/abi-tools";
+import {
+  type Change,
+  createRuntime,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  Registry,
+} from "@themoss/core";
+import { ERC20Abi } from "@themoss/erc";
+import { createTraceSimulator } from "@themoss/simulator";
+
+import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ShMonadAbi } from "../src/abis/shmonad.js";
+import { SHMONAD_ADDRESS, SHMONAD_IMPLEMENTATION_ADDRESS, ShMonad } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const RECEIVER = getAddress("0xdddddddddddddddddddddddddddddddddddddddd");
+const runtime = {
+  rpcUrl: "http://offline",
+  client: {} as MossRuntime["client"],
+};
+
+describe("shMONAD adapter", () => {
+  it("registers its exported Protocol directly and builds one stake transaction", async () => {
+    const registry = new Registry(runtime).use(ShMonad);
+    const capability = await registry.action("shmonad", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const nodes = flattenCapabilityTree(capability);
+    expect(nodes[0]?.transaction).toMatchObject({
+      to: SHMONAD_ADDRESS,
+      value: "0xde0b6b3a7640000",
+    });
+  });
+
+  it("registers and builds one unstake transaction", async () => {
+    const registry = new Registry(runtime).use(ShMonad);
+    const capability = await registry.action("shmonad", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: RECEIVER,
+      owner: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const nodes = flattenCapabilityTree(capability);
+    expect(nodes[0]?.transaction).toMatchObject({
+      to: SHMONAD_ADDRESS,
+    });
+  });
+
+  it("parses all stake Changes without replacing their objects", async () => {
+    const registry = new Registry(runtime).use(ShMonad);
+    const capability = await registry.action("shmonad", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: SHMONAD_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+
+    const transferMint = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Transfer",
+        args: {
+          from: "0x0000000000000000000000000000000000000000",
+          to: RECEIVER,
+        },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }], [10n ** 18n]),
+    } satisfies Change;
+
+    const depositEvent = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Deposit",
+        args: { sender: ACCOUNT, owner: RECEIVER },
+      }) as readonly Hex[],
+      data: encodeAbiParameters(
+        [{ type: "uint256" }, { type: "uint256" }],
+        [10n ** 18n, 10n ** 18n],
+      ),
+    } satisfies Change;
+
+    const receipt = registry.parseReceipt(capability, [native, transferMint, depositEvent]);
+    expect(receipt.outcome).toEqual({
+      operation: "stake",
+      depositor: ACCOUNT,
+      receiver: RECEIVER,
+      assets: "1000000000000000000",
+      shares: "1000000000000000000",
+    });
+  });
+
+  it("parses all unstake Changes without replacing their objects", async () => {
+    const registry = new Registry(runtime).use(ShMonad);
+    const capability = await registry.action("shmonad", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: RECEIVER,
+      owner: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const transferBurn = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Transfer",
+        args: {
+          from: ACCOUNT,
+          to: "0x0000000000000000000000000000000000000000",
+        },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }], [10n ** 18n]),
+    } satisfies Change;
+
+    const withdrawEvent = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Withdraw",
+        args: { sender: ACCOUNT, receiver: RECEIVER, owner: ACCOUNT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters(
+        [{ type: "uint256" }, { type: "uint256" }],
+        [10n ** 18n, 10n ** 18n],
+      ),
+    } satisfies Change;
+
+    const native = {
+      kind: "nativeTransfer",
+      from: SHMONAD_ADDRESS,
+      to: RECEIVER,
+      value: "1000000000000000000",
+    } satisfies Change;
+
+    const receipt = registry.parseReceipt(capability, [transferBurn, withdrawEvent, native]);
+    expect(receipt.outcome).toEqual({
+      operation: "unstake",
+      owner: ACCOUNT,
+      receiver: RECEIVER,
+      assets: "1000000000000000000",
+      shares: "1000000000000000000",
+    });
+  });
+
+  it("rejects stake receipt with missing Deposit event", async () => {
+    const registry = new Registry(runtime).use(ShMonad);
+    const capability = await registry.action("shmonad", "stake", ACCOUNT, {
+      amount: "1",
+      receiver: RECEIVER,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: SHMONAD_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+
+    expect(() => registry.parseReceipt(capability, [native])).toThrow(
+      "requires both a Deposit event and a native transfer",
+    );
+  });
+
+  it("rejects unstake receipt with mismatched amounts", async () => {
+    const registry = new Registry(runtime).use(ShMonad);
+    const capability = await registry.action("shmonad", "unstake", ACCOUNT, {
+      shares: "1",
+      receiver: RECEIVER,
+      owner: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const withdrawEvent = {
+      kind: "event",
+      address: SHMONAD_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ShMonadAbi,
+        eventName: "Withdraw",
+        args: { sender: ACCOUNT, receiver: RECEIVER, owner: ACCOUNT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters(
+        [{ type: "uint256" }, { type: "uint256" }],
+        [10n ** 18n, 10n ** 18n],
+      ),
+    } satisfies Change;
+
+    const native = {
+      kind: "nativeTransfer",
+      from: SHMONAD_ADDRESS,
+      to: RECEIVER,
+      value: "999999999999999999",
+    } satisfies Change;
+
+    expect(() => registry.parseReceipt(capability, [withdrawEvent, native])).toThrow(
+      "assets differ between Withdraw event and native transfer",
+    );
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("shMONAD live mainnet", () => {
+  it("has deployed bytecode and expected token metadata", { timeout: 60_000 }, async () => {
+    const { client } = await createRuntime();
+    const [bytecode, symbol, decimals] = await Promise.all([
+      client.getCode({ address: SHMONAD_ADDRESS }),
+      client.readContract({ address: SHMONAD_ADDRESS, abi: ERC20Abi, functionName: "symbol" }),
+      client.readContract({ address: SHMONAD_ADDRESS, abi: ERC20Abi, functionName: "decimals" }),
+    ]);
+    expect(bytecode?.length).toBeGreaterThan(2);
+    expect(symbol).toBe("shMON");
+    expect(Number(decimals)).toBe(18);
+  });
+
+  it("proxy still points at the recorded implementation (ERC-1967 slot)", {
+    timeout: 60_000,
+  }, async () => {
+    const { client } = await createRuntime();
+    const slot = await client.getStorageAt({
+      address: SHMONAD_ADDRESS,
+      slot: ERC1967_IMPLEMENTATION_SLOT,
+    });
+    expect(erc1967ImplementationAddress(slot).toLowerCase()).toBe(
+      SHMONAD_IMPLEMENTATION_ADDRESS.toLowerCase(),
+    );
+  });
+
+  it("simulates a stake with exhaustive ordered Receipt coverage", {
+    timeout: 120_000,
+  }, async () => {
+    const rt = await createRuntime();
+    const registry = new Registry(rt).use(ShMonad);
+    const capability = await registry.action("shmonad", "stake", ACCOUNT, {
+      amount: "0.25",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected Capability");
+    const outcome = await createTraceSimulator(rt, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results[0]?.warnings).toEqual([]);
+    expect(outcome.results[0]?.receipt?.outcome).toMatchObject({
+      operation: "stake",
+      receiver: ACCOUNT,
+    });
+  });
+});

--- a/packages/protocols/shmonad/test/types.fixture.ts
+++ b/packages/protocols/shmonad/test/types.fixture.ts
@@ -1,0 +1,155 @@
+import {
+  Capability,
+  type Change,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import type { ShMonadAbi } from "../src/abis/shmonad.js";
+import { ShMonad } from "../src/shmonad.js";
+
+const fixtureParams = {
+  amount: { type: UnsignedIntegerString, description: "Fixture amount." },
+} satisfies ParamsSpec;
+
+const validParams: InferParams<typeof fixtureParams> = { amount: "42" };
+// @ts-expect-error Params are inferred from the Zod schema as strings, not numbers.
+const invalidParams: InferParams<typeof fixtureParams> = { amount: 42 };
+const dependency = null as unknown as ProtocolRef<ShMonad>;
+void dependency.stake;
+void dependency.unstake;
+// @ts-expect-error Injected Protocol references expose methods, not Handles.
+void dependency.shmonad;
+
+function handleFixture(handle: Handle<typeof ShMonadAbi>) {
+  handle.deposit([1n, "0x1111111111111111111111111111111111111111"], {
+    value: 1n,
+  });
+  handle.read.balanceOf(["0x1111111111111111111111111111111111111111"]);
+  handle.read.convertToAssets([1n]);
+  handle.read.convertToShares([1n]);
+  // @ts-expect-error ABI-generic Handles reject unknown contract methods.
+  handle.notAContractMethod([1n]);
+  // @ts-expect-error ABI-generic Handles reject invalid ABI arguments.
+  handle.read.balanceOf(["not-an-address"]);
+}
+
+@Protocol({
+  name: "valid-dependency-fixture",
+  category: "staking",
+  description: "Compile-time dependency fixture.",
+  contracts: {},
+  protocols: { shmonad: ShMonad },
+})
+class ValidDependencyFixture {
+  declare shmonad: ProtocolRef<ShMonad>;
+}
+
+// @ts-expect-error Protocol dependencies require a matching typed instance field.
+@Protocol({
+  name: "invalid-dependency-fixture",
+  category: "staking",
+  description: "Compile-time dependency fixture.",
+  contracts: {},
+  protocols: { shmonad: ShMonad },
+})
+class InvalidDependencyFixture {}
+
+// @ts-expect-error Protocol classes cannot require constructor arguments; Registry owns construction.
+@Protocol({
+  name: "invalid-constructor-fixture",
+  category: "staking",
+  description: "Compile-time constructor fixture.",
+  contracts: {},
+})
+class InvalidConstructorFixture {
+  constructor(_required: string) {}
+}
+
+class ReceiptNameFixture extends ShMonad {
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "supply",
+    params: fixtureParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+  })
+  async valid(_: InferParams<typeof fixtureParams>) {
+    return [];
+  }
+
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "supply",
+    params: fixtureParams,
+    // @ts-expect-error Receipt names are limited to methods returning ReceiptResult.
+    receipt: "missingReceipt",
+    risk: ["fundOut"],
+  })
+  async invalid() {
+    return [];
+  }
+
+  // @ts-expect-error Capability method params must match the declared parameter schemas.
+  @Capability<ReceiptNameFixture, typeof fixtureParams>({
+    intent: "Compile-time fixture",
+    verb: "supply",
+    params: fixtureParams,
+    receipt: "stakeReceipt",
+    risk: ["fundOut"],
+  })
+  async invalidParams(_: { amount: number }) {
+    return [];
+  }
+
+  @Query({ intent: "Compile-time query fixture", params: fixtureParams })
+  async validQuery(params: InferParams<typeof fixtureParams>) {
+    return params.amount;
+  }
+
+  // @ts-expect-error Query method params must match the declared parameter schemas.
+  @Query({ intent: "Compile-time query fixture", params: fixtureParams })
+  async invalidQuery(_: { amount: number }) {
+    return "invalid";
+  }
+
+  @Receipt()
+  typedReceipt(changes: readonly Change[]): ReceiptResult<{ ok: true }> {
+    return {
+      kind: "receipt",
+      outcome: { ok: true },
+      text: "Fixture Receipt: valid",
+      changes: changes.map((change) => ({
+        kind: "change",
+        change,
+        data: null,
+        text: "change",
+      })),
+    };
+  }
+
+  // @ts-expect-error Receipt parsers accept only an immutable ordered Change list.
+  @Receipt()
+  invalidReceipt(_: string): ReceiptResult<{ ok: true }> {
+    return {
+      kind: "receipt",
+      outcome: { ok: true },
+      text: "invalid",
+      changes: [],
+    };
+  }
+}
+
+void validParams;
+void invalidParams;
+void handleFixture;
+void ValidDependencyFixture;
+void InvalidDependencyFixture;
+void InvalidConstructorFixture;
+void ReceiptNameFixture;

--- a/packages/protocols/shmonad/tsconfig.json
+++ b/packages/protocols/shmonad/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test", "scripts"]
+}

--- a/packages/protocols/shmonad/vitest.config.ts
+++ b/packages/protocols/shmonad/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,40 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
+  packages/protocols/shmonad:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/abi-tools':
+        specifier: workspace:*
+        version: link:../../abi-tools
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
   packages/simulator:
     dependencies:
       '@themoss/core':


### PR DESCRIPTION
## What and why

A Moss protocol adapter for FastLane shMONAD liquid staking on Monad mainnet. Staking MON mints shMON, an ERC-4626 vault share that accrues staking and MEV rewards.

- `stake`: deposit native MON, receive shMON (ERC-4626 `deposit`, MON sent as `msg.value`)
- `unstake`: redeem shMON for MON (`redeem`)
- `balanceOf`: read a shMON balance
- `exchangeRate`: read the current shMON-to-MON rate

## Type of change

- [x] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

New package `@themoss/protocol-shmonad` only. No changes to public types, package boundaries, the Capability tree, or Change/Receipt behavior in existing packages. The package is `private: true`, so no changeset is included.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

### Protocol changes

- [x] Parameters separate reusable Zod value types from field-purpose descriptions
- [x] Every Capability owns one direct TransactionNode and one typed Receipt
- [x] Receipt tests preserve every original Change object in exact length and order
- [x] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [x] Fixed addresses and ABIs include sources and verification
- [x] A live Monad happy path returns zero Warnings

## Evidence

ABI provenance (ADR 0007, explorer tier): shMONAD is a TransparentUpgradeableProxy, and `getabi` on the proxy returns the proxy's own ABI, so the full verified implementation ABI is fetched from the ERC-1967 implementation address.

- `scripts/abis.ts` records the implementation address as the fetch source.
- `scripts/update-abis.ts` regenerates `src/abis/shmonad.ts` (`pnpm update:abis`).
- `test/abis.test.ts` pins the committed module to `renderAbiModule` output and to the exported `SHMONAD_IMPLEMENTATION_ADDRESS`.
- The live e2e reads the proxy's ERC-1967 slot and asserts it equals that constant, so a proxy upgrade turns the suite red.

Test run: 11 passed across 2 files, including live Monad mainnet e2e: deployed bytecode and shMON metadata, the ERC-1967 implementation tripwire, and an exhaustive stake simulation receipt with zero Warnings.