### PR TITLE
feat(protocols): add Magma read-only adapter

### DIFF
--- a/packages/protocols/magma/.gitignore
+++ b/packages/protocols/magma/.gitignore
@@ -1,0 +1,2 @@
+out/
+cache/

--- a/packages/protocols/magma/README.md
+++ b/packages/protocols/magma/README.md
@@ -1,0 +1,36 @@
+# @themoss/protocol-magma
+
+A read-only Moss Protocol package for querying Magma liquid-staking vault state on Monad mainnet.
+
+## Supported Queries
+
+- `totalAssets` — reads the total MON assets managed by Magma.
+- `coreVault` — reads the configured Core Vault address.
+- `gVault` — reads the configured gVault address.
+- `rewardsFee` — reads the current rewards fee in protocol base units.
+- `withdrawalFee` — reads the current withdrawal fee in protocol base units.
+
+## Contract
+
+- Network: Monad mainnet
+- Magma address: `0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081`
+- ABI origin: compiled from the pinned official `IMagma.sol` source
+- ABI provenance: see `contracts/SOURCE.md`
+
+## Regenerate the ABI
+
+Run from the Moss repository root:
+
+    pnpm --filter @themoss/protocol-magma gen:abis
+
+## Verify the Package
+
+Run from the Moss repository root:
+
+    pnpm --filter @themoss/protocol-magma build
+    pnpm --filter @themoss/protocol-magma typecheck
+    pnpm --filter @themoss/protocol-magma test
+
+## Current Limitations
+
+This initial version is read-only. It does not implement staking, redemption, wallet signing, or transaction broadcasting.

--- a/packages/protocols/magma/contracts/IMagma.sol
+++ b/packages/protocols/magma/contracts/IMagma.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+interface IMagma {
+    /// @notice Struct to track pending redeem requests
+    /// @dev Claimable state may transition automatically after a timestamp has passed.
+    /// @dev https://eips.ethereum.org/EIPS/eip-7540#no-event-for-claimable-state
+    /// @dev https://eips.ethereum.org/EIPS/eip-7540#request-lifecycle
+    struct RedeemRequests {
+        address owner; // Owner of the shares
+        bool isGVault; // If redeemRequest is for gVault or not
+        uint256 shares; // Amount of shares to redeem
+        uint256 assets; // Amount of assets to withdraw
+        uint256 claimableTime; // When assets become claimable
+    }
+
+    // View functions
+    function claimableRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
+    function coreVault() external view returns (address);
+    function feeReceiver() external view returns (address);
+    function gVault() external view returns (address);
+    function isOperator(address controller, address operator) external view returns (bool);
+    function mevRewardsInjector() external view returns (address);
+    function owner() external view returns (address);
+    function pendingRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
+    function pendingRedeemRequestData(uint256 requestId, address controller)
+        external
+        view
+        returns (RedeemRequests memory data);
+    function ownerRequestId(address _owner) external view returns (uint256);
+    function rewardsFee() external view returns (uint256);
+    function totalAssets() external view returns (uint256);
+    function withdrawalFee() external view returns (uint256);
+
+    // Write functions
+    function deposit(uint256 assets, address receiver) external returns (uint256);
+    function depositWMON(uint256 assets, address receiver, uint256 referralId) external returns (uint256);
+    function depositWMONGVault(uint256 assets, address receiver, uint64 valId, uint256 referralId)
+        external
+        returns (uint256);
+    function mint(uint256 shares, address receiver) external returns (uint256);
+    function redeem(uint256 requestId, address controller, address receiver) external returns (uint256 assets);
+    function redeemMON(uint256 requestId, address controller, address receiver) external returns (uint256 assets);
+    function refreshCache() external;
+    function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256 requestId);
+    function requestRedeemGVault(uint256 shares, address controller, address owner, uint64 valId)
+        external
+        returns (uint256 requestId);
+    function setOperator(address operator, bool approved) external returns (bool);
+
+    // Payable functions
+    function depositMON(address receiver, uint256 referralId) external payable returns (uint256 shares);
+    function depositMONGVault(address receiver, uint64 valId, uint256 referralId)
+        external
+        payable
+        returns (uint256 shares);
+
+    // Events
+    /// @dev Emitted upon a successful deposit, will be sent on every deposit to facilitate on the indexer side
+    event DepositWithReferral(
+        address indexed sender, address indexed owner, uint256 assets, uint256 shares, uint256 indexed referralId
+    );
+    event FeeReceiverUpdated(address indexed newFeeReceiver);
+    event OperatorSet(address indexed controller, address indexed operator, bool indexed approved);
+    event RedeemDelayUpdated(uint256 indexed newRedeemDelay);
+    // Events for ERC-7540 compatibility and admin
+    event RedeemRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares
+    );
+    event RewardsFeeUpdated(uint256 indexed newRewardsFee);
+    event VaultsSet(address indexed newCoreVault, address indexed newGVault);
+    event WithdrawalFeeUpdated(uint256 indexed newWithdrawalFee);
+    event MevRewardsInjectorUpdated(address indexed oldInjector, address indexed newInjector);
+}

--- a/packages/protocols/magma/contracts/SOURCE.md
+++ b/packages/protocols/magma/contracts/SOURCE.md
@@ -1,0 +1,14 @@
+# Magma ABI source
+
+- ABI origin: compiled (Moss ADR 0007)
+- Upstream repository: `MagmaStaking/contracts-public`
+- Upstream commit: `5793bdb9e102d581347a3cde76c7f70ba6b362d0`
+- Upstream file: `interfaces/IMagma.sol`
+- Upstream source: `https://github.com/MagmaStaking/contracts-public/blob/5793bdb9e102d581347a3cde76c7f70ba6b362d0/interfaces/IMagma.sol`
+- Local source: `packages/protocols/magma/contracts/IMagma.sol`
+- Solidity compiler: `0.8.30`
+- Regenerate from the repository root: `pnpm --filter @themoss/protocol-magma gen:abis`
+
+The upstream `IMagma.sol` interface file is committed verbatim in full.
+The ABI is generated from this pinned source rather than hand-transcribed
+or reduced to a manually selected function subset.

--- a/packages/protocols/magma/foundry.toml
+++ b/packages/protocols/magma/foundry.toml
@@ -1,0 +1,5 @@
+[profile.default]
+src = "contracts"
+out = "out"
+cache_path = "cache"
+solc_version = "0.8.30"

--- a/packages/protocols/magma/package.json
+++ b/packages/protocols/magma/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@themoss/protocol-magma",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Moss Protocol for Magma gMON liquid staking on Monad",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "gen:abis": "wagmi generate"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6",
+    "@wagmi/cli": "^2.10.0"
+  }
+}

--- a/packages/protocols/magma/src/abis/magma.ts
+++ b/packages/protocols/magma/src/abis/magma.ts
@@ -1,0 +1,432 @@
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IMagma
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const iMagmaAbi = [
+  {
+    type: 'function',
+    inputs: [
+      { name: 'requestId', internalType: 'uint256', type: 'uint256' },
+      { name: 'controller', internalType: 'address', type: 'address' },
+    ],
+    name: 'claimableRedeemRequest',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'coreVault',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'assets', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+    ],
+    name: 'deposit',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'receiver', internalType: 'address', type: 'address' },
+      { name: 'referralId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'depositMON',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'receiver', internalType: 'address', type: 'address' },
+      { name: 'valId', internalType: 'uint64', type: 'uint64' },
+      { name: 'referralId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'depositMONGVault',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'assets', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+      { name: 'referralId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'depositWMON',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'assets', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+      { name: 'valId', internalType: 'uint64', type: 'uint64' },
+      { name: 'referralId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'depositWMONGVault',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'feeReceiver',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'gVault',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'controller', internalType: 'address', type: 'address' },
+      { name: 'operator', internalType: 'address', type: 'address' },
+    ],
+    name: 'isOperator',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'mevRewardsInjector',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'shares', internalType: 'uint256', type: 'uint256' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+    ],
+    name: 'mint',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'owner',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '_owner', internalType: 'address', type: 'address' }],
+    name: 'ownerRequestId',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'requestId', internalType: 'uint256', type: 'uint256' },
+      { name: 'controller', internalType: 'address', type: 'address' },
+    ],
+    name: 'pendingRedeemRequest',
+    outputs: [{ name: 'shares', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'requestId', internalType: 'uint256', type: 'uint256' },
+      { name: 'controller', internalType: 'address', type: 'address' },
+    ],
+    name: 'pendingRedeemRequestData',
+    outputs: [
+      {
+        name: 'data',
+        internalType: 'struct IMagma.RedeemRequests',
+        type: 'tuple',
+        components: [
+          { name: 'owner', internalType: 'address', type: 'address' },
+          { name: 'isGVault', internalType: 'bool', type: 'bool' },
+          { name: 'shares', internalType: 'uint256', type: 'uint256' },
+          { name: 'assets', internalType: 'uint256', type: 'uint256' },
+          { name: 'claimableTime', internalType: 'uint256', type: 'uint256' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'requestId', internalType: 'uint256', type: 'uint256' },
+      { name: 'controller', internalType: 'address', type: 'address' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+    ],
+    name: 'redeem',
+    outputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'requestId', internalType: 'uint256', type: 'uint256' },
+      { name: 'controller', internalType: 'address', type: 'address' },
+      { name: 'receiver', internalType: 'address', type: 'address' },
+    ],
+    name: 'redeemMON',
+    outputs: [{ name: 'assets', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'refreshCache',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'shares', internalType: 'uint256', type: 'uint256' },
+      { name: 'controller', internalType: 'address', type: 'address' },
+      { name: 'owner', internalType: 'address', type: 'address' },
+    ],
+    name: 'requestRedeem',
+    outputs: [{ name: 'requestId', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'shares', internalType: 'uint256', type: 'uint256' },
+      { name: 'controller', internalType: 'address', type: 'address' },
+      { name: 'owner', internalType: 'address', type: 'address' },
+      { name: 'valId', internalType: 'uint64', type: 'uint64' },
+    ],
+    name: 'requestRedeemGVault',
+    outputs: [{ name: 'requestId', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'rewardsFee',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'operator', internalType: 'address', type: 'address' },
+      { name: 'approved', internalType: 'bool', type: 'bool' },
+    ],
+    name: 'setOperator',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'totalAssets',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'withdrawalFee',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'sender',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'owner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'assets',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'shares',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'referralId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+    ],
+    name: 'DepositWithReferral',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'newFeeReceiver',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+    ],
+    name: 'FeeReceiverUpdated',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'oldInjector',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'newInjector',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+    ],
+    name: 'MevRewardsInjectorUpdated',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'controller',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'operator',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'approved', internalType: 'bool', type: 'bool', indexed: true },
+    ],
+    name: 'OperatorSet',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'newRedeemDelay',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+    ],
+    name: 'RedeemDelayUpdated',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'controller',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'owner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'requestId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'sender',
+        internalType: 'address',
+        type: 'address',
+        indexed: false,
+      },
+      {
+        name: 'shares',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'RedeemRequest',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'newRewardsFee',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+    ],
+    name: 'RewardsFeeUpdated',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'newCoreVault',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'newGVault',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+    ],
+    name: 'VaultsSet',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'newWithdrawalFee',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+    ],
+    name: 'WithdrawalFeeUpdated',
+  },
+] as const

--- a/packages/protocols/magma/src/index.ts
+++ b/packages/protocols/magma/src/index.ts
@@ -1,0 +1,2 @@
+export { iMagmaAbi } from "./abis/magma.js";
+export { MAGMA_ADDRESS, Magma } from "./magma.js";

--- a/packages/protocols/magma/src/magma.ts
+++ b/packages/protocols/magma/src/magma.ts
@@ -1,0 +1,96 @@
+import {
+  type AddressValue,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  Query,
+} from "@themoss/core";
+import { iMagmaAbi } from "./abis/magma.js";
+
+export const MAGMA_ADDRESS: AddressValue = "0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081";
+
+const noParams = {} satisfies ParamsSpec;
+
+@Protocol({
+  name: "magma",
+  category: "staking",
+  description: "Read Magma liquid-staking vault state on Monad mainnet.",
+  contracts: {
+    magma: {
+      abi: iMagmaAbi,
+      addr: MAGMA_ADDRESS,
+    },
+  },
+  labels: {
+    Magma: MAGMA_ADDRESS,
+  },
+})
+export class Magma {
+  declare magma: Handle<typeof iMagmaAbi>;
+
+  @Query({
+    intent: "Read the total MON assets managed by Magma",
+    params: noParams,
+    tags: ["tvl", "liquid-staking"],
+  })
+  async totalAssets(_params: InferParams<typeof noParams>) {
+    const assets = await this.magma.read.totalAssets();
+
+    return {
+      assets: assets.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Read the Magma Core Vault address",
+    params: noParams,
+    tags: ["vault", "liquid-staking"],
+  })
+  async coreVault(_params: InferParams<typeof noParams>) {
+    const address = await this.magma.read.coreVault();
+
+    return {
+      address,
+    };
+  }
+
+  @Query({
+    intent: "Read the Magma gVault address",
+    params: noParams,
+    tags: ["vault", "liquid-staking"],
+  })
+  async gVault(_params: InferParams<typeof noParams>) {
+    const address = await this.magma.read.gVault();
+
+    return {
+      address,
+    };
+  }
+
+  @Query({
+    intent: "Read the current Magma rewards fee",
+    params: noParams,
+    tags: ["fee", "liquid-staking"],
+  })
+  async rewardsFee(_params: InferParams<typeof noParams>) {
+    const fee = await this.magma.read.rewardsFee();
+
+    return {
+      rewardsFee: fee.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Read the current Magma withdrawal fee",
+    params: noParams,
+    tags: ["fee", "liquid-staking"],
+  })
+  async withdrawalFee(_params: InferParams<typeof noParams>) {
+    const fee = await this.magma.read.withdrawalFee();
+
+    return {
+      withdrawalFee: fee.toString(),
+    };
+  }
+}

--- a/packages/protocols/magma/test/magma.test.ts
+++ b/packages/protocols/magma/test/magma.test.ts
@@ -1,0 +1,120 @@
+import { type MossRuntime, Registry } from "@themoss/core";
+import { getAddress, isAddress } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MAGMA_ADDRESS, Magma } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const CORE_VAULT = getAddress("0x1111111111111111111111111111111111111111");
+const G_VAULT = getAddress("0x2222222222222222222222222222222222222222");
+
+interface ReadRequest {
+  address: string;
+  functionName: string;
+  args?: readonly unknown[];
+}
+
+const readContract = vi.fn(async ({ functionName }: ReadRequest) => {
+  switch (functionName) {
+    case "totalAssets":
+      return 123456789n;
+    case "coreVault":
+      return CORE_VAULT;
+    case "gVault":
+      return G_VAULT;
+    case "rewardsFee":
+      return 300n;
+    case "withdrawalFee":
+      return 50n;
+    default:
+      throw new Error(`Unexpected read: ${functionName}`);
+  }
+});
+
+const runtime = {
+  rpcUrl: "http://offline",
+  client: { readContract } as unknown as MossRuntime["client"],
+};
+
+describe("Magma read-only Protocol", () => {
+  beforeEach(() => {
+    readContract.mockClear();
+  });
+
+  it("registers the canonical address and five read-only Queries", () => {
+    expect(isAddress(MAGMA_ADDRESS, { strict: false })).toBe(true);
+
+    const registry = new Registry(runtime).use(Magma);
+    const discovered = registry.discover({ protocol: "magma" });
+
+    expect(discovered).toHaveLength(5);
+    expect(discovered.map(({ method }) => method).sort()).toEqual(
+      ["coreVault", "gVault", "rewardsFee", "totalAssets", "withdrawalFee"].sort(),
+    );
+    expect(
+      discovered.every(({ kind, category }) => kind === "query" && category === "staking"),
+    ).toBe(true);
+
+    expect(registry.load([{ protocol: "magma", method: "totalAssets" }])[0]).toMatchObject({
+      protocol: "magma",
+      method: "totalAssets",
+      kind: "query",
+      category: "staking",
+      risk: [],
+      params: {},
+    });
+  });
+
+  it("reads and serializes Magma vault state through the configured contract", async () => {
+    const registry = new Registry(runtime).use(Magma);
+
+    await expect(registry.action("magma", "totalAssets", ACCOUNT, {})).resolves.toEqual({
+      kind: "query",
+      protocol: "magma",
+      method: "totalAssets",
+      data: { assets: "123456789" },
+    });
+
+    await expect(registry.action("magma", "coreVault", ACCOUNT, {})).resolves.toEqual({
+      kind: "query",
+      protocol: "magma",
+      method: "coreVault",
+      data: { address: CORE_VAULT },
+    });
+
+    await expect(registry.action("magma", "gVault", ACCOUNT, {})).resolves.toEqual({
+      kind: "query",
+      protocol: "magma",
+      method: "gVault",
+      data: { address: G_VAULT },
+    });
+
+    await expect(registry.action("magma", "rewardsFee", ACCOUNT, {})).resolves.toEqual({
+      kind: "query",
+      protocol: "magma",
+      method: "rewardsFee",
+      data: { rewardsFee: "300" },
+    });
+
+    await expect(registry.action("magma", "withdrawalFee", ACCOUNT, {})).resolves.toEqual({
+      kind: "query",
+      protocol: "magma",
+      method: "withdrawalFee",
+      data: { withdrawalFee: "50" },
+    });
+
+    expect(readContract.mock.calls.map(([request]) => request.functionName)).toEqual([
+      "totalAssets",
+      "coreVault",
+      "gVault",
+      "rewardsFee",
+      "withdrawalFee",
+    ]);
+
+    for (const [request] of readContract.mock.calls) {
+      expect(request).toMatchObject({
+        address: MAGMA_ADDRESS,
+        args: [],
+      });
+    }
+  });
+});

--- a/packages/protocols/magma/test/types.fixture.ts
+++ b/packages/protocols/magma/test/types.fixture.ts
@@ -1,0 +1,28 @@
+import type { Handle, ProtocolRef } from "@themoss/core";
+import type { iMagmaAbi } from "../src/abis/magma.js";
+import type { Magma } from "../src/magma.js";
+
+const dependency = null as unknown as ProtocolRef<Magma>;
+
+void dependency.totalAssets;
+void dependency.coreVault;
+void dependency.gVault;
+void dependency.rewardsFee;
+void dependency.withdrawalFee;
+
+// @ts-expect-error Injected Protocol references expose methods, not contract Handles.
+void dependency.magma;
+
+function handleFixture(handle: Handle<typeof iMagmaAbi>) {
+  void handle.read.totalAssets();
+  void handle.read.coreVault();
+  void handle.read.pendingRedeemRequest([1n, "0x1111111111111111111111111111111111111111"]);
+
+  // @ts-expect-error ABI-typed Handles reject unknown contract functions.
+  void handle.read.unknownMethod();
+
+  // @ts-expect-error ABI-typed Handles reject invalid address arguments.
+  void handle.read.pendingRedeemRequest([1n, "not-an-address"]);
+}
+
+void handleFixture;

--- a/packages/protocols/magma/tsconfig.json
+++ b/packages/protocols/magma/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/magma/vitest.config.ts
+++ b/packages/protocols/magma/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/protocols/magma/wagmi.config.ts
+++ b/packages/protocols/magma/wagmi.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@wagmi/cli";
+import { foundry } from "@wagmi/cli/plugins";
+
+/**
+ * ABI origin: compiled (Moss ADR 0007).
+ *
+ * Upstream repository: MagmaStaking/contracts-public
+ * Upstream commit: 5793bdb9e102d581347a3cde76c7f70ba6b362d0
+ * Upstream source: interfaces/IMagma.sol
+ * Local source: contracts/IMagma.sol
+ * Compiler: solc 0.8.30
+ * Regenerate: pnpm gen:abis
+ */
+export default defineConfig({
+  out: "src/abis/magma.ts",
+  plugins: [
+    foundry({
+      project: ".",
+      include: ["IMagma.sol/**"],
+      exclude: ["build-info/**"],
+    }),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,28 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
+  packages/protocols/magma:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@wagmi/cli':
+        specifier: ^2.10.0
+        version: 2.10.0(typescript@5.9.3)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
   packages/protocols/pancakeswap:
     dependencies:
       '@themoss/core':


### PR DESCRIPTION
## What and why

Adds `@themoss/protocol-magma`, a focused read-only Protocol for querying
Magma liquid-staking vault state on Monad mainnet.

This initial version provides a small, reviewable integration based on a
compiled ABI generated from a pinned official Magma interface source.

## Included

- `totalAssets`
- `coreVault`
- `gVault`
- `rewardsFee`
- `withdrawalFee`
- compiled ABI provenance from a pinned official source
- deterministic ABI regeneration with Foundry and Wagmi
- Protocol registration and offline Query tests
- TypeScript ABI and Protocol reference fixtures
- package README and ABI source documentation

## Not included

- staking transactions
- Receipt parsing
- `previewDeposit` or `convertToAssets`
- redemption
- wallet signing or transaction broadcasting
- default MCP server composition
- root README support-table changes
- package publication or changeset

## Coordination

I was unable to open a proposal Issue because Issue creation is currently
restricted for my account, so I am using this Draft PR for early scope and
implementation feedback.

## Verification

Completed after implementing the package:

- [x] `pnpm --filter @themoss/protocol-magma build`
- [x] `pnpm --filter @themoss/protocol-magma typecheck`
- [x] `pnpm --filter @themoss/protocol-magma test`
- [x] `pnpm lint`

Not yet rerun after the final package changes:

- [ ] `pnpm build`
- [ ] `pnpm typecheck`
- [ ] `pnpm test:offline`
- [ ] `pnpm test`

## ABI provenance

- Origin tier: compiled
- Upstream repository: `MagmaStaking/contracts-public`
- Pinned commit: `5793bdb9e102d581347a3cde76c7f70ba6b362d0`
- Upstream source: `interfaces/IMagma.sol`
- Solidity compiler: `0.8.30`
- Regenerate from the repository root:
  `pnpm --filter @themoss/protocol-magma gen:abis`

The upstream interface is committed verbatim and the generated ABI is not a
manually selected function subset.

## Current limitations

This version exposes read-only protocol state only. I would appreciate
maintainer feedback on whether the next revision should add default MCP
composition and whether a write-capable staking flow belongs in this PR or a
follow-up contribution.
