### PR TITLE
fix(kuru): represent flip-order receipt evidence

### DIFF
--- a/.changeset/kuru-flip-order-receipts.md
+++ b/.changeset/kuru-flip-order-receipts.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-kuru": patch
+---
+
+Represent Kuru flip-order lifecycle events in swap Receipts while preserving exact ordered Change evidence and rejecting unsupported market events.

--- a/packages/protocols/kuru/src/kuru.ts
+++ b/packages/protocols/kuru/src/kuru.ts
@@ -155,9 +155,7 @@ export class Kuru {
   swapReceipt(changes: readonly Change[]): ReceiptResult<KuruSwapOutcome> {
     let routerSwap: KuruSwapOutcome | undefined;
     let tradeEvents = 0;
-    const tradeEmitters = new Set<string>();
-    const flipEventEmitters = new Set<string>();
-    const parsed = changes.map((change) => {
+    const parsed = changes.map((change, index) => {
       if (change.kind === "nativeTransfer") return this.erc20.changesReceipt([change]);
       if (sameAddress(change.address, KURU_ROUTER_ADDRESS)) {
         const event = decodeKuruEvent(KuruRouterAbi, change);
@@ -185,7 +183,7 @@ export class Kuru {
       const event = tryDecodeKuruEvent(KuruOrderbookAbi, change);
       if (!event) return this.erc20.changesReceipt([change]);
       if (event.eventName === "FlipOrderUpdated") {
-        flipEventEmitters.add(change.address.toLowerCase());
+        requireFollowingRouterTrade(changes, index, change.address);
         const data = {
           event: "FlipOrderUpdated",
           emitter: change.address,
@@ -200,7 +198,7 @@ export class Kuru {
         };
       }
       if (event.eventName === "FlippedOrderCreated") {
-        flipEventEmitters.add(change.address.toLowerCase());
+        requireFollowingRouterTrade(changes, index, change.address);
         const data = {
           event: "FlippedOrderCreated",
           emitter: change.address,
@@ -226,7 +224,6 @@ export class Kuru {
         throw new Error("Kuru Receipt Trade taker is not the Kuru router");
       }
       tradeEvents += 1;
-      tradeEmitters.add(change.address.toLowerCase());
       const data = {
         event: "Trade",
         emitter: change.address,
@@ -246,11 +243,6 @@ export class Kuru {
 
     if (!routerSwap) throw new Error("Kuru swap Receipt requires KuruRouterSwap");
     if (tradeEvents === 0) throw new Error("Kuru swap Receipt requires at least one Trade");
-    for (const emitter of flipEventEmitters) {
-      if (!tradeEmitters.has(emitter)) {
-        throw new Error("Kuru flip-order Receipt requires a Trade from the same market");
-      }
-    }
     const outcome: KuruSwapOutcome = routerSwap;
     return {
       kind: "receipt",
@@ -702,4 +694,21 @@ function decodeKuruEvent<TAbi extends typeof KuruRouterAbi | typeof KuruOrderboo
   if (!event)
     throw new Error(`Unexpected Change: ${change.address} emitted an unsupported Kuru event`);
   return event;
+}
+
+function requireFollowingRouterTrade(
+  changes: readonly Change[],
+  index: number,
+  market: AddressValue,
+): void {
+  const next = changes[index + 1];
+  if (next?.kind === "event" && sameAddress(next.address, market)) {
+    const event = tryDecodeKuruEvent(KuruOrderbookAbi, next);
+    if (event?.eventName === "Trade" && sameAddress(event.args.takerAddress, KURU_ROUTER_ADDRESS)) {
+      return;
+    }
+  }
+  throw new Error(
+    "Kuru flip-order Receipt requires an immediately following Router Trade from the same market",
+  );
 }

--- a/packages/protocols/kuru/src/kuru.ts
+++ b/packages/protocols/kuru/src/kuru.ts
@@ -214,7 +214,7 @@ export class Kuru {
           kind: "change" as const,
           change,
           data,
-          text: `Flipped Order Created: order ${data.orderId} created ${data.flippedId} for ${data.owner}; size ${data.size}, price ${data.price}, flipped price ${data.flippedPrice}, is buy ${data.isBuy} emitted by ${data.emitter}`,
+          text: `Flipped Order Created: order ID ${data.orderId}, flipped ID ${data.flippedId}, owner ${data.owner}; size ${data.size}, price ${data.price}, flipped price ${data.flippedPrice}, is buy ${data.isBuy}, emitted by ${data.emitter}`,
         };
       }
       if (event.eventName !== "Trade") {
@@ -696,6 +696,7 @@ function decodeKuruEvent<TAbi extends typeof KuruRouterAbi | typeof KuruOrderboo
   return event;
 }
 
+// The pinned OrderBook executes _fillOrder -> _handleFlipOrderUpdate -> _emitTrade.
 function requireFollowingRouterTrade(
   changes: readonly Change[],
   index: number,

--- a/packages/protocols/kuru/src/kuru.ts
+++ b/packages/protocols/kuru/src/kuru.ts
@@ -155,6 +155,8 @@ export class Kuru {
   swapReceipt(changes: readonly Change[]): ReceiptResult<KuruSwapOutcome> {
     let routerSwap: KuruSwapOutcome | undefined;
     let tradeEvents = 0;
+    const tradeEmitters = new Set<string>();
+    const flipEventEmitters = new Set<string>();
     const parsed = changes.map((change) => {
       if (change.kind === "nativeTransfer") return this.erc20.changesReceipt([change]);
       if (sameAddress(change.address, KURU_ROUTER_ADDRESS)) {
@@ -182,6 +184,41 @@ export class Kuru {
 
       const event = tryDecodeKuruEvent(KuruOrderbookAbi, change);
       if (!event) return this.erc20.changesReceipt([change]);
+      if (event.eventName === "FlipOrderUpdated") {
+        flipEventEmitters.add(change.address.toLowerCase());
+        const data = {
+          event: "FlipOrderUpdated",
+          emitter: change.address,
+          orderId: event.args.orderId.toString(),
+          size: event.args.size.toString(),
+        } as const;
+        return {
+          kind: "change" as const,
+          change,
+          data,
+          text: `Flip Order Updated: order ${data.orderId} has size ${data.size} emitted by ${data.emitter}`,
+        };
+      }
+      if (event.eventName === "FlippedOrderCreated") {
+        flipEventEmitters.add(change.address.toLowerCase());
+        const data = {
+          event: "FlippedOrderCreated",
+          emitter: change.address,
+          orderId: event.args.orderId.toString(),
+          flippedId: event.args.flippedId.toString(),
+          owner: event.args.owner,
+          size: event.args.size.toString(),
+          price: event.args.price.toString(),
+          flippedPrice: event.args.flippedPrice.toString(),
+          isBuy: event.args.isBuy,
+        } as const;
+        return {
+          kind: "change" as const,
+          change,
+          data,
+          text: `Flipped Order Created: order ${data.orderId} created ${data.flippedId} for ${data.owner}; size ${data.size}, price ${data.price}, flipped price ${data.flippedPrice}, is buy ${data.isBuy} emitted by ${data.emitter}`,
+        };
+      }
       if (event.eventName !== "Trade") {
         throw new Error(`Unexpected Change: Kuru market emitted ${event.eventName}`);
       }
@@ -189,6 +226,7 @@ export class Kuru {
         throw new Error("Kuru Receipt Trade taker is not the Kuru router");
       }
       tradeEvents += 1;
+      tradeEmitters.add(change.address.toLowerCase());
       const data = {
         event: "Trade",
         emitter: change.address,
@@ -208,6 +246,11 @@ export class Kuru {
 
     if (!routerSwap) throw new Error("Kuru swap Receipt requires KuruRouterSwap");
     if (tradeEvents === 0) throw new Error("Kuru swap Receipt requires at least one Trade");
+    for (const emitter of flipEventEmitters) {
+      if (!tradeEmitters.has(emitter)) {
+        throw new Error("Kuru flip-order Receipt requires a Trade from the same market");
+      }
+    }
     const outcome: KuruSwapOutcome = routerSwap;
     return {
       kind: "receipt",

--- a/packages/protocols/kuru/test-online/abi-explorer.test.ts
+++ b/packages/protocols/kuru/test-online/abi-explorer.test.ts
@@ -35,16 +35,21 @@
  * mismatch (`transferOwnership`: vendored payable, explorer nonpayable).
  *
  * The Moss-required surface was instead verified once by hand:
- * - `Trade`, `placeAndExecuteMarketBuy`, and `placeAndExecuteMarketSell`
- *   are field-for-field identical between the vendored ABI and the
- *   explorer ABI of 0xea2Cc876… (same comparison as above; all three are
- *   absent from every issue bucket), and
+ * - `Trade`, `FlipOrderUpdated`, `FlippedOrderCreated`,
+ *   `placeAndExecuteMarketBuy`, and `placeAndExecuteMarketSell` are
+ *   field-for-field identical between the vendored ABI and the explorer ABI
+ *   of 0xea2Cc876… (same comparison as above; all five are absent from every
+ *   issue bucket), and
  * - present in 0x4C0bA1BA…'s deployed bytecode (`eth_getCode`, then search
  *   the hex for the dispatcher selectors and the event topic):
  *     placeAndExecuteMarketBuy(uint96,uint256,bool,bool)  = 0x7c51d6cf
  *     placeAndExecuteMarketSell(uint96,uint256,bool,bool) = 0x532c46db
  *     Trade(uint40,address,bool,uint256,uint96,address,address,uint96)
  *       topic0 = 0xf16924fba1c18c108912fcacaac7450c98eb3f2d8c0a3cdf3df7066c08f21581
+ *     FlipOrderUpdated(uint40,uint96)
+ *       topic0 = 0xb74e966bc873b8c144fab39c9981210f50130885e89caf4556c0840cec741dcd
+ *     FlippedOrderCreated(uint40,uint40,address,uint96,uint32,uint32,bool)
+ *       topic0 = 0x49496a41b922bdba3ff7f57bb0992ab1a1a3ee95b5ae5bd7271c67861f018352
  * The template assertion below is the tripwire that forces this record to
  * be redone whenever Kuru upgrades.
  */

--- a/packages/protocols/kuru/test/kuru.test.ts
+++ b/packages/protocols/kuru/test/kuru.test.ts
@@ -277,7 +277,7 @@ describe("Kuru", () => {
     const receipt = registry.parseReceipt(capability, changes);
     expect(receipt.changes[0]).toMatchObject({
       kind: "change",
-      text: `Flipped Order Created: order 11 created 12 for ${ACCOUNT}; size 30, price 40, flipped price 50, is buy true emitted by ${MON_USDC}`,
+      text: `Flipped Order Created: order ID 11, flipped ID 12, owner ${ACCOUNT}; size 30, price 40, flipped price 50, is buy true, emitted by ${MON_USDC}`,
       data: {
         event: "FlippedOrderCreated",
         emitter: MON_USDC,

--- a/packages/protocols/kuru/test/kuru.test.ts
+++ b/packages/protocols/kuru/test/kuru.test.ts
@@ -296,7 +296,27 @@ describe("Kuru", () => {
     expect(firstChange(first)).toBe(flipped);
   });
 
-  it("rejects flip-order evidence without a Trade from the same market", async () => {
+  it("accepts multiple adjacent flip-order and Trade pairs", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const firstFlip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
+    const firstTrade = tradeChange(MON_USDC, 8n);
+    const secondFlip = flippedOrderCreatedChange(MON_AUSD);
+    const secondTrade = tradeChange(MON_AUSD, 11n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+    const changes = [firstFlip, firstTrade, secondFlip, secondTrade, router] as const;
+
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.changes.map(firstChange)).toEqual([
+      firstFlip,
+      firstTrade,
+      secondFlip,
+      secondTrade,
+      router,
+    ]);
+  });
+
+  it("rejects a flip-order event followed by a Trade from another market", async () => {
     const { registry } = offlineRegistry();
     const capability = await swapCapability(registry);
     const flip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
@@ -304,8 +324,58 @@ describe("Kuru", () => {
     const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
 
     expect(() => registry.parseReceipt(capability, [flip, otherTrade, router])).toThrow(
-      "Kuru flip-order Receipt requires a Trade from the same market",
+      "requires an immediately following Router Trade from the same market",
     );
+  });
+
+  it("rejects Trade before its flip-order event", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const trade = tradeChange(MON_USDC, 8n);
+    const flip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    expect(() => registry.parseReceipt(capability, [trade, flip, router])).toThrow(
+      "requires an immediately following Router Trade from the same market",
+    );
+  });
+
+  it("rejects an unrelated Change between a flip-order event and Trade", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const flip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
+    const transfer = erc20Transfer(USDC_ADDRESS, ACCOUNT, KURU_ROUTER_ADDRESS, 1n);
+    const trade = tradeChange(MON_USDC, 8n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    expect(() => registry.parseReceipt(capability, [flip, transfer, trade, router])).toThrow(
+      "requires an immediately following Router Trade from the same market",
+    );
+  });
+
+  it("rejects an isolated flip-order event", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const flip = flippedOrderCreatedChange(MON_USDC);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    expect(() => registry.parseReceipt(capability, [flip, router])).toThrow(
+      "requires an immediately following Router Trade from the same market",
+    );
+  });
+
+  it("rejects crossed flip-order and Trade pairs", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const firstFlip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
+    const secondTrade = tradeChange(MON_AUSD, 11n);
+    const secondFlip = flippedOrderCreatedChange(MON_AUSD);
+    const firstTrade = tradeChange(MON_USDC, 8n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    expect(() =>
+      registry.parseReceipt(capability, [firstFlip, secondTrade, secondFlip, firstTrade, router]),
+    ).toThrow("requires an immediately following Router Trade from the same market");
   });
 
   it("continues to reject unrelated OrderBook events", async () => {

--- a/packages/protocols/kuru/test/kuru.test.ts
+++ b/packages/protocols/kuru/test/kuru.test.ts
@@ -241,6 +241,83 @@ describe("Kuru", () => {
     expect(receipt.changes.map(firstChange)).toEqual(changes);
   });
 
+  it("represents FlipOrderUpdated before its market Trade", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const flip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
+    const trade = tradeChange(MON_USDC, 7n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+    const changes = [flip, trade, router] as const;
+
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "change",
+      text: `Flip Order Updated: order 7 has size 30 emitted by ${MON_USDC}`,
+      data: {
+        event: "FlipOrderUpdated",
+        emitter: MON_USDC,
+        orderId: "7",
+        size: "30",
+      },
+    });
+    const first = receipt.changes[0];
+    if (!first) throw new Error("expected flip-order ReceiptChange");
+    expect(receipt.changes.map(firstChange)).toEqual(changes);
+    expect(firstChange(first)).toBe(flip);
+  });
+
+  it("represents FlippedOrderCreated before its market Trade", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const flipped = flippedOrderCreatedChange(MON_USDC);
+    const trade = tradeChange(MON_USDC, 11n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+    const changes = [flipped, trade, router] as const;
+
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "change",
+      text: `Flipped Order Created: order 11 created 12 for ${ACCOUNT}; size 30, price 40, flipped price 50, is buy true emitted by ${MON_USDC}`,
+      data: {
+        event: "FlippedOrderCreated",
+        emitter: MON_USDC,
+        orderId: "11",
+        flippedId: "12",
+        owner: ACCOUNT,
+        size: "30",
+        price: "40",
+        flippedPrice: "50",
+        isBuy: true,
+      },
+    });
+    const first = receipt.changes[0];
+    if (!first) throw new Error("expected flipped-order ReceiptChange");
+    expect(receipt.changes.map(firstChange)).toEqual(changes);
+    expect(firstChange(first)).toBe(flipped);
+  });
+
+  it("rejects flip-order evidence without a Trade from the same market", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const flip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
+    const otherTrade = tradeChange(MON_AUSD, 7n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    expect(() => registry.parseReceipt(capability, [flip, otherTrade, router])).toThrow(
+      "Kuru flip-order Receipt requires a Trade from the same market",
+    );
+  });
+
+  it("continues to reject unrelated OrderBook events", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const order = orderCreatedChange(MON_USDC);
+
+    expect(() => registry.parseReceipt(capability, [order])).toThrow(
+      "Unexpected Change: Kuru market emitted OrderCreated",
+    );
+  });
+
   it("rejects API markets that the Router does not verify", async () => {
     const unverified = { ...MARKETS[0], verified: false } as MockMarket;
     const { registry } = offlineRegistry([unverified]);
@@ -447,6 +524,16 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Kuru mainnet", () => {
   });
 });
 
+async function swapCapability(registry: Registry) {
+  const capability = await registry.action("kuru", "swap", ACCOUNT, {
+    tokenIn: USDC_ADDRESS,
+    tokenOut: AUSD_ADDRESS,
+    amountIn: "1",
+  });
+  if (capability.kind !== "capability") throw new Error("expected capability");
+  return capability;
+}
+
 function offlineRegistry(
   markets: readonly MockMarket[] = MARKETS,
   fetchMock = marketDiscoveryFetch(markets),
@@ -637,6 +724,36 @@ function tradeChange(address: `0x${string}`, orderId: bigint): Change {
   );
 }
 
+function flipOrderUpdatedChange(address: `0x${string}`, orderId: bigint, size: bigint): Change {
+  return eventChange(
+    address,
+    KuruOrderbookAbi,
+    "FlipOrderUpdated",
+    [orderId, size],
+    ["uint40", "uint96"],
+  );
+}
+
+function flippedOrderCreatedChange(address: `0x${string}`): Change {
+  return eventChange(
+    address,
+    KuruOrderbookAbi,
+    "FlippedOrderCreated",
+    [11n, 12n, ACCOUNT, 30n, 40n, 50n, true],
+    ["uint40", "uint40", "address", "uint96", "uint32", "uint32", "bool"],
+  );
+}
+
+function orderCreatedChange(address: `0x${string}`): Change {
+  return eventChange(
+    address,
+    KuruOrderbookAbi,
+    "OrderCreated",
+    [11n, ACCOUNT, 30n, 40n, true],
+    ["uint40", "address", "uint96", "uint32", "bool"],
+  );
+}
+
 function routerSwapChange(
   sender: `0x${string}`,
   tokenIn: `0x${string}`,
@@ -674,7 +791,12 @@ function erc20Transfer(
 function eventChange(
   address: `0x${string}`,
   abi: typeof KuruRouterAbi | typeof KuruOrderbookAbi,
-  eventName: "Trade" | "KuruRouterSwap",
+  eventName:
+    | "Trade"
+    | "FlipOrderUpdated"
+    | "FlippedOrderCreated"
+    | "OrderCreated"
+    | "KuruRouterSwap",
   values: readonly unknown[],
   types: readonly string[],
 ): Change {


### PR DESCRIPTION
## Problem

On `main@da9b566` when this issue was captured, Kuru's live native MON -> USDC simulation reproducibly halted when a legitimate OrderBook fill emits `FlipOrderUpdated` before `Trade`:

```text
Unexpected Change: Kuru market emitted FlipOrderUpdated
```

The event is part of the vendored, provenance-checked Kuru OrderBook ABI and the protocol's documented flip-order fill path. Ignoring it would violate ADR 0011 because every original Change must remain represented with exact identity, length, and order.

Closes #117.

## Change

- represent `FlipOrderUpdated` as a Kuru ReceiptChange containing only its directly observed emitter, order ID, and size;
- represent `FlippedOrderCreated` with only the fields directly carried by that event;
- require each accepted flip-order Change to be immediately followed by a `Trade` from the same market whose taker is the Kuru Router;
- preserve each original Change object and its exact ordering relative to `Trade`;
- keep all other OrderBook events fail-closed;
- add exact structured-data, text, identity, ordering, adjacency, same-market/Router binding, multiple-pair, and unsupported-event regressions;
- add a patch changeset.

No ABI, Capability, parameter, public type, routing, dependency, or transaction-construction behavior changes.

## Why adjacency

The official Kuru OrderBook implementation handles the flip update and then immediately emits the corresponding `Trade`. Two captured Monad mainnet receipts preserve that same adjacent order with the same market emitter. Their flip and trade order IDs differ, so this PR deliberately does not invent an order-ID relationship.

Requiring adjacency avoids accepting a flip merely because an unrelated Trade from the same market appears elsewhere in the Receipt. Reverse order, an intervening Change, a different market, and crossed market pairs all remain rejected.

## Effect

Legitimate Kuru swaps that exercise either flip-order lifecycle branch can produce exhaustive Receipts instead of halting. The parser does not infer user intent or order semantics beyond the event fields, and it does not broaden support to unrelated OrderBook events.

## Verification

After rebasing onto `main@0618926`, verified in the required order:

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test:offline`
- full live `pnpm test`: all 259 tests passed
- focused live Kuru suite: 27/27 passed
- `git diff --check`

A three-commit `range-diff` against the previous PR head `fd36f74` showed `=` for every commit, confirming no behavior drift during the rebase. A fresh live Kuru simulation produced zero Warnings.

`MONADSCAN_API_KEY` is unavailable in this environment, so the keyed explorer suite was not rerun. This PR changes no ABI artifact or keyed-check logic; it only extends the existing maintained manual-verification record for the two interpreted events. Focused regressions cover both flip variants, multiple adjacent pairs, exact Change identity/order, and rejection of reverse, separated, isolated, cross-market, and unsupported evidence.

`pnpm audit --prod` still reports the existing main-branch advisories tracked in #125; this PR adds no dependencies or lockfile changes.

## Coordination

This implements the narrowly proposed scope from #117 after the failure became reproducible on current main. Zane also offered to help, so I would appreciate an independent review. Box can decide whether I should continue maintaining this fix or hand it over.
