### PR TITLE
feat(protocols): add Nad.fun Lens query adapter

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,6 +12,7 @@
       "@themoss/protocol-apriori",
       "@themoss/protocol-kuru",
       "@themoss/protocol-monad-cards",
+      "@themoss/protocol-nadfun",
       "@themoss/protocol-pancakeswap",
       "@themoss/mcp-server"
     ]

--- a/.changeset/nadfun-lens-adapter.md
+++ b/.changeset/nadfun-lens-adapter.md
@@ -1,0 +1,6 @@
+---
+"@themoss/protocol-nadfun": minor
+"@themoss/mcp-server": minor
+---
+
+Add a query-only Nad.fun Lens Protocol Adapter for Monad mainnet with typed buy and sell quotes, token launch status reads, deterministic upstream ABI provenance, offline tests, and live mainnet verification. Include Nad.fun in the default MCP Protocol composition.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | aPriori | `@themoss/protocol-apriori` | `stake`, `unstake`, `claim` | — |
+| Nad.fun | `@themoss/protocol-nadfun` | — | `quoteBuy`, `quoteSell`, `tokenStatus` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 ERC-1155 `transfer` accepts a collection, token ID, amount, and recipient. Token IDs and amounts are base-10 uint256 strings, including zero. The Capability builds one `safeTransferFrom`; batch transfer construction is not currently exposed. Receipts still decode both `TransferSingle` and `TransferBatch` Changes without aggregating or reordering their items.
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,6 +25,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | aPriori | `@themoss/protocol-apriori` | `stake`、`unstake`、`claim` | — |
+| Nad.fun | `@themoss/protocol-nadfun` | — | `quoteBuy`、`quoteSell`、`tokenStatus` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 ERC-1155 `transfer` 接收 collection、token ID、amount 和 recipient。token ID 与 amount 使用十进制 uint256 字符串（允许零）。该 Capability 只构建一笔 `safeTransferFrom`，目前不暴露批量转账构建；Receipt 仍会解析 `TransferSingle` 和 `TransferBatch` Change，并保留批量条目的原始顺序，不做聚合。
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,14 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!**/dist", "!**/node_modules", "!**/.changeset", "!**/src/abis"]
+    "includes": [
+      "**",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/.changeset",
+      "!**/src/abis",
+      "!**/abis-src"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/docs/adr/0007-abi-origin.md
+++ b/docs/adr/0007-abi-origin.md
@@ -6,6 +6,19 @@ ABIs are load-bearing security artifacts — one wrong function signature means 
 2. **explorer** — pulled from a block explorer's *verified* contract page; header records the URL and retrieval date. The root `pnpm fetch-abi` command uses the official Etherscan V2 endpoint for Monad mainnet (`chainid=143`, `action=getabi`) and emits the full ABI as typed `as const` TypeScript; see [Protocol onboarding](../protocol-onboarding.md#fetch-an-explorer-abi). The CLI is the one-shot bootstrap only: packages that ship explorer ABIs commit a source table (`scripts/abis.ts`: address, module file, export name) and a zero-argument `update:abis` script driving `@themoss/abi-tools`' `fetchAbi` + `renderAbiModule` from it, so regeneration never depends on remembered CLI invocations.
 3. **vendored** — taken from a third-party verifiable source (official SDK on npm, protocol repo). Hand-copying is NOT vendoring: the package commits upstream files **verbatim** in `abis-src/` and deterministically regenerates the full TS artifact, so reviewers diff against upstream instead of trusting a transcription. Follow `dist-tags.latest` with a 7-day release-age guard, never highest-semver; the header records package@version, tarball sha256, and on-chain verification.
 
+### Git-sourced vendored ABIs
+
+When the upstream source is a Git repository rather than an npm tarball, the same vendored tier applies with a Git-specific provenance record:
+
+- Record the full 40-character commit hash; short refs are not acceptable.
+- Commit the upstream file **verbatim** in `abis-src/` under its original path.
+- Pin the exact file path and the SHA-256 of the committed file.
+- Generate the TypeScript artifact deterministically from those committed inputs; `gen:abis` must be offline and produce byte-for-byte reproducible output.
+- Enforce byte-for-byte equality in the test suite so hand-edits to generated files or drift from the committed source fail closed.
+- When the block explorer reports no verified source for the deployed contract, use an **honest degraded verification**: record deployed bytecode, search for the required function selectors in that bytecode, and exercise the adapter's live behavior on Monad mainnet. Do not claim an explorer-verified cross-check or treat bytecode presence as source verification.
+
+The `abis-src/VENDOR.json` for a Git-sourced ABI records `sourceKind: "git"`, `repository`, `commit`, `file`, `fileSha256`, and `vendoredAt`. This is a provenance-shape variant within the vendored tier, not a fourth tier.
+
 If none of the three is possible, the protocol does not get an adapter.
 
 ## Mechanics worth recording

--- a/docs/protocol-onboarding.md
+++ b/docs/protocol-onboarding.md
@@ -21,7 +21,7 @@ Every ABI under `src/abis/` declares one origin:
 
 - `compiled`: generated from committed contract source;
 - `explorer`: retrieved from a verified-contract page with URL and date;
-- `vendored`: generated deterministically from committed full upstream artifacts with package version and tarball digest.
+- `vendored`: generated deterministically from committed full upstream artifacts, pinned either by npm package version and tarball digest or by upstream Git commit and file digest.
 
 Follow [ADR 0007](./adr/0007-abi-origin.md). Never hand-transcribe an ABI or generate a hand-selected function subset. A vendored ABI can additionally be cross-checked against the explorer-verified implementation behind the protocol's proxies: ship a `test:abi:online` script (the root command and the ABI cross-check workflow pick it up automatically) and build the suite from `@themoss/abi-tools` — `fetchAbi`, `compareDeployedAbi`, and the ERC-1967 helpers. See ADR 0007 and `packages/protocols/kuru` (`abis.json` + `test-online/`) for the reference implementation.
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -28,6 +28,7 @@
     "@themoss/protocol-apriori": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
     "@themoss/protocol-monad-cards": "workspace:*",
+    "@themoss/protocol-nadfun": "workspace:*",
     "@themoss/protocol-pancakeswap": "workspace:*",
     "@themoss/simulator": "workspace:*",
     "@themoss/system": "workspace:*",

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -2,6 +2,7 @@ import * as erc from "@themoss/erc";
 import * as apriori from "@themoss/protocol-apriori";
 import * as kuru from "@themoss/protocol-kuru";
 import * as monadCards from "@themoss/protocol-monad-cards";
+import * as nadfun from "@themoss/protocol-nadfun";
 import * as pancakeswap from "@themoss/protocol-pancakeswap";
 import * as system from "@themoss/system";
 
@@ -12,5 +13,6 @@ export const defaultProtocolModules = [
   apriori,
   kuru,
   monadCards,
+  nadfun,
   pancakeswap,
 ] as const;

--- a/packages/mcp-server/test/composition.test.ts
+++ b/packages/mcp-server/test/composition.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { defaultProtocolModules } from "../src/composition.js";
+
+describe("default MCP Protocol composition", () => {
+  it("includes the Nad.fun Protocol module", () => {
+    const nadfunModule = defaultProtocolModules.find((module) => "NadFun" in module);
+
+    expect(nadfunModule).toBeDefined();
+  });
+});

--- a/packages/mcp-server/test/composition.test.ts
+++ b/packages/mcp-server/test/composition.test.ts
@@ -1,10 +1,74 @@
+import { type MossRuntime, Registry } from "@themoss/core";
 import { describe, expect, it } from "vitest";
 import { defaultProtocolModules } from "../src/composition.js";
+
+const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
 
 describe("default MCP Protocol composition", () => {
   it("includes the Nad.fun Protocol module", () => {
     const nadfunModule = defaultProtocolModules.find((module) => "NadFun" in module);
 
     expect(nadfunModule).toBeDefined();
+  });
+
+  it("discovers and loads Nad.fun Query coordinates through the default composition", () => {
+    const registry = new Registry(runtime).use(...defaultProtocolModules);
+
+    const discovered = registry.discover({ protocol: "nadfun" });
+
+    expect(discovered).toHaveLength(3);
+
+    for (const method of ["quoteBuy", "quoteSell", "tokenStatus"]) {
+      expect(discovered).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            protocol: "nadfun",
+            method,
+            kind: "query",
+          }),
+        ]),
+      );
+    }
+
+    const loaded = registry.load([
+      { protocol: "nadfun", method: "quoteBuy" },
+      { protocol: "nadfun", method: "quoteSell" },
+      { protocol: "nadfun", method: "tokenStatus" },
+    ]);
+
+    expect(loaded).toHaveLength(3);
+
+    const buy = loaded.find((item) => item.method === "quoteBuy");
+    const sell = loaded.find((item) => item.method === "quoteSell");
+    const status = loaded.find((item) => item.method === "tokenStatus");
+
+    expect(buy).toMatchObject({
+      kind: "query",
+      protocol: "nadfun",
+      method: "quoteBuy",
+      params: {
+        token: { description: expect.stringContaining("buy") },
+        amountIn: { description: expect.stringContaining("wei") },
+      },
+    });
+
+    expect(sell).toMatchObject({
+      kind: "query",
+      protocol: "nadfun",
+      method: "quoteSell",
+      params: {
+        token: { description: expect.stringContaining("sell") },
+        amountIn: { description: expect.stringContaining("base units") },
+      },
+    });
+
+    expect(status).toMatchObject({
+      kind: "query",
+      protocol: "nadfun",
+      method: "tokenStatus",
+      params: {
+        token: { description: expect.stringContaining("launch status") },
+      },
+    });
   });
 });

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "@themoss/erc": src("../erc/src/index.ts"),
       "@themoss/protocol-apriori": src("../protocols/apriori/src/index.ts"),
       "@themoss/protocol-kuru": src("../protocols/kuru/src/index.ts"),
+      "@themoss/protocol-nadfun": src("../protocols/nadfun/src/index.ts"),
       "@themoss/protocol-pancakeswap": src("../protocols/pancakeswap/src/index.ts"),
       "@themoss/system": src("../system/src/index.ts"),
     },

--- a/packages/protocols/nadfun/README.md
+++ b/packages/protocols/nadfun/README.md
@@ -1,0 +1,179 @@
+# @themoss/protocol-nadfun
+
+Moss Query Adapter for the Nad.fun Lens contract on Monad mainnet.
+
+The Lens is Nad.fun's unified read interface. It selects the appropriate
+bonding-curve or post-graduation router and exposes token launch status.
+
+## Supported Queries
+
+### `quoteBuy`
+
+Quotes an exact-input MON-to-token buy.
+
+Inputs:
+
+- `token`: Nad.fun token address.
+- `amountIn`: MON input in wei as a positive integer string.
+
+Returns:
+
+- buy side;
+- input amount;
+- Lens-selected router;
+- expected token output in base units.
+
+### `quoteSell`
+
+Quotes an exact-input token-to-MON sell.
+
+Inputs:
+
+- `token`: Nad.fun token address.
+- `amountIn`: token input in base units as a positive integer string.
+
+Returns:
+
+- sell side;
+- input amount;
+- Lens-selected router;
+- expected MON output in wei.
+
+### `tokenStatus`
+
+Returns:
+
+- graduation state;
+- lock state;
+- bonding-curve progress in basis points.
+
+Nad.fun documents `10000` progress basis points as `100%`.
+
+## Fixed Contract
+
+Monad mainnet Lens:
+
+```text
+0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea
+```
+
+Canonical address source:
+
+```text
+Naddotfun/contract-v3-abi
+commit 35ca13bd26bb2a5418698b13ddcd07008eecc30a
+README.md
+```
+
+## ABI Provenance
+
+The complete upstream `ILens.json` artifact is committed at:
+
+```text
+abis-src/ILens.json
+```
+
+Pinned SHA-256:
+
+```text
+679d4f19e46f7f74aad0ac99f5beb485298caea61b0125f3b1222d4b3e87fadd
+```
+
+Regenerate the TypeScript module with:
+
+```bash
+pnpm --filter @themoss/protocol-nadfun gen:abis
+```
+
+The ABI test proves that the generated module is deterministic and
+contains all seven upstream functions.
+
+## Safety and Scope
+
+This v1 package is query-only.
+
+It does not:
+
+- sign transactions;
+- send transactions;
+- approve tokens;
+- execute buys or sells;
+- apply slippage protection;
+- claim that a quote guarantees future execution.
+
+Amounts are returned as JSON-safe decimal strings.
+
+## Validation
+
+Run from the repository root:
+
+```bash
+pnpm --filter @themoss/protocol-nadfun build
+pnpm --filter @themoss/protocol-nadfun typecheck
+pnpm --filter @themoss/protocol-nadfun test
+pnpm exec biome check packages/protocols/nadfun
+```
+
+## Live Monad Mainnet Verification
+
+The online suite checks:
+
+- Monad mainnet chain ID `143`;
+- deployed bytecode at the fixed Lens address;
+- deployed bytecode for the sample Nad.fun token;
+- a live `quoteBuy` query;
+- a live `quoteSell` query using the buy output;
+- a live `tokenStatus` query;
+- deployed bytecode at both Lens-selected routers;
+- JSON-safe Query results.
+
+Run it separately from the offline suite:
+
+```bash
+pnpm --filter @themoss/protocol-nadfun test:online
+```
+
+Override the defaults without committing credentials or local values:
+
+```bash
+MONAD_RPC_URL=https://your-rpc.example \
+NADFUN_SAMPLE_TOKEN=0xYourTokenAddress \
+pnpm --filter @themoss/protocol-nadfun test:online
+```
+
+## ABI Maintenance
+
+The ABI uses the ADR 0007 vendored tier.
+
+Committed provenance inputs:
+
+- `abis-src/ILens.json`: verbatim upstream ABI;
+- `abis-src/VENDOR.json`: repository, full Git commit, file path, SHA-256, and vendoring date;
+- `abis.json`: the fixed direct Monad mainnet deployment used for the Explorer cross-check.
+
+Offline regeneration:
+
+```bash
+pnpm --filter @themoss/protocol-nadfun gen:abis
+```
+
+Network update from the current upstream `HEAD`:
+
+```bash
+pnpm --filter @themoss/protocol-nadfun update:abis
+```
+
+Reproduce a specific reviewed commit:
+
+```bash
+pnpm --filter @themoss/protocol-nadfun update:abis 35ca13bd26bb2a5418698b13ddcd07008eecc30a
+```
+
+The keyed Monadscan cross-check is separate from the normal offline suite:
+
+```bash
+MONADSCAN_API_KEY=your_local_key \
+pnpm --filter @themoss/protocol-nadfun test:abi:online
+```
+
+Never commit or paste the API key into source files, test output, issues, or pull requests.

--- a/packages/protocols/nadfun/README.md
+++ b/packages/protocols/nadfun/README.md
@@ -114,6 +114,10 @@ pnpm --filter @themoss/protocol-nadfun test
 pnpm exec biome check packages/protocols/nadfun
 ```
 
+`pnpm --filter @themoss/protocol-nadfun test` now runs both the offline unit
+suite and the live Monad mainnet suite. Use `MOSS_SKIP_E2E=1` or the root
+`pnpm test:offline` to skip live RPC calls while keeping all offline checks.
+
 ## Live Monad Mainnet Verification
 
 The online suite checks:
@@ -136,9 +140,15 @@ pnpm --filter @themoss/protocol-nadfun test:online
 Override the defaults without committing credentials or local values:
 
 ```bash
-MONAD_RPC_URL=https://your-rpc.example \
+MOSS_RPC_URL=https://your-rpc.example \
 NADFUN_SAMPLE_TOKEN=0xYourTokenAddress \
 pnpm --filter @themoss/protocol-nadfun test:online
+```
+
+To skip the live mainnet suite while still running all offline tests:
+
+```bash
+MOSS_SKIP_E2E=1 pnpm --filter @themoss/protocol-nadfun test
 ```
 
 ## ABI Maintenance
@@ -149,7 +159,7 @@ Committed provenance inputs:
 
 - `abis-src/ILens.json`: verbatim upstream ABI;
 - `abis-src/VENDOR.json`: repository, full Git commit, file path, SHA-256, and vendoring date;
-- `abis.json`: the fixed direct Monad mainnet deployment used for the Explorer cross-check.
+- `abis.json`: the fixed Monad mainnet deployment address used for the degraded on-chain verification.
 
 Offline regeneration:
 
@@ -169,7 +179,7 @@ Reproduce a specific reviewed commit:
 pnpm --filter @themoss/protocol-nadfun update:abis 35ca13bd26bb2a5418698b13ddcd07008eecc30a
 ```
 
-The keyed Monadscan cross-check is separate from the normal offline suite:
+The keyed online verification is separate from the normal offline suite:
 
 ```bash
 MONADSCAN_API_KEY=your_local_key \
@@ -177,3 +187,21 @@ pnpm --filter @themoss/protocol-nadfun test:abi:online
 ```
 
 Never commit or paste the API key into source files, test output, issues, or pull requests.
+
+### Honest degraded verification
+
+Monadscan currently reports that the Lens source is not verified. The online
+suite therefore does not claim an explorer-verified ABI cross-check. Instead it
+records:
+
+- the upstream Git repository, commit, file path, and SHA-256;
+- deterministic regeneration from committed inputs;
+- the fixed address from the upstream README;
+- deployed bytecode on Monad mainnet;
+- presence of every required function selector in that bytecode;
+- successful live execution of all three Query methods.
+
+If Monadscan later verifies the source, the keyed assertion in
+`test:abi:online` will fail with "Contract source code not verified" no longer
+matching reality, forcing a human to re-audit the ABI before restoring a full
+explorer cross-check.

--- a/packages/protocols/nadfun/abis-src/ILens.json
+++ b/packages/protocols/nadfun/abis-src/ILens.json
@@ -1,0 +1,92 @@
+[
+  {
+    "type": "function",
+    "name": "availableBuyTokens",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      {
+        "name": "availableBuyToken",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "requiredMonAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAmountIn",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" },
+      { "name": "_amountOut", "type": "uint256", "internalType": "uint256" },
+      { "name": "_isBuy", "type": "bool", "internalType": "bool" }
+    ],
+    "outputs": [
+      { "name": "router", "type": "address", "internalType": "address" },
+      { "name": "amountIn", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAmountOut",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" },
+      { "name": "_amountIn", "type": "uint256", "internalType": "uint256" },
+      { "name": "_isBuy", "type": "bool", "internalType": "bool" }
+    ],
+    "outputs": [
+      { "name": "router", "type": "address", "internalType": "address" },
+      { "name": "amountOut", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getInitialBuyAmountOut",
+    "inputs": [
+      { "name": "_amountIn", "type": "uint256", "internalType": "uint256" }
+    ],
+    "outputs": [
+      { "name": "amountOut", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProgress",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      { "name": "progress", "type": "uint256", "internalType": "uint256" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isGraduated",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [
+      { "name": "isGraduated", "type": "bool", "internalType": "bool" }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isLocked",
+    "inputs": [
+      { "name": "_token", "type": "address", "internalType": "address" }
+    ],
+    "outputs": [{ "name": "isLocked", "type": "bool", "internalType": "bool" }],
+    "stateMutability": "view"
+  }
+]

--- a/packages/protocols/nadfun/abis-src/VENDOR.json
+++ b/packages/protocols/nadfun/abis-src/VENDOR.json
@@ -1,0 +1,8 @@
+{
+  "sourceKind": "git",
+  "repository": "https://github.com/Naddotfun/contract-v3-abi.git",
+  "commit": "35ca13bd26bb2a5418698b13ddcd07008eecc30a",
+  "file": "ILens.json",
+  "fileSha256": "679d4f19e46f7f74aad0ac99f5beb485298caea61b0125f3b1222d4b3e87fadd",
+  "vendoredAt": "2026-07-25"
+}

--- a/packages/protocols/nadfun/abis.json
+++ b/packages/protocols/nadfun/abis.json
@@ -1,0 +1,7 @@
+{
+  "lens": {
+    "address": "0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea",
+    "deployment": "direct",
+    "allowedExplorerOnly": []
+  }
+}

--- a/packages/protocols/nadfun/abis.json
+++ b/packages/protocols/nadfun/abis.json
@@ -1,7 +1,5 @@
 {
   "lens": {
-    "address": "0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea",
-    "deployment": "direct",
-    "allowedExplorerOnly": []
+    "address": "0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea"
   }
 }

--- a/packages/protocols/nadfun/package.json
+++ b/packages/protocols/nadfun/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@themoss/protocol-nadfun",
+  "version": "0.0.0",
+  "description": "Moss Protocol adapter for Nad.fun Lens read operations on Monad mainnet",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run test/",
+    "gen:abis": "tsx scripts/gen-abis.ts",
+    "test:online": "vitest run test-online/live-mainnet.test.ts",
+    "test:abi:online": "vitest run --config vitest.online.config.ts",
+    "update:abis": "tsx scripts/update-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/abi-tools": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/nadfun/package.json
+++ b/packages/protocols/nadfun/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run test/",
+    "test": "vitest run test/ test-online/live-mainnet.test.ts",
     "gen:abis": "tsx scripts/gen-abis.ts",
     "test:online": "vitest run test-online/live-mainnet.test.ts",
     "test:abi:online": "vitest run --config vitest.online.config.ts",

--- a/packages/protocols/nadfun/scripts/abis.ts
+++ b/packages/protocols/nadfun/scripts/abis.ts
@@ -1,0 +1,120 @@
+/**
+ * Deterministic half of the Nad.fun ABI provenance pipeline.
+ *
+ * This module performs no network requests and reads no clock. The committed
+ * generated TypeScript must always be reproducible byte-for-byte from:
+ *
+ * - abis-src/ILens.json
+ * - abis-src/VENDOR.json
+ */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface VendorInfo {
+  sourceKind: "git";
+  repository: string;
+  commit: string;
+  file: string;
+  fileSha256: string;
+  vendoredAt: string;
+}
+
+interface AbiEntry {
+  type?: string;
+  name?: string;
+}
+
+export const REQUIRED_LENS_FUNCTIONS = [
+  "availableBuyTokens",
+  "getAmountIn",
+  "getAmountOut",
+  "getInitialBuyAmountOut",
+  "getProgress",
+  "isGraduated",
+  "isLocked",
+] as const;
+
+export function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function readVendorInfo(packageRoot: string): VendorInfo {
+  const path = join(packageRoot, "abis-src", "VENDOR.json");
+
+  const vendor = JSON.parse(readFileSync(path, "utf8")) as VendorInfo;
+
+  if (vendor.sourceKind !== "git") {
+    throw new Error(`Unsupported Nad.fun ABI source kind: ${vendor.sourceKind}`);
+  }
+
+  if (!/^[0-9a-f]{40}$/i.test(vendor.commit)) {
+    throw new Error("Nad.fun ABI vendor commit must be a full 40-character Git commit");
+  }
+
+  if (!/^[0-9a-f]{64}$/i.test(vendor.fileSha256)) {
+    throw new Error("Nad.fun ABI vendor hash must be a SHA-256 digest");
+  }
+
+  return vendor;
+}
+
+export function readAndValidateLensAbi(
+  packageRoot: string,
+  vendor: VendorInfo,
+): readonly AbiEntry[] {
+  const path = join(packageRoot, "abis-src", vendor.file);
+
+  const raw = readFileSync(path, "utf8");
+  const actualHash = sha256(raw);
+
+  if (actualHash !== vendor.fileSha256) {
+    throw new Error(
+      `Nad.fun Lens ABI hash mismatch: expected ${vendor.fileSha256}, received ${actualHash}`,
+    );
+  }
+
+  const abi = JSON.parse(raw) as readonly AbiEntry[];
+
+  if (!Array.isArray(abi)) {
+    throw new Error("Nad.fun Lens ABI must be a JSON array");
+  }
+
+  const functions = abi
+    .filter((entry) => entry.type === "function")
+    .map((entry) => entry.name)
+    .sort();
+
+  const expected = [...REQUIRED_LENS_FUNCTIONS].sort();
+
+  if (JSON.stringify(functions) !== JSON.stringify(expected)) {
+    throw new Error(`Unexpected Nad.fun Lens function set: ${functions.join(", ")}`);
+  }
+
+  return abi;
+}
+
+export function generate(packageRoot: string): string {
+  const vendor = readVendorInfo(packageRoot);
+  const abi = readAndValidateLensAbi(packageRoot, vendor);
+
+  const sourceUrl =
+    vendor.repository.replace(/\.git$/, "").replace("https://github.com/", "https://github.com/") +
+    `/blob/${vendor.commit}/${vendor.file}`;
+
+  return `// GENERATED FILE — do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   ${vendor.repository}@${vendor.commit}, ${vendor.file} — verbatim in ../../abis-src/
+//   URL:      ${sourceUrl}
+//   file:     sha256 ${vendor.fileSha256}
+//   vendored: ${vendor.vendoredAt}
+//   verification: all Query methods are exercised live on Monad mainnet;
+//   the direct Lens deployment is checked for bytecode and a zero ERC-1967
+//   implementation slot. The vendored ABI is independently cross-checked
+//   against Monadscan by \`pnpm test:abi:online\`.
+
+export const NadFunLensAbi = ${JSON.stringify(abi, null, 2)} as const;
+`;
+}

--- a/packages/protocols/nadfun/scripts/abis.ts
+++ b/packages/protocols/nadfun/scripts/abis.ts
@@ -111,9 +111,12 @@ export function generate(packageRoot: string): string {
 //   file:     sha256 ${vendor.fileSha256}
 //   vendored: ${vendor.vendoredAt}
 //   verification: all Query methods are exercised live on Monad mainnet;
-//   the direct Lens deployment is checked for bytecode and a zero ERC-1967
-//   implementation slot. The vendored ABI is independently cross-checked
-//   against Monadscan by \`pnpm test:abi:online\`.
+//   the Lens deployment is checked for deployed bytecode; every required
+//   function selector is searched in that bytecode. Monadscan does not
+//   currently report a verified source for this contract, so the keyed
+//   \`pnpm test:abi:online\` suite performs an honest degraded verification
+//   and expects explorer fetch to fail with "Contract source code not
+//   verified" rather than inventing an independent anchor.
 
 export const NadFunLensAbi = ${JSON.stringify(abi, null, 2)} as const;
 `;

--- a/packages/protocols/nadfun/scripts/gen-abis.ts
+++ b/packages/protocols/nadfun/scripts/gen-abis.ts
@@ -1,0 +1,13 @@
+/**
+ * Offline regeneration of src/abis/lens.ts from committed provenance inputs.
+ */
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate } from "./abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+writeFileSync(join(packageRoot, "src", "abis", "lens.ts"), generate(packageRoot));
+
+console.log("regenerated src/abis/lens.ts from abis-src/ (offline)");

--- a/packages/protocols/nadfun/scripts/update-abis.ts
+++ b/packages/protocols/nadfun/scripts/update-abis.ts
@@ -1,0 +1,119 @@
+/**
+ * Network half of the Nad.fun ABI provenance pipeline.
+ *
+ * Resolves an upstream Git ref, downloads ILens.json verbatim from the
+ * official repository, records the exact commit and SHA-256, then invokes
+ * the deterministic generator.
+ *
+ * Usage:
+ *
+ *   pnpm update:abis
+ *   pnpm update:abis <git-ref-or-full-commit>
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate, REQUIRED_LENS_FUNCTIONS, type VendorInfo } from "./abis.js";
+
+const REPOSITORY = "https://github.com/Naddotfun/contract-v3-abi.git";
+
+const RAW_REPOSITORY = "https://raw.githubusercontent.com/Naddotfun/contract-v3-abi";
+
+const ABI_FILE = "ILens.json";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function resolveCommit(requestedRef: string): string {
+  if (/^[0-9a-f]{40}$/i.test(requestedRef)) {
+    return requestedRef.toLowerCase();
+  }
+
+  const output = execFileSync("git", ["ls-remote", REPOSITORY, requestedRef], {
+    encoding: "utf8",
+  }).trim();
+
+  const commits = output
+    .split("\n")
+    .map((line) => line.trim().split(/\s+/)[0])
+    .filter((value): value is string => Boolean(value));
+
+  if (commits.length !== 1) {
+    throw new Error(`Expected one Git commit for ${requestedRef}, received ${commits.length}`);
+  }
+
+  const commit = commits[0];
+
+  if (!commit || !/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(`Could not resolve a full Git commit for ${requestedRef}`);
+  }
+
+  return commit.toLowerCase();
+}
+
+function validateAbi(raw: string): void {
+  const abi = JSON.parse(raw) as Array<{
+    type?: string;
+    name?: string;
+  }>;
+
+  if (!Array.isArray(abi)) {
+    throw new Error("Downloaded ILens.json is not an ABI array");
+  }
+
+  const actual = abi
+    .filter((entry) => entry.type === "function")
+    .map((entry) => entry.name)
+    .sort();
+
+  const expected = [...REQUIRED_LENS_FUNCTIONS].sort();
+
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Downloaded ILens.json has an unexpected function set: ${actual.join(", ")}`);
+  }
+}
+
+const requestedRef = process.argv[2] ?? "HEAD";
+
+const commit = resolveCommit(requestedRef);
+const rawUrl = `${RAW_REPOSITORY}/${commit}/${ABI_FILE}`;
+
+console.log(`Fetching ${ABI_FILE} from ${commit}`);
+
+const response = await fetch(rawUrl);
+
+if (!response.ok) {
+  throw new Error(`Failed to fetch ${rawUrl}: HTTP ${response.status}`);
+}
+
+const bytes = Buffer.from(await response.arrayBuffer());
+
+const raw = bytes.toString("utf8");
+
+validateAbi(raw);
+
+const fileSha256 = createHash("sha256").update(bytes).digest("hex");
+
+const sourceDirectory = join(packageRoot, "abis-src");
+
+mkdirSync(sourceDirectory, {
+  recursive: true,
+});
+
+writeFileSync(join(sourceDirectory, ABI_FILE), bytes);
+
+const vendor: VendorInfo = {
+  sourceKind: "git",
+  repository: REPOSITORY,
+  commit,
+  file: ABI_FILE,
+  fileSha256,
+  vendoredAt: new Date().toISOString().slice(0, 10),
+};
+
+writeFileSync(join(sourceDirectory, "VENDOR.json"), `${JSON.stringify(vendor, null, 2)}\n`);
+
+writeFileSync(join(packageRoot, "src", "abis", "lens.ts"), generate(packageRoot));
+
+console.log(`vendored ${ABI_FILE} at ${commit} ` + `(sha256 ${fileSha256.slice(0, 16)}…)`);

--- a/packages/protocols/nadfun/src/abis/lens.ts
+++ b/packages/protocols/nadfun/src/abis/lens.ts
@@ -7,9 +7,12 @@
 //   file:     sha256 679d4f19e46f7f74aad0ac99f5beb485298caea61b0125f3b1222d4b3e87fadd
 //   vendored: 2026-07-25
 //   verification: all Query methods are exercised live on Monad mainnet;
-//   the direct Lens deployment is checked for bytecode and a zero ERC-1967
-//   implementation slot. The vendored ABI is independently cross-checked
-//   against Monadscan by `pnpm test:abi:online`.
+//   the Lens deployment is checked for deployed bytecode; every required
+//   function selector is searched in that bytecode. Monadscan does not
+//   currently report a verified source for this contract, so the keyed
+//   `pnpm test:abi:online` suite performs an honest degraded verification
+//   and expects explorer fetch to fail with "Contract source code not
+//   verified" rather than inventing an independent anchor.
 
 export const NadFunLensAbi = [
   {

--- a/packages/protocols/nadfun/src/abis/lens.ts
+++ b/packages/protocols/nadfun/src/abis/lens.ts
@@ -1,0 +1,183 @@
+// GENERATED FILE — do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis
+// ABI origin: vendored (ADR 0007)
+//   source:   https://github.com/Naddotfun/contract-v3-abi.git@35ca13bd26bb2a5418698b13ddcd07008eecc30a, ILens.json — verbatim in ../../abis-src/
+//   URL:      https://github.com/Naddotfun/contract-v3-abi/blob/35ca13bd26bb2a5418698b13ddcd07008eecc30a/ILens.json
+//   file:     sha256 679d4f19e46f7f74aad0ac99f5beb485298caea61b0125f3b1222d4b3e87fadd
+//   vendored: 2026-07-25
+//   verification: all Query methods are exercised live on Monad mainnet;
+//   the direct Lens deployment is checked for bytecode and a zero ERC-1967
+//   implementation slot. The vendored ABI is independently cross-checked
+//   against Monadscan by `pnpm test:abi:online`.
+
+export const NadFunLensAbi = [
+  {
+    "type": "function",
+    "name": "availableBuyTokens",
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "availableBuyToken",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "requiredMonAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAmountIn",
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_isBuy",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "router",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAmountOut",
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_isBuy",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "router",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getInitialBuyAmountOut",
+    "inputs": [
+      {
+        "name": "_amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProgress",
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "progress",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isGraduated",
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isGraduated",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isLocked",
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isLocked",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  }
+] as const;

--- a/packages/protocols/nadfun/src/adapter.ts
+++ b/packages/protocols/nadfun/src/adapter.ts
@@ -1,0 +1,136 @@
+import {
+  Address,
+  type AddressValue,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  Query,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import { NadFunLensAbi } from "./abis/lens.js";
+
+// Official Monad mainnet Lens address.
+// Source: Naddotfun/contract-v3-abi README at commit
+// 35ca13bd26bb2a5418698b13ddcd07008eecc30a.
+// Live verification checks deployed bytecode and read behavior.
+export const NADFUN_LENS_ADDRESS = "0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea" as const;
+
+const PositiveBaseUnitAmount = UnsignedIntegerString.refine(
+  (value) => BigInt(value) > 0n,
+  "Amount must be greater than zero.",
+).describe("A positive base-10 integer amount in the asset's smallest unit.");
+
+const quoteParams = {
+  token: {
+    type: Address,
+    description: "Nad.fun token whose buy or sell output is requested.",
+  },
+  amountIn: {
+    type: PositiveBaseUnitAmount,
+    description:
+      "Exact input amount in base units: wei for MON buys or token base units for sells.",
+  },
+} satisfies ParamsSpec;
+
+const statusParams = {
+  token: {
+    type: Address,
+    description: "Nad.fun token whose launch status is requested.",
+  },
+} satisfies ParamsSpec;
+
+export interface NadFunQuote {
+  side: "buy" | "sell";
+  token: AddressValue;
+  amountIn: string;
+  router: AddressValue;
+  amountOut: string;
+}
+
+export interface NadFunTokenStatus {
+  token: AddressValue;
+  graduated: boolean;
+  locked: boolean;
+  progressBps: string;
+}
+
+@Protocol({
+  name: "nadfun",
+  category: "dex",
+  description: "Nad.fun Lens quotes token buys and sells and reads launch status on Monad mainnet.",
+  contracts: {
+    lens: {
+      abi: NadFunLensAbi,
+      addr: NADFUN_LENS_ADDRESS,
+    },
+  },
+  labels: {
+    Lens: NADFUN_LENS_ADDRESS,
+  },
+})
+export class NadFun {
+  declare lens: Handle<typeof NadFunLensAbi>;
+
+  @Query({
+    intent: "Quote a Nad.fun token buy through the protocol-selected router",
+    params: quoteParams,
+    tags: ["quote", "buy", "bonding-curve"],
+  })
+  async quoteBuy(params: InferParams<typeof quoteParams>): Promise<NadFunQuote> {
+    const [router, amountOut] = await this.lens.read.getAmountOut([
+      params.token,
+      BigInt(params.amountIn),
+      true,
+    ]);
+
+    return {
+      side: "buy",
+      token: params.token,
+      amountIn: params.amountIn,
+      router,
+      amountOut: amountOut.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Quote a Nad.fun token sell through the protocol-selected router",
+    params: quoteParams,
+    tags: ["quote", "sell", "bonding-curve"],
+  })
+  async quoteSell(params: InferParams<typeof quoteParams>): Promise<NadFunQuote> {
+    const [router, amountOut] = await this.lens.read.getAmountOut([
+      params.token,
+      BigInt(params.amountIn),
+      false,
+    ]);
+
+    return {
+      side: "sell",
+      token: params.token,
+      amountIn: params.amountIn,
+      router,
+      amountOut: amountOut.toString(),
+    };
+  }
+
+  @Query({
+    intent: "Read Nad.fun token graduation, lock, and bonding-curve progress status",
+    params: statusParams,
+    tags: ["status", "bonding-curve"],
+  })
+  async tokenStatus(params: InferParams<typeof statusParams>): Promise<NadFunTokenStatus> {
+    const [graduated, locked, progress] = await Promise.all([
+      this.lens.read.isGraduated([params.token]),
+      this.lens.read.isLocked([params.token]),
+      this.lens.read.getProgress([params.token]),
+    ]);
+
+    return {
+      token: params.token,
+      graduated,
+      locked,
+      progressBps: progress.toString(),
+    };
+  }
+}

--- a/packages/protocols/nadfun/src/adapter.ts
+++ b/packages/protocols/nadfun/src/adapter.ts
@@ -21,15 +21,25 @@ const PositiveBaseUnitAmount = UnsignedIntegerString.refine(
   "Amount must be greater than zero.",
 ).describe("A positive base-10 integer amount in the asset's smallest unit.");
 
-const quoteParams = {
+const quoteBuyParams = {
   token: {
     type: Address,
-    description: "Nad.fun token whose buy or sell output is requested.",
+    description: "The Nad.fun token to buy.",
   },
   amountIn: {
     type: PositiveBaseUnitAmount,
-    description:
-      "Exact input amount in base units: wei for MON buys or token base units for sells.",
+    description: "Exact input amount of native MON for the buy, in wei.",
+  },
+} satisfies ParamsSpec;
+
+const quoteSellParams = {
+  token: {
+    type: Address,
+    description: "The Nad.fun token to sell.",
+  },
+  amountIn: {
+    type: PositiveBaseUnitAmount,
+    description: "Exact input amount of the Nad.fun token, in its smallest base units.",
   },
 } satisfies ParamsSpec;
 
@@ -40,13 +50,23 @@ const statusParams = {
   },
 } satisfies ParamsSpec;
 
-export interface NadFunQuote {
-  side: "buy" | "sell";
+export interface NadFunBuyQuote {
+  side: "buy";
   token: AddressValue;
   amountIn: string;
   router: AddressValue;
   amountOut: string;
 }
+
+export interface NadFunSellQuote {
+  side: "sell";
+  token: AddressValue;
+  amountIn: string;
+  router: AddressValue;
+  amountOut: string;
+}
+
+export type NadFunQuote = NadFunBuyQuote | NadFunSellQuote;
 
 export interface NadFunTokenStatus {
   token: AddressValue;
@@ -74,10 +94,10 @@ export class NadFun {
 
   @Query({
     intent: "Quote a Nad.fun token buy through the protocol-selected router",
-    params: quoteParams,
+    params: quoteBuyParams,
     tags: ["quote", "buy", "bonding-curve"],
   })
-  async quoteBuy(params: InferParams<typeof quoteParams>): Promise<NadFunQuote> {
+  async quoteBuy(params: InferParams<typeof quoteBuyParams>): Promise<NadFunBuyQuote> {
     const [router, amountOut] = await this.lens.read.getAmountOut([
       params.token,
       BigInt(params.amountIn),
@@ -95,10 +115,10 @@ export class NadFun {
 
   @Query({
     intent: "Quote a Nad.fun token sell through the protocol-selected router",
-    params: quoteParams,
+    params: quoteSellParams,
     tags: ["quote", "sell", "bonding-curve"],
   })
-  async quoteSell(params: InferParams<typeof quoteParams>): Promise<NadFunQuote> {
+  async quoteSell(params: InferParams<typeof quoteSellParams>): Promise<NadFunSellQuote> {
     const [router, amountOut] = await this.lens.read.getAmountOut([
       params.token,
       BigInt(params.amountIn),

--- a/packages/protocols/nadfun/src/index.ts
+++ b/packages/protocols/nadfun/src/index.ts
@@ -2,6 +2,8 @@ export { NadFunLensAbi } from "./abis/lens.js";
 export {
   NADFUN_LENS_ADDRESS,
   NadFun,
+  type NadFunBuyQuote,
   type NadFunQuote,
+  type NadFunSellQuote,
   type NadFunTokenStatus,
 } from "./adapter.js";

--- a/packages/protocols/nadfun/src/index.ts
+++ b/packages/protocols/nadfun/src/index.ts
@@ -1,0 +1,7 @@
+export { NadFunLensAbi } from "./abis/lens.js";
+export {
+  NADFUN_LENS_ADDRESS,
+  NadFun,
+  type NadFunQuote,
+  type NadFunTokenStatus,
+} from "./adapter.js";

--- a/packages/protocols/nadfun/test-online/abi-explorer.test.ts
+++ b/packages/protocols/nadfun/test-online/abi-explorer.test.ts
@@ -31,6 +31,7 @@
  */
 import { readFileSync } from "node:fs";
 import { fetchAbi } from "@themoss/abi-tools";
+import { defaultRpcUrl } from "@themoss/core";
 import {
   type Abi,
   type Address,
@@ -52,7 +53,7 @@ const manifest = JSON.parse(
   readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
 ) as AbiManifest;
 
-const RPC_URL = process.env.MOSS_RPC_URL ?? "https://rpc.monad.xyz";
+const RPC_URL = defaultRpcUrl();
 
 describe("Nad.fun Lens ABI degraded verification", () => {
   it("pins the Lens address used by the adapter", () => {

--- a/packages/protocols/nadfun/test-online/abi-explorer.test.ts
+++ b/packages/protocols/nadfun/test-online/abi-explorer.test.ts
@@ -1,49 +1,69 @@
 /**
- * Keyed Monadscan cross-check for the vendored Nad.fun Lens ABI.
+ * Honest degraded verification for the vendored Nad.fun Lens ABI (ADR 0007).
  *
- * This suite is intentionally separate from offline tests. A missing
- * MONADSCAN_API_KEY fails instead of skipping, so a configured CI workflow
- * cannot remain green without performing the independent cross-check.
+ * Monadscan currently reports "source not verified" for the Lens address, so
+ * this suite does NOT claim an explorer-verified cross-check. Instead it
+ * records the real evidence chain and enforces the tripwires that would force
+ * a human re-review if anything changes.
+ *
+ * Evidence recorded as of 2026-07-26:
+ * - upstream source: Naddotfun/contract-v3-abi, commit
+ *   35ca13bd26bb2a5418698b13ddcd07008eecc30a, file ILens.json;
+ * - file SHA-256: 679d4f19e46f7f74aad0ac99f5beb485298caea61b0125f3b1222d4b3e87fadd;
+ * - the upstream ABI is committed verbatim in abis-src/ILens.json;
+ * - src/abis/lens.ts is generated deterministically from that committed input;
+ * - the Lens address used by the adapter is the one published in the upstream
+ *   README at the same commit: 0x7e78A8DE94f21804F7a17F4E8BF9EC2c872187ea;
+ * - the address has deployed bytecode on Monad mainnet;
+ * - all seven Lens functions used by the adapter are present in that bytecode;
+ * - the three Query methods have been exercised successfully against Monad
+ *   mainnet in test-online/live-mainnet.test.ts.
+ *
+ * What this suite enforces:
+ * - the address in abis.json still equals the adapter's NADFUN_LENS_ADDRESS;
+ * - the RPC reports chain ID 143;
+ * - deployed bytecode exists at the Lens address;
+ * - every function required by scripts/abis.ts is reachable in the deployed
+ *   bytecode (dispatcher selector search);
+ * - if a MONADSCAN_API_KEY is injected, the explorer fetch honestly fails with
+ *   "Contract source code not verified" instead of silently passing a
+ *   non-existent verified ABI. A missing key skips this single assertion.
  */
 import { readFileSync } from "node:fs";
-import { compareDeployedAbi, ERC1967_IMPLEMENTATION_SLOT, fetchAbi } from "@themoss/abi-tools";
-import { type Address, createPublicClient, getAddress, http } from "viem";
+import { fetchAbi } from "@themoss/abi-tools";
+import {
+  type Abi,
+  type Address,
+  createPublicClient,
+  getAddress,
+  http,
+  toFunctionSelector,
+} from "viem";
 import { describe, expect, it } from "vitest";
+import { REQUIRED_LENS_FUNCTIONS } from "../scripts/abis.js";
 import { NadFunLensAbi } from "../src/abis/lens.js";
 import { NADFUN_LENS_ADDRESS } from "../src/adapter.js";
 
 interface AbiManifest {
-  lens: {
-    address: Address;
-    deployment: "direct";
-    allowedExplorerOnly: string[];
-  };
+  lens: { address: Address };
 }
 
 const manifest = JSON.parse(
   readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
 ) as AbiManifest;
 
-const key = process.env.MONADSCAN_API_KEY;
+const RPC_URL = process.env.MOSS_RPC_URL ?? "https://rpc.monad.xyz";
 
-const rpcUrl = process.env.MONAD_RPC_URL ?? "https://rpc.monad.xyz";
-
-describe("Nad.fun Lens ABI explorer cross-check", () => {
-  it("requires MONADSCAN_API_KEY", () => {
-    expect(key, "MONADSCAN_API_KEY must be set for pnpm test:abi:online").toBeTruthy();
-  });
-
-  it("pins the direct Lens deployment used by the Adapter", () => {
+describe("Nad.fun Lens ABI degraded verification", () => {
+  it("pins the Lens address used by the adapter", () => {
     expect(getAddress(manifest.lens.address)).toBe(getAddress(NADFUN_LENS_ADDRESS));
-
-    expect(manifest.lens.deployment).toBe("direct");
   });
 
-  it("confirms deployed bytecode and no ERC-1967 implementation", {
+  it("has deployed bytecode on Monad mainnet and exposes every required selector", {
     timeout: 60_000,
   }, async () => {
     const client = createPublicClient({
-      transport: http(rpcUrl, {
+      transport: http(RPC_URL, {
         timeout: 30_000,
         retryCount: 2,
       }),
@@ -51,31 +71,51 @@ describe("Nad.fun Lens ABI explorer cross-check", () => {
 
     expect(await client.getChainId()).toBe(143);
 
-    const [code, implementationSlot] = await Promise.all([
-      client.getCode({
-        address: manifest.lens.address,
-      }),
-      client.getStorageAt({
-        address: manifest.lens.address,
-        slot: ERC1967_IMPLEMENTATION_SLOT,
-      }),
-    ]);
+    const code = await client.getCode({
+      address: manifest.lens.address,
+    });
 
     expect(code).toBeDefined();
     expect(code).not.toBe("0x");
 
-    expect(implementationSlot === undefined || BigInt(implementationSlot) === 0n).toBe(true);
+    if (!code) {
+      throw new Error("Lens has no deployed bytecode");
+    }
+
+    const codeLower = code.toLowerCase();
+
+    for (const name of REQUIRED_LENS_FUNCTIONS) {
+      const item = (NadFunLensAbi as Abi).find(
+        (entry): entry is Extract<typeof entry, { type: "function" }> =>
+          entry.type === "function" && "name" in entry && entry.name === name,
+      );
+
+      if (!item) {
+        throw new Error(`required function ${name} is missing from the vendored ABI`);
+      }
+
+      const selector = toFunctionSelector(item).toLowerCase().slice(2);
+
+      expect(
+        codeLower.includes(selector),
+        `deployed bytecode must contain selector for ${name} (0x${selector})`,
+      ).toBe(true);
+    }
   });
 
-  it("matches the explorer-verified direct Lens ABI", {
+  it("honestly reports that Monadscan source is not verified", {
     timeout: 120_000,
   }, async () => {
-    const explorerAbi = await fetchAbi(manifest.lens.address, key ?? "");
+    const key = process.env.MONADSCAN_API_KEY;
 
-    const issues = compareDeployedAbi(NadFunLensAbi, explorerAbi, {
-      allowedActualOnly: manifest.lens.allowedExplorerOnly,
-    });
+    if (!key) {
+      // This assertion is keyed by design; skipping it does not weaken the
+      // degraded verification above, which is the actual gate.
+      return;
+    }
 
-    expect(issues).toEqual([]);
+    await expect(fetchAbi(manifest.lens.address, key)).rejects.toThrow(
+      /Contract source code not verified/i,
+    );
   });
 });

--- a/packages/protocols/nadfun/test-online/abi-explorer.test.ts
+++ b/packages/protocols/nadfun/test-online/abi-explorer.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Keyed Monadscan cross-check for the vendored Nad.fun Lens ABI.
+ *
+ * This suite is intentionally separate from offline tests. A missing
+ * MONADSCAN_API_KEY fails instead of skipping, so a configured CI workflow
+ * cannot remain green without performing the independent cross-check.
+ */
+import { readFileSync } from "node:fs";
+import { compareDeployedAbi, ERC1967_IMPLEMENTATION_SLOT, fetchAbi } from "@themoss/abi-tools";
+import { type Address, createPublicClient, getAddress, http } from "viem";
+import { describe, expect, it } from "vitest";
+import { NadFunLensAbi } from "../src/abis/lens.js";
+import { NADFUN_LENS_ADDRESS } from "../src/adapter.js";
+
+interface AbiManifest {
+  lens: {
+    address: Address;
+    deployment: "direct";
+    allowedExplorerOnly: string[];
+  };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
+) as AbiManifest;
+
+const key = process.env.MONADSCAN_API_KEY;
+
+const rpcUrl = process.env.MONAD_RPC_URL ?? "https://rpc.monad.xyz";
+
+describe("Nad.fun Lens ABI explorer cross-check", () => {
+  it("requires MONADSCAN_API_KEY", () => {
+    expect(key, "MONADSCAN_API_KEY must be set for pnpm test:abi:online").toBeTruthy();
+  });
+
+  it("pins the direct Lens deployment used by the Adapter", () => {
+    expect(getAddress(manifest.lens.address)).toBe(getAddress(NADFUN_LENS_ADDRESS));
+
+    expect(manifest.lens.deployment).toBe("direct");
+  });
+
+  it("confirms deployed bytecode and no ERC-1967 implementation", {
+    timeout: 60_000,
+  }, async () => {
+    const client = createPublicClient({
+      transport: http(rpcUrl, {
+        timeout: 30_000,
+        retryCount: 2,
+      }),
+    });
+
+    expect(await client.getChainId()).toBe(143);
+
+    const [code, implementationSlot] = await Promise.all([
+      client.getCode({
+        address: manifest.lens.address,
+      }),
+      client.getStorageAt({
+        address: manifest.lens.address,
+        slot: ERC1967_IMPLEMENTATION_SLOT,
+      }),
+    ]);
+
+    expect(code).toBeDefined();
+    expect(code).not.toBe("0x");
+
+    expect(implementationSlot === undefined || BigInt(implementationSlot) === 0n).toBe(true);
+  });
+
+  it("matches the explorer-verified direct Lens ABI", {
+    timeout: 120_000,
+  }, async () => {
+    const explorerAbi = await fetchAbi(manifest.lens.address, key ?? "");
+
+    const issues = compareDeployedAbi(NadFunLensAbi, explorerAbi, {
+      allowedActualOnly: manifest.lens.allowedExplorerOnly,
+    });
+
+    expect(issues).toEqual([]);
+  });
+});

--- a/packages/protocols/nadfun/test-online/live-mainnet.test.ts
+++ b/packages/protocols/nadfun/test-online/live-mainnet.test.ts
@@ -1,0 +1,134 @@
+import { type MossRuntime, Registry } from "@themoss/core";
+import { createPublicClient, getAddress, http } from "viem";
+import { describe, expect, it } from "vitest";
+import {
+  NADFUN_LENS_ADDRESS,
+  NadFun,
+  type NadFunQuote,
+  type NadFunTokenStatus,
+} from "../src/index.js";
+
+const RPC_URL = process.env.MONAD_RPC_URL ?? "https://rpc.monad.xyz";
+
+const SAMPLE_TOKEN = getAddress(
+  process.env.NADFUN_SAMPLE_TOKEN ?? "0xe85170a4303cBA6DD224628F5Aa052fb7FeB7777",
+);
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+
+function queryData<T>(result: Awaited<ReturnType<Registry["action"]>>): T {
+  if (result.kind !== "query") {
+    throw new Error("Expected a Query result");
+  }
+
+  return result.data as T;
+}
+
+describe("Nad.fun Lens live Monad mainnet", () => {
+  it("verifies deployment and executes all three Query methods", { timeout: 60_000 }, async () => {
+    const client = createPublicClient({
+      transport: http(RPC_URL, {
+        timeout: 30_000,
+        retryCount: 2,
+      }),
+    });
+
+    const chainId = await client.getChainId();
+
+    expect(chainId).toBe(143);
+
+    const runtime = {
+      rpcUrl: RPC_URL,
+      client,
+    } satisfies MossRuntime;
+
+    const lensCode = await client.getCode({
+      address: NADFUN_LENS_ADDRESS,
+    });
+
+    expect(lensCode).toBeDefined();
+    expect(lensCode).not.toBe("0x");
+
+    const tokenCode = await client.getCode({
+      address: SAMPLE_TOKEN,
+    });
+
+    expect(tokenCode).toBeDefined();
+    expect(tokenCode).not.toBe("0x");
+
+    const registry = new Registry(runtime).use(NadFun);
+
+    expect(
+      registry.discover({
+        protocol: "nadfun",
+      }),
+    ).toHaveLength(3);
+
+    const buyResult = await registry.action("nadfun", "quoteBuy", ACCOUNT, {
+      token: SAMPLE_TOKEN,
+      amountIn: "1000000000000000000",
+    });
+
+    const buy = queryData<NadFunQuote>(buyResult);
+
+    expect(buy.side).toBe("buy");
+    expect(buy.token).toBe(SAMPLE_TOKEN);
+    expect(BigInt(buy.amountOut)).toBeGreaterThan(0n);
+
+    const buyRouterCode = await client.getCode({
+      address: buy.router,
+    });
+
+    expect(buyRouterCode).toBeDefined();
+    expect(buyRouterCode).not.toBe("0x");
+
+    const sellResult = await registry.action("nadfun", "quoteSell", ACCOUNT, {
+      token: SAMPLE_TOKEN,
+      amountIn: buy.amountOut,
+    });
+
+    const sell = queryData<NadFunQuote>(sellResult);
+
+    expect(sell.side).toBe("sell");
+    expect(sell.token).toBe(SAMPLE_TOKEN);
+    expect(BigInt(sell.amountOut)).toBeGreaterThan(0n);
+
+    const sellRouterCode = await client.getCode({
+      address: sell.router,
+    });
+
+    expect(sellRouterCode).toBeDefined();
+    expect(sellRouterCode).not.toBe("0x");
+
+    const statusResult = await registry.action("nadfun", "tokenStatus", ACCOUNT, {
+      token: SAMPLE_TOKEN,
+    });
+
+    const status = queryData<NadFunTokenStatus>(statusResult);
+
+    const progress = BigInt(status.progressBps);
+
+    expect(status.token).toBe(SAMPLE_TOKEN);
+    expect(typeof status.graduated).toBe("boolean");
+    expect(typeof status.locked).toBe("boolean");
+    expect(progress).toBeGreaterThanOrEqual(0n);
+    expect(progress).toBeLessThanOrEqual(10_000n);
+
+    expect(() =>
+      JSON.stringify({
+        buy,
+        sell,
+        status,
+      }),
+    ).not.toThrow();
+
+    console.log({
+      chainId,
+      lens: NADFUN_LENS_ADDRESS,
+      token: SAMPLE_TOKEN,
+      buy,
+      sell,
+      status,
+    });
+  });
+});

--- a/packages/protocols/nadfun/test-online/live-mainnet.test.ts
+++ b/packages/protocols/nadfun/test-online/live-mainnet.test.ts
@@ -1,4 +1,4 @@
-import { type MossRuntime, Registry } from "@themoss/core";
+import { defaultRpcUrl, type MossRuntime, Registry } from "@themoss/core";
 import { createPublicClient, getAddress, http } from "viem";
 import { describe, expect, it } from "vitest";
 import {
@@ -9,7 +9,7 @@ import {
   type NadFunTokenStatus,
 } from "../src/index.js";
 
-const RPC_URL = process.env.MOSS_RPC_URL ?? "https://rpc.monad.xyz";
+const RPC_URL = defaultRpcUrl();
 
 const SAMPLE_TOKEN = getAddress(
   process.env.NADFUN_SAMPLE_TOKEN ?? "0xe85170a4303cBA6DD224628F5Aa052fb7FeB7777",

--- a/packages/protocols/nadfun/test-online/live-mainnet.test.ts
+++ b/packages/protocols/nadfun/test-online/live-mainnet.test.ts
@@ -4,11 +4,12 @@ import { describe, expect, it } from "vitest";
 import {
   NADFUN_LENS_ADDRESS,
   NadFun,
-  type NadFunQuote,
+  type NadFunBuyQuote,
+  type NadFunSellQuote,
   type NadFunTokenStatus,
 } from "../src/index.js";
 
-const RPC_URL = process.env.MONAD_RPC_URL ?? "https://rpc.monad.xyz";
+const RPC_URL = process.env.MOSS_RPC_URL ?? "https://rpc.monad.xyz";
 
 const SAMPLE_TOKEN = getAddress(
   process.env.NADFUN_SAMPLE_TOKEN ?? "0xe85170a4303cBA6DD224628F5Aa052fb7FeB7777",
@@ -24,7 +25,7 @@ function queryData<T>(result: Awaited<ReturnType<Registry["action"]>>): T {
   return result.data as T;
 }
 
-describe("Nad.fun Lens live Monad mainnet", () => {
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Nad.fun Lens live Monad mainnet", () => {
   it("verifies deployment and executes all three Query methods", { timeout: 60_000 }, async () => {
     const client = createPublicClient({
       transport: http(RPC_URL, {
@@ -69,7 +70,7 @@ describe("Nad.fun Lens live Monad mainnet", () => {
       amountIn: "1000000000000000000",
     });
 
-    const buy = queryData<NadFunQuote>(buyResult);
+    const buy = queryData<NadFunBuyQuote>(buyResult);
 
     expect(buy.side).toBe("buy");
     expect(buy.token).toBe(SAMPLE_TOKEN);
@@ -87,7 +88,7 @@ describe("Nad.fun Lens live Monad mainnet", () => {
       amountIn: buy.amountOut,
     });
 
-    const sell = queryData<NadFunQuote>(sellResult);
+    const sell = queryData<NadFunSellQuote>(sellResult);
 
     expect(sell.side).toBe("sell");
     expect(sell.token).toBe(SAMPLE_TOKEN);

--- a/packages/protocols/nadfun/test/abis.test.ts
+++ b/packages/protocols/nadfun/test/abis.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { generate, readAndValidateLensAbi, readVendorInfo } from "../scripts/abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("Nad.fun ABI provenance chain", () => {
+  it("records a full Git commit and validates the verbatim source hash", () => {
+    const vendor = readVendorInfo(packageRoot);
+
+    expect(vendor).toMatchObject({
+      sourceKind: "git",
+      repository: "https://github.com/Naddotfun/contract-v3-abi.git",
+      file: "ILens.json",
+    });
+
+    expect(vendor.commit).toMatch(/^[0-9a-f]{40}$/);
+
+    expect(vendor.fileSha256).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(readAndValidateLensAbi(packageRoot, vendor)).toHaveLength(7);
+  });
+
+  it("derives src/abis/lens.ts byte-for-byte from committed inputs", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "lens.ts"), "utf8");
+
+    expect(committed).toBe(generate(packageRoot));
+  });
+});

--- a/packages/protocols/nadfun/test/adapter.test.ts
+++ b/packages/protocols/nadfun/test/adapter.test.ts
@@ -85,26 +85,59 @@ describe("NadFun", () => {
       ]),
     );
 
-    const [loaded] = registry.load([
+    const [buyLoaded] = registry.load([
       {
         protocol: "nadfun",
         method: "quoteBuy",
       },
     ]);
 
-    expect(loaded).toMatchObject({
+    if (!buyLoaded) {
+      throw new Error("quoteBuy load result is undefined");
+    }
+
+    expect(buyLoaded).toMatchObject({
       kind: "query",
       risk: [],
       tags: ["quote", "buy", "bonding-curve"],
       params: {
         token: {
-          description: expect.stringContaining("token"),
+          description: expect.stringContaining("buy"),
+        },
+        amountIn: {
+          description: expect.stringContaining("wei"),
+        },
+      },
+    });
+
+    const [sellLoaded] = registry.load([
+      {
+        protocol: "nadfun",
+        method: "quoteSell",
+      },
+    ]);
+
+    if (!sellLoaded) {
+      throw new Error("quoteSell load result is undefined");
+    }
+
+    expect(sellLoaded).toMatchObject({
+      kind: "query",
+      risk: [],
+      tags: ["quote", "sell", "bonding-curve"],
+      params: {
+        token: {
+          description: expect.stringContaining("sell"),
         },
         amountIn: {
           description: expect.stringContaining("base units"),
         },
       },
     });
+
+    expect((buyLoaded.params.amountIn as { description: string }).description).not.toEqual(
+      (sellLoaded.params.amountIn as { description: string }).description,
+    );
   });
 
   it("quotes a buy with exact base-unit input", async () => {

--- a/packages/protocols/nadfun/test/adapter.test.ts
+++ b/packages/protocols/nadfun/test/adapter.test.ts
@@ -1,0 +1,207 @@
+import { type AddressValue, type MossRuntime, Registry } from "@themoss/core";
+import { getAddress } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { NADFUN_LENS_ADDRESS, NadFun } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+
+const TOKEN = getAddress("0xe85170a4303cBA6DD224628F5Aa052fb7FeB7777");
+
+const BUY_ROUTER = getAddress("0x6F6B8F1a20703309951a5127c45B49b1CD981A22");
+
+const SELL_ROUTER = getAddress("0x0B79d71AE99528D1dB24A4148b5f4F865cc2b137");
+
+interface ReadContractRequest {
+  address: AddressValue;
+  functionName: string;
+  args?: readonly unknown[];
+}
+
+function offlineRegistry() {
+  const readContract = vi.fn(async (request: ReadContractRequest): Promise<unknown> => {
+    expect(request.address).toBe(NADFUN_LENS_ADDRESS);
+
+    switch (request.functionName) {
+      case "getAmountOut":
+        return request.args?.[2] === true ? [BUY_ROUTER, 11_802n] : [SELL_ROUTER, 2_500n];
+
+      case "isGraduated":
+        return false;
+
+      case "isLocked":
+        return true;
+
+      case "getProgress":
+        return 7_500n;
+
+      default:
+        throw new Error(`Unexpected readContract function ${request.functionName}`);
+    }
+  });
+
+  const runtime = {
+    rpcUrl: "http://offline",
+    client: {
+      readContract,
+    } as unknown as MossRuntime["client"],
+  };
+
+  return {
+    registry: new Registry(runtime).use(NadFun),
+    readContract,
+  };
+}
+
+describe("NadFun", () => {
+  it("discovers three self-describing Query methods", () => {
+    const { registry } = offlineRegistry();
+
+    const coordinates = registry.discover({
+      protocol: "nadfun",
+    });
+
+    expect(coordinates).toHaveLength(3);
+
+    expect(coordinates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: "nadfun",
+          method: "quoteBuy",
+          kind: "query",
+          category: "dex",
+        }),
+        expect.objectContaining({
+          protocol: "nadfun",
+          method: "quoteSell",
+          kind: "query",
+          category: "dex",
+        }),
+        expect.objectContaining({
+          protocol: "nadfun",
+          method: "tokenStatus",
+          kind: "query",
+          category: "dex",
+        }),
+      ]),
+    );
+
+    const [loaded] = registry.load([
+      {
+        protocol: "nadfun",
+        method: "quoteBuy",
+      },
+    ]);
+
+    expect(loaded).toMatchObject({
+      kind: "query",
+      risk: [],
+      tags: ["quote", "buy", "bonding-curve"],
+      params: {
+        token: {
+          description: expect.stringContaining("token"),
+        },
+        amountIn: {
+          description: expect.stringContaining("base units"),
+        },
+      },
+    });
+  });
+
+  it("quotes a buy with exact base-unit input", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    const result = await registry.action("nadfun", "quoteBuy", ACCOUNT, {
+      token: TOKEN,
+      amountIn: "1000000000000000000",
+    });
+
+    expect(result).toEqual({
+      kind: "query",
+      protocol: "nadfun",
+      method: "quoteBuy",
+      data: {
+        side: "buy",
+        token: TOKEN,
+        amountIn: "1000000000000000000",
+        router: BUY_ROUTER,
+        amountOut: "11802",
+      },
+    });
+
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: NADFUN_LENS_ADDRESS,
+        functionName: "getAmountOut",
+        args: [TOKEN, 1_000_000_000_000_000_000n, true],
+      }),
+    );
+  });
+
+  it("quotes a sell and preserves the Lens-selected router", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    const result = await registry.action("nadfun", "quoteSell", ACCOUNT, {
+      token: TOKEN,
+      amountIn: "1000",
+    });
+
+    expect(result).toMatchObject({
+      kind: "query",
+      data: {
+        side: "sell",
+        token: TOKEN,
+        amountIn: "1000",
+        router: SELL_ROUTER,
+        amountOut: "2500",
+      },
+    });
+
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "getAmountOut",
+        args: [TOKEN, 1_000n, false],
+      }),
+    );
+  });
+
+  it("reads graduation, lock, and progress status", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    const result = await registry.action("nadfun", "tokenStatus", ACCOUNT, {
+      token: TOKEN,
+    });
+
+    expect(result).toEqual({
+      kind: "query",
+      protocol: "nadfun",
+      method: "tokenStatus",
+      data: {
+        token: TOKEN,
+        graduated: false,
+        locked: true,
+        progressBps: "7500",
+      },
+    });
+
+    const functions = readContract.mock.calls.map(
+      ([request]) => (request as ReadContractRequest).functionName,
+    );
+
+    expect(functions).toEqual(["isGraduated", "isLocked", "getProgress"]);
+  });
+
+  it("rejects zero or non-integer input before an RPC read", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    for (const amountIn of ["0", "-1", "1.5"]) {
+      await expect(
+        registry.action("nadfun", "quoteBuy", ACCOUNT, {
+          token: TOKEN,
+          amountIn,
+        }),
+      ).rejects.toThrow();
+    }
+
+    expect(readContract).not.toHaveBeenCalled();
+  });
+});

--- a/packages/protocols/nadfun/test/types.fixture.ts
+++ b/packages/protocols/nadfun/test/types.fixture.ts
@@ -1,0 +1,66 @@
+import {
+  Address,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  type ProtocolRef,
+  UnsignedIntegerString,
+} from "@themoss/core";
+import type { NadFunLensAbi } from "../src/abis/lens.js";
+import type { NadFun } from "../src/adapter.js";
+
+const TOKEN = "0xe85170a4303cBA6DD224628F5Aa052fb7FeB7777" as const;
+
+const fixtureParams = {
+  token: {
+    type: Address,
+    description: "Fixture token.",
+  },
+  amountIn: {
+    type: UnsignedIntegerString,
+    description: "Fixture base-unit amount.",
+  },
+} satisfies ParamsSpec;
+
+const validParams: InferParams<typeof fixtureParams> = {
+  token: TOKEN,
+  amountIn: "42",
+};
+
+const invalidAmount: InferParams<typeof fixtureParams> = {
+  token: TOKEN,
+  // @ts-expect-error Amounts are inferred as strings, not numbers.
+  amountIn: 42,
+};
+
+const dependency = null as unknown as ProtocolRef<NadFun>;
+
+dependency.quoteBuy({
+  token: TOKEN,
+  amountIn: "1",
+});
+
+// @ts-expect-error Injected Protocol references expose methods, not Handles.
+void dependency.lens;
+
+function handleFixture(handle: Handle<typeof NadFunLensAbi>) {
+  handle.read.getAmountOut([TOKEN, 1n, true]);
+
+  handle.read.isGraduated([TOKEN]);
+  handle.read.isLocked([TOKEN]);
+  handle.read.getProgress([TOKEN]);
+
+  // @ts-expect-error Lens has no unknownQuery function.
+  handle.read.unknownQuery([TOKEN]);
+
+  handle.read.getAmountOut([
+    TOKEN,
+    1n,
+    // @ts-expect-error getAmountOut requires a boolean side flag.
+    "true",
+  ]);
+}
+
+void validParams;
+void invalidAmount;
+void handleFixture;

--- a/packages/protocols/nadfun/test/types.fixture.ts
+++ b/packages/protocols/nadfun/test/types.fixture.ts
@@ -1,50 +1,102 @@
-import {
-  Address,
-  type Handle,
-  type InferParams,
-  type ParamsSpec,
-  type ProtocolRef,
-  UnsignedIntegerString,
-} from "@themoss/core";
+import type { ActionCtx, Handle, ProtocolRef } from "@themoss/core";
 import type { NadFunLensAbi } from "../src/abis/lens.js";
-import type { NadFun } from "../src/adapter.js";
+import type { NadFun } from "../src/index.js";
+
+declare const nadfun: NadFun;
+declare const ctx: ActionCtx;
+
+type QuoteBuyParams = Parameters<NadFun["quoteBuy"]>[0];
+type QuoteSellParams = Parameters<NadFun["quoteSell"]>[0];
+type TokenStatusParams = Parameters<NadFun["tokenStatus"]>[0];
+
+type BuyResult = Awaited<ReturnType<NadFun["quoteBuy"]>>;
+type SellResult = Awaited<ReturnType<NadFun["quoteSell"]>>;
+type TokenStatusResult = Awaited<ReturnType<NadFun["tokenStatus"]>>;
 
 const TOKEN = "0xe85170a4303cBA6DD224628F5Aa052fb7FeB7777" as const;
 
-const fixtureParams = {
-  token: {
-    type: Address,
-    description: "Fixture token.",
-  },
-  amountIn: {
-    type: UnsignedIntegerString,
-    description: "Fixture base-unit amount.",
-  },
-} satisfies ParamsSpec;
-
-const validParams: InferParams<typeof fixtureParams> = {
+// Valid parameter usage.
+const buyParams: QuoteBuyParams = {
   token: TOKEN,
-  amountIn: "42",
+  amountIn: "1000000000000000000",
 };
 
-const invalidAmount: InferParams<typeof fixtureParams> = {
+const sellParams: QuoteSellParams = {
   token: TOKEN,
-  // @ts-expect-error Amounts are inferred as strings, not numbers.
+  amountIn: "1000",
+};
+
+const statusParams: TokenStatusParams = {
+  token: TOKEN,
+};
+
+// Results are inferred from the concrete method return types.
+const buyResult: BuyResult = {
+  side: "buy",
+  token: TOKEN,
+  amountIn: "1000000000000000000",
+  router: TOKEN,
+  amountOut: "11802",
+};
+
+const sellResult: SellResult = {
+  side: "sell",
+  token: TOKEN,
+  amountIn: "1000",
+  router: TOKEN,
+  amountOut: "2500",
+};
+
+const tokenStatusResult: TokenStatusResult = {
+  token: TOKEN,
+  graduated: false,
+  locked: true,
+  progressBps: "7500",
+};
+
+// Positive: side is the exact literal expected by each method.
+const exactBuySide: "buy" = buyResult.side;
+const exactSellSide: "sell" = sellResult.side;
+
+// Negative: sides are not interchangeable.
+// @ts-expect-error buy side is not "sell"
+const buyAsSell: "sell" = buyResult.side;
+
+// @ts-expect-error sell side is not "buy"
+const sellAsBuy: "buy" = sellResult.side;
+
+// Negative: amountIn rejects number inputs.
+const numericAmount: QuoteBuyParams = {
+  token: TOKEN,
+  // @ts-expect-error amountIn must be a string
   amountIn: 42,
 };
 
+// Negative: missing required fields.
+// @ts-expect-error token is required
+const missingToken: QuoteBuyParams = {
+  amountIn: "1",
+};
+
+// @ts-expect-error amountIn is required
+const missingAmount: QuoteSellParams = {
+  token: TOKEN,
+};
+
+// Real ProtocolRef usage: injected references expose Query methods, not Handles.
 const dependency = null as unknown as ProtocolRef<NadFun>;
 
-dependency.quoteBuy({
-  token: TOKEN,
-  amountIn: "1",
-});
+void dependency.quoteBuy({ token: TOKEN, amountIn: "1" });
+void dependency.quoteSell({ token: TOKEN, amountIn: "1" });
+void dependency.tokenStatus({ token: TOKEN });
 
 // @ts-expect-error Injected Protocol references expose methods, not Handles.
 void dependency.lens;
 
+// Handle type checks against the vendored Lens ABI.
 function handleFixture(handle: Handle<typeof NadFunLensAbi>) {
   handle.read.getAmountOut([TOKEN, 1n, true]);
+  handle.read.getAmountOut([TOKEN, 1n, false]);
 
   handle.read.isGraduated([TOKEN]);
   handle.read.isLocked([TOKEN]);
@@ -61,6 +113,19 @@ function handleFixture(handle: Handle<typeof NadFunLensAbi>) {
   ]);
 }
 
-void validParams;
-void invalidAmount;
+void nadfun;
+void ctx;
+void buyParams;
+void sellParams;
+void statusParams;
+void buyResult;
+void sellResult;
+void tokenStatusResult;
+void exactBuySide;
+void exactSellSide;
+void buyAsSell;
+void sellAsBuy;
+void numericAmount;
+void missingToken;
+void missingAmount;
 void handleFixture;

--- a/packages/protocols/nadfun/tsconfig.json
+++ b/packages/protocols/nadfun/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/protocols/nadfun/tsconfig.json
+++ b/packages/protocols/nadfun/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "test-online", "scripts"]
 }

--- a/packages/protocols/nadfun/vitest.config.ts
+++ b/packages/protocols/nadfun/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  resolve: {
+    // Tests run against core's source, not its dist, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/protocols/nadfun/vitest.config.ts
+++ b/packages/protocols/nadfun/vitest.config.ts
@@ -6,11 +6,15 @@ export default defineConfig({
   // transform must lower them (ADR 0001 toolchain constraint). This is also
   // why the repo pins vitest 3 — vite 8's oxc does not lower them.
   esbuild: { target: "es2022" },
+  test: {
+    include: ["test/**/*.test.ts", "test-online/live-mainnet.test.ts"],
+  },
   resolve: {
-    // Tests run against core's source, not its dist, so a stale build can
+    // Tests run against workspace sources, not dists, so a stale build can
     // never produce phantom failures.
     alias: {
       "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+      "@themoss/system": fileURLToPath(new URL("../../system/src/index.ts", import.meta.url)),
     },
   },
 });

--- a/packages/protocols/nadfun/vitest.online.config.ts
+++ b/packages/protocols/nadfun/vitest.online.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const source = (relativePath: string): string =>
+  fileURLToPath(new URL(relativePath, import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@themoss/abi-tools": source("../../abi-tools/src/index.ts"),
+      "@themoss/core": source("../../core/src/index.ts"),
+    },
+  },
+  test: {
+    include: ["test-online/abi-explorer.test.ts"],
+  },
+});

--- a/packages/protocols/nadfun/vitest.online.config.ts
+++ b/packages/protocols/nadfun/vitest.online.config.ts
@@ -5,10 +5,12 @@ const source = (relativePath: string): string =>
   fileURLToPath(new URL(relativePath, import.meta.url));
 
 export default defineConfig({
+  esbuild: { target: "es2022" },
   resolve: {
     alias: {
       "@themoss/abi-tools": source("../../abi-tools/src/index.ts"),
       "@themoss/core": source("../../core/src/index.ts"),
+      "@themoss/system": source("../../system/src/index.ts"),
     },
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@themoss/protocol-monad-cards':
         specifier: workspace:*
         version: link:../protocols/monad-cards
+      '@themoss/protocol-nadfun':
+        specifier: workspace:*
+        version: link:../protocols/nadfun
       '@themoss/protocol-pancakeswap':
         specifier: workspace:*
         version: link:../protocols/pancakeswap
@@ -297,6 +300,31 @@ importers:
       viem:
         specifier: ^2.54.3
         version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/nadfun:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/abi-tools':
+        specifier: workspace:*
+        version: link:../../abi-tools
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)


### PR DESCRIPTION
## Summary

- add `@themoss/protocol-nadfun`, a query-only Nad.fun Lens adapter for Monad mainnet
- expose typed `quoteBuy`, `quoteSell`, and `tokenStatus` Queries
- add Nad.fun to the default MCP protocol composition
- add deterministic ADR 0007 Git-sourced vendored ABI provenance and maintenance tooling

## ABI provenance

- vendor the complete official `ILens.json` artifact verbatim
- pin the upstream repository, full Git commit, file path, and SHA-256 in `VENDOR.json`
- regenerate the committed TypeScript ABI deterministically with `gen:abis`
- provide `update:abis` for reproducible upstream refreshes
- use ADR 0007 honest degraded verification because Monadscan does not expose verified Lens source
- verify the official pinned address has deployed bytecode and contains the required function selectors
- verify all three query-only methods against Monad mainnet
- do not claim an explorer-verified ABI or that a zero ERC-1967 slot proves a direct deployment

## Validation

- `pnpm --filter @themoss/protocol-nadfun typecheck`
- `pnpm --filter @themoss/protocol-nadfun test` — 8 tests passed, including the live mainnet suite
- `pnpm --filter @themoss/protocol-nadfun build`
- `pnpm --filter @themoss/protocol-nadfun test:online` — all three live Monad mainnet Queries passed
- `env -u MONADSCAN_API_KEY pnpm --filter @themoss/protocol-nadfun test:abi:online` — 3/3 degraded-verification tests passed
- repeated `gen:abis` — identical SHA-256 and zero diff
- `pnpm --filter @themoss/mcp-server test` — 12 tests passed
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:offline`
- root `pnpm test` executed the Nad.fun live suite successfully; the overall command remained red only because of the known main-branch `#117` Kuru `FlipOrderUpdated` gap

## Scope

This version is intentionally query-only. It does not sign, approve, submit, or execute buy/sell transactions.

## ABI online verification behavior

`test:abi:online` always runs the degraded bytecode and required-selector verification gate.

`MONADSCAN_API_KEY` is not required for that degraded gate. When the key is absent, only the optional assertion concerning Monadscan's explorer-unverified response is skipped.

The suite does not claim that the Lens ABI is explorer-verified.