### PR TITLE
docs: add toolchain checks to getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,8 @@ pnpm build
 Prove the toolchain without making RPC calls:
 
 ```bash
+pnpm typecheck
+pnpm lint
 pnpm test:offline
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,8 +20,8 @@ pnpm build
 Prove the toolchain without making RPC calls:
 
 ```bash
-pnpm typecheck
 pnpm lint
+pnpm typecheck
 pnpm test:offline
 ```
 

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -20,6 +20,8 @@ pnpm build
 先在不访问 RPC 的情况下验证工具链：
 
 ```bash
+pnpm typecheck
+pnpm lint
 pnpm test:offline
 ```
 

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -20,8 +20,8 @@ pnpm build
 先在不访问 RPC 的情况下验证工具链：
 
 ```bash
-pnpm typecheck
 pnpm lint
+pnpm typecheck
 pnpm test:offline
 ```
 


### PR DESCRIPTION
## Motivation

The English and Chinese Getting Started guides explain that `pnpm build` must run before `pnpm typecheck`, but their offline toolchain verification blocks currently only show `pnpm test:offline`.

This can lead new contributors to skip the typecheck and lint checks listed in `CONTRIBUTING.md`.

## Changes

- add `pnpm typecheck` to the English and Chinese Getting Started guides
- add `pnpm lint` to both guides
- keep the two localized guides consistent
- preserve the existing build-first command order

## Behavior and package boundaries

This is a documentation-only change.

It does not modify runtime behavior, package APIs, dependencies, examples, tests, or protocol implementations. No changeset is included because there is no user-facing package behavior change.

## Verification

The following checks passed locally:

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:offline`
- `git diff --check`

Diff summary:

```text
docs/getting-started.md       | 2 ++
docs/getting-started.zh-CN.md | 2 ++
2 files changed, 4 insertions(+)