### PR TITLE
feat(protocols): add Monad Cards totalMinted query adapter

### DIFF
--- a/.changeset/bright-monad-cards.md
+++ b/.changeset/bright-monad-cards.md
@@ -1,0 +1,6 @@
+---
+"@themoss/protocol-monad-cards": minor
+"@themoss/mcp-server": minor
+---
+
+Add the Monad Cards Query-only Protocol for Monad mainnet, exposing the cumulative minted supply as a JSON-safe decimal string through the default MCP composition.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,7 @@
       "@themoss/erc",
       "@themoss/system",
       "@themoss/protocol-kuru",
+      "@themoss/protocol-monad-cards",
       "@themoss/protocol-pancakeswap",
       "@themoss/mcp-server"
     ]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`, `balanceOf` |
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 
 ERC-1155 `transfer` accepts a collection, token ID, amount, and recipient. Token IDs and amounts are base-10 uint256 strings, including zero. The Capability builds one `safeTransferFrom`; batch transfer construction is not currently exposed. Receipts still decode both `TransferSingle` and `TransferBatch` Changes without aggregating or reordering their items.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | ERC-721 | `@themoss/erc` | `transfer` | `ownerOf`、`balanceOf` |
 | ERC-1155 | `@themoss/erc` | `transfer`, `approve` | `balanceOf`, `uri`, `isApprovedForAll` |
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
+| Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 
 ERC-1155 `transfer` 接收 collection、token ID、amount 和 recipient。token ID 与 amount 使用十进制 uint256 字符串（允许零）。该 Capability 只构建一笔 `safeTransferFrom`，目前不暴露批量转账构建；Receipt 仍会解析 `TransferSingle` 和 `TransferBatch` Change，并保留批量条目的原始顺序，不做聚合。

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -25,6 +25,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@themoss/core": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
+    "@themoss/protocol-monad-cards": "workspace:*",
     "@themoss/protocol-pancakeswap": "workspace:*",
     "zod": "^3.25.0",
     "@themoss/erc": "workspace:*",

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -1,7 +1,8 @@
 import * as erc from "@themoss/erc";
 import * as kuru from "@themoss/protocol-kuru";
+import * as monadCards from "@themoss/protocol-monad-cards";
 import * as pancakeswap from "@themoss/protocol-pancakeswap";
 import * as system from "@themoss/system";
 
 /** Protocol modules selected by the default MCP CLI application. */
-export const defaultProtocolModules = [system, erc, kuru, pancakeswap] as const;
+export const defaultProtocolModules = [system, erc, kuru, monadCards, pancakeswap] as const;

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -99,6 +99,24 @@ describe("moss MCP server", () => {
       type: { default: 50, description: expect.stringContaining("1 bps equals 0.01%") },
       description: expect.stringContaining("adverse movement"),
     });
+
+    const monadCards = parseText(
+      await client.callTool({ name: "discover", arguments: { protocol: "monad-cards" } }),
+    ) as { protocol: string; method: string; kind: string }[];
+    expect(monadCards).toEqual([
+      expect.objectContaining({
+        protocol: "monad-cards",
+        method: "totalMinted",
+        kind: "query",
+      }),
+    ]);
+    const loadedMonadCards = parseText(
+      await client.callTool({
+        name: "load",
+        arguments: { items: [{ protocol: "monad-cards", method: "totalMinted" }] },
+      }),
+    ) as { params: Record<string, { type: unknown; description: string }> }[];
+    expect(loadedMonadCards[0]?.params).toEqual({});
   });
 
   it("round-trips a Capability tree through action JSON", async () => {

--- a/packages/protocols/monad-cards/README.md
+++ b/packages/protocols/monad-cards/README.md
@@ -1,0 +1,27 @@
+# @themoss/protocol-monad-cards
+
+This package contains the self-describing Monad Cards Protocol for Monad
+mainnet. It exposes one read-only Query:
+
+- `totalMinted`: returns the collection's cumulative minted supply as a
+  JSON-safe decimal string.
+
+The Query accepts no parameters. This package does not expose minting,
+claiming, transfers, Capabilities, or Receipt parsers.
+
+## Deployment and ABI origin
+
+Monad Cards is deployed at
+`0x0000CA12D5c07085022eBC74867157449919Fd67`. The address is recorded in
+[Monad's official protocol registry](https://github.com/monad-crypto/protocols/blob/main/mainnet/monad_cards.jsonc).
+
+The committed ABI is the complete explorer-tier artifact from the
+[verified MonadScan contract](https://monadscan.com/address/0x0000CA12D5c07085022eBC74867157449919Fd67#code).
+Regenerate it with:
+
+```bash
+MONADSCAN_API_KEY=... pnpm --filter @themoss/protocol-monad-cards update:abis
+```
+
+`test/abis.test.ts` verifies the committed module is exactly the shared ABI
+renderer output for the recorded address and retrieval date.

--- a/packages/protocols/monad-cards/package.json
+++ b/packages/protocols/monad-cards/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@themoss/protocol-monad-cards",
+  "version": "0.1.0",
+  "description": "Moss Protocol for the Monad Cards minted-supply Query on Monad mainnet",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "update:abis": "tsx scripts/update-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/abi-tools": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/monad-cards/package.json
+++ b/packages/protocols/monad-cards/package.json
@@ -20,14 +20,14 @@
     "update:abis": "tsx scripts/update-abis.ts"
   },
   "dependencies": {
-    "@themoss/core": "workspace:*",
-    "viem": "^2.54.3"
+    "@themoss/core": "workspace:*"
   },
   "devDependencies": {
     "@themoss/abi-tools": "workspace:*",
     "tsup": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "~5.9.0",
+    "viem": "^2.54.3",
     "vitest": "^3.2.6"
   }
 }

--- a/packages/protocols/monad-cards/scripts/abis.ts
+++ b/packages/protocols/monad-cards/scripts/abis.ts
@@ -1,0 +1,18 @@
+/**
+ * The source-of-truth table for the complete explorer ABI generated under
+ * src/abis/. The address is Monad Cards' official Monad-mainnet deployment:
+ * https://github.com/monad-crypto/protocols/blob/main/mainnet/monad_cards.jsonc
+ */
+export interface AbiSource {
+  exportName: string;
+  file: string;
+  address: `0x${string}`;
+}
+
+export const SOURCES: readonly AbiSource[] = [
+  {
+    exportName: "monadCards",
+    file: "monad-cards.ts",
+    address: "0x0000CA12D5c07085022eBC74867157449919Fd67",
+  },
+];

--- a/packages/protocols/monad-cards/scripts/update-abis.ts
+++ b/packages/protocols/monad-cards/scripts/update-abis.ts
@@ -1,0 +1,24 @@
+/**
+ * Fetch the verified complete Monad Cards ABI from the official Etherscan V2
+ * endpoint for Monad mainnet and render it deterministically (ADR 0007).
+ *
+ * Usage: MONADSCAN_API_KEY=... pnpm update:abis
+ */
+import { writeFileSync } from "node:fs";
+import { fetchAbi, renderAbiModule } from "@themoss/abi-tools";
+import { SOURCES } from "./abis.js";
+
+const key = process.env.MONADSCAN_API_KEY;
+if (!key) {
+  throw new Error(
+    "MONADSCAN_API_KEY is not set; create one at https://info.monadscan.com/myapikey/ and export it.",
+  );
+}
+
+const abisDir = new URL("../src/abis/", import.meta.url);
+const retrievedAt = new Date();
+for (const { exportName, file, address } of SOURCES) {
+  const abi = await fetchAbi(address, key);
+  writeFileSync(new URL(file, abisDir), renderAbiModule({ exportName, address, abi, retrievedAt }));
+  console.log(`src/abis/${file}: ${abi.length} ABI entries from ${address}`);
+}

--- a/packages/protocols/monad-cards/src/abis/monad-cards.ts
+++ b/packages/protocols/monad-cards/src/abis/monad-cards.ts
@@ -1,0 +1,855 @@
+// ABI origin: explorer (ADR 0007)
+//   Source:    https://monadscan.com/address/0x0000CA12D5c07085022eBC74867157449919Fd67
+//   Endpoint:  Etherscan V2 (chainid=143, module=contract, action=getabi)
+//   Retrieved: 2026-07-27 (UTC)
+
+export const monadCardsAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "initialOwner",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "baseTokenUriValue",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "initialRoot",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyClaimed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721IncorrectOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC721InsufficientApproval",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidOperator",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC721NonexistentToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidMerkleRoot",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTrancheId",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReceiverIsClaimant",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SignatureExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Soulbound",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_fromTokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_toTokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "BatchMetadataUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "CardClaimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MetadataUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nextTrancheId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "merkleRoot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "NewTranche",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "root",
+        "type": "bytes32"
+      }
+    ],
+    "name": "addRoot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "trancheId_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "claimant",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApproved",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isClaimed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "merkleRoots",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nextTrancheId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "baseTokenUriValue",
+        "type": "string"
+      }
+    ],
+    "name": "setBaseURI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenURI",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalMinted",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+] as const;

--- a/packages/protocols/monad-cards/src/index.ts
+++ b/packages/protocols/monad-cards/src/index.ts
@@ -1,0 +1,2 @@
+export { monadCardsAbi } from "./abis/monad-cards.js";
+export { MONAD_CARDS_ADDRESS, MonadCards } from "./monad-cards.js";

--- a/packages/protocols/monad-cards/src/monad-cards.ts
+++ b/packages/protocols/monad-cards/src/monad-cards.ts
@@ -16,9 +16,6 @@ const noParams = {} satisfies ParamsSpec;
   contracts: {
     collection: { abi: monadCardsAbi, addr: MONAD_CARDS_ADDRESS },
   },
-  labels: {
-    Collection: MONAD_CARDS_ADDRESS,
-  },
 })
 export class MonadCards {
   declare collection: Handle<typeof monadCardsAbi>;

--- a/packages/protocols/monad-cards/src/monad-cards.ts
+++ b/packages/protocols/monad-cards/src/monad-cards.ts
@@ -1,0 +1,35 @@
+import { type AddressValue, type Handle, type ParamsSpec, Protocol, Query } from "@themoss/core";
+import { monadCardsAbi } from "./abis/monad-cards.js";
+
+/**
+ * Monad Cards' official Monad-mainnet deployment.
+ * Source: https://github.com/monad-crypto/protocols/blob/main/mainnet/monad_cards.jsonc
+ */
+export const MONAD_CARDS_ADDRESS: AddressValue = "0x0000CA12D5c07085022eBC74867157449919Fd67";
+
+const noParams = {} satisfies ParamsSpec;
+
+@Protocol({
+  name: "monad-cards",
+  category: "nft",
+  description: "Read the cumulative minted supply of the Monad Cards collectible.",
+  contracts: {
+    collection: { abi: monadCardsAbi, addr: MONAD_CARDS_ADDRESS },
+  },
+  labels: {
+    Collection: MONAD_CARDS_ADDRESS,
+  },
+})
+export class MonadCards {
+  declare collection: Handle<typeof monadCardsAbi>;
+
+  @Query({
+    intent: "Read the total number of Monad Cards minted",
+    params: noParams,
+    tags: ["supply"],
+  })
+  async totalMinted() {
+    const totalMinted = await this.collection.read.totalMinted();
+    return { totalMinted: totalMinted.toString() };
+  }
+}

--- a/packages/protocols/monad-cards/test/abis.test.ts
+++ b/packages/protocols/monad-cards/test/abis.test.ts
@@ -28,6 +28,7 @@ describe("Monad Cards explorer ABI derivation (ADR 0007)", () => {
 
   it("records the official address and complete totalMinted function", () => {
     expect(SOURCES.map(({ address }) => address)).toEqual([MONAD_CARDS_ADDRESS]);
+    // MonadScan's verified full ABI currently has 54 entries; pinning the count detects drift.
     expect(monadCardsAbi).toHaveLength(54);
     expect(
       monadCardsAbi.find((item) => item.type === "function" && item.name === "totalMinted"),

--- a/packages/protocols/monad-cards/test/abis.test.ts
+++ b/packages/protocols/monad-cards/test/abis.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { type RenderAbiModuleOptions, renderAbiModule } from "@themoss/abi-tools";
+import { describe, expect, it } from "vitest";
+import { SOURCES } from "../scripts/abis.js";
+import { monadCardsAbi } from "../src/abis/monad-cards.js";
+import { MONAD_CARDS_ADDRESS } from "../src/monad-cards.js";
+
+describe("Monad Cards explorer ABI derivation (ADR 0007)", () => {
+  it("is exactly the shared renderer output for the verified address", () => {
+    const [source] = SOURCES;
+    expect(source).toBeDefined();
+    const committed = readFileSync(new URL(`../src/abis/${source?.file}`, import.meta.url), "utf8");
+    const retrieved = /^\/\/ {3}Retrieved: (\d{4}-\d{2}-\d{2}) \(UTC\)$/m.exec(committed)?.[1];
+    expect(retrieved).toBeDefined();
+    const literal = /^export const \w+Abi = (\[[\s\S]*\]) as const;$/m.exec(committed)?.[1];
+    expect(literal).toBeDefined();
+    const abi = JSON.parse(literal as string) as RenderAbiModuleOptions["abi"];
+
+    expect(committed).toBe(
+      renderAbiModule({
+        exportName: source?.exportName as string,
+        address: source?.address as string,
+        abi,
+        retrievedAt: new Date(`${retrieved}T00:00:00Z`),
+      }),
+    );
+  });
+
+  it("records the official address and complete totalMinted function", () => {
+    expect(SOURCES.map(({ address }) => address)).toEqual([MONAD_CARDS_ADDRESS]);
+    expect(monadCardsAbi).toHaveLength(54);
+    expect(
+      monadCardsAbi.find((item) => item.type === "function" && item.name === "totalMinted"),
+    ).toEqual({
+      inputs: [],
+      name: "totalMinted",
+      outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+      stateMutability: "view",
+      type: "function",
+    });
+  });
+});

--- a/packages/protocols/monad-cards/test/monad-cards.test.ts
+++ b/packages/protocols/monad-cards/test/monad-cards.test.ts
@@ -1,7 +1,7 @@
 import { createRuntime, type MossRuntime, Registry } from "@themoss/core";
 import { getAddress } from "viem";
 import { describe, expect, it, vi } from "vitest";
-import { MONAD_CARDS_ADDRESS, MonadCards } from "../src/index.js";
+import { MONAD_CARDS_ADDRESS, MonadCards, monadCardsAbi } from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 
@@ -71,13 +71,33 @@ describe("Monad Cards", () => {
 });
 
 describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Monad Cards on Monad mainnet", () => {
-  it("has deployed bytecode and returns a positive minted supply", {
+  it("is the Monad Cards collection and returns a positive minted supply", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await createRuntime({ rpcUrl: "https://rpc.monad.xyz" });
+    const runtime = await createRuntime({
+      rpcUrl: process.env.MOSS_RPC_URL ?? "https://rpc.monad.xyz",
+    });
     expect(
       (await runtime.client.getCode({ address: MONAD_CARDS_ADDRESS }))?.length,
     ).toBeGreaterThan(2);
+
+    const collection = {
+      address: MONAD_CARDS_ADDRESS,
+      abi: monadCardsAbi,
+    } as const;
+    expect(await runtime.client.readContract({ ...collection, functionName: "name" })).toBe(
+      "Monad Cards",
+    );
+    expect(await runtime.client.readContract({ ...collection, functionName: "symbol" })).toBe(
+      "CARDS",
+    );
+    expect(
+      await runtime.client.readContract({
+        ...collection,
+        functionName: "supportsInterface",
+        args: ["0x80ac58cd"],
+      }),
+    ).toBe(true);
 
     const query = await new Registry(runtime)
       .use(MonadCards)

--- a/packages/protocols/monad-cards/test/monad-cards.test.ts
+++ b/packages/protocols/monad-cards/test/monad-cards.test.ts
@@ -1,0 +1,88 @@
+import { createRuntime, type MossRuntime, Registry } from "@themoss/core";
+import { getAddress } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { MONAD_CARDS_ADDRESS, MonadCards } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+
+function offlineRegistry(readContract: MossRuntime["client"]["readContract"]) {
+  const runtime = {
+    rpcUrl: "http://offline",
+    client: { readContract } as unknown as MossRuntime["client"],
+  };
+  return new Registry(runtime).use(MonadCards);
+}
+
+describe("Monad Cards", () => {
+  it("discovers and loads totalMinted with no parameters", () => {
+    const registry = offlineRegistry(vi.fn());
+
+    expect(registry.discover({ protocol: "monad-cards" })).toEqual([
+      expect.objectContaining({
+        protocol: "monad-cards",
+        method: "totalMinted",
+        kind: "query",
+        category: "nft",
+      }),
+    ]);
+    expect(registry.load([{ protocol: "monad-cards", method: "totalMinted" }])).toEqual([
+      expect.objectContaining({
+        protocol: "monad-cards",
+        method: "totalMinted",
+        kind: "query",
+        params: {},
+      }),
+    ]);
+  });
+
+  it("reads the fixed contract and converts bigint to a decimal string", async () => {
+    const readContract = vi.fn(async () => 12_345n);
+    const registry = offlineRegistry(
+      readContract as unknown as MossRuntime["client"]["readContract"],
+    );
+
+    await expect(registry.action("monad-cards", "totalMinted", ACCOUNT, {})).resolves.toEqual({
+      kind: "query",
+      protocol: "monad-cards",
+      method: "totalMinted",
+      data: { totalMinted: "12345" },
+    });
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: MONAD_CARDS_ADDRESS,
+        functionName: "totalMinted",
+        args: [],
+      }),
+    );
+  });
+
+  it("propagates contract read failures", async () => {
+    const readContract = vi.fn(async () => {
+      throw new Error("Monad Cards read unavailable");
+    });
+    const registry = offlineRegistry(
+      readContract as unknown as MossRuntime["client"]["readContract"],
+    );
+
+    await expect(registry.action("monad-cards", "totalMinted", ACCOUNT, {})).rejects.toThrow(
+      "Monad Cards read unavailable",
+    );
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Monad Cards on Monad mainnet", () => {
+  it("has deployed bytecode and returns a positive minted supply", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime({ rpcUrl: "https://rpc.monad.xyz" });
+    expect(
+      (await runtime.client.getCode({ address: MONAD_CARDS_ADDRESS }))?.length,
+    ).toBeGreaterThan(2);
+
+    const query = await new Registry(runtime)
+      .use(MonadCards)
+      .action("monad-cards", "totalMinted", ACCOUNT, {});
+    if (query.kind !== "query") throw new Error("expected totalMinted Query");
+    expect(BigInt((query.data as { totalMinted: string }).totalMinted)).toBeGreaterThan(0n);
+  });
+});

--- a/packages/protocols/monad-cards/test/types.fixture.ts
+++ b/packages/protocols/monad-cards/test/types.fixture.ts
@@ -1,0 +1,23 @@
+import type { Handle } from "@themoss/core";
+import type { monadCardsAbi } from "../src/abis/monad-cards.js";
+import type { MonadCards } from "../src/monad-cards.js";
+
+function handleFixture(handle: Handle<typeof monadCardsAbi>) {
+  handle.read.totalMinted();
+  // @ts-expect-error totalMinted takes no ABI arguments.
+  handle.read.totalMinted([]);
+  // @ts-expect-error ABI-generic Handles reject unknown contract methods.
+  handle.read.mintedSupply();
+}
+
+const protocol = null as unknown as MonadCards;
+const result: Awaited<ReturnType<MonadCards["totalMinted"]>> = { totalMinted: "42" };
+protocol.totalMinted();
+// @ts-expect-error The Query accepts no parameters.
+protocol.totalMinted({});
+// @ts-expect-error The Query result is JSON-safe and never exposes bigint.
+const invalidResult: Awaited<ReturnType<MonadCards["totalMinted"]>> = { totalMinted: 42n };
+
+void handleFixture;
+void result;
+void invalidResult;

--- a/packages/protocols/monad-cards/tsconfig.json
+++ b/packages/protocols/monad-cards/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test", "scripts"]
+}

--- a/packages/protocols/monad-cards/vitest.config.ts
+++ b/packages/protocols/monad-cards/vitest.config.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: { target: "es2022" },
+  resolve: {
+    alias: {
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
+      '@themoss/protocol-monad-cards':
+        specifier: workspace:*
+        version: link:../protocols/monad-cards
       '@themoss/protocol-pancakeswap':
         specifier: workspace:*
         version: link:../protocols/pancakeswap
@@ -226,6 +229,31 @@ importers:
       '@themoss/system':
         specifier: workspace:*
         version: link:../../system
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/monad-cards:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/abi-tools':
+        specifier: workspace:*
+        version: link:../../abi-tools
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,9 +247,6 @@ importers:
       '@themoss/core':
         specifier: workspace:*
         version: link:../../core
-      viem:
-        specifier: ^2.54.3
-        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
     devDependencies:
       '@themoss/abi-tools':
         specifier: workspace:*
@@ -263,6 +260,9 @@ importers:
       typescript:
         specifier: ~5.9.0
         version: 5.9.3
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
       vitest:
         specifier: ^3.2.6
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)


### PR DESCRIPTION
## Summary

Add `@themoss/protocol-monad-cards`, a Query-only Monad Cards Protocol Adapter for Monad mainnet.

The adapter exposes one operation:

- `monad-cards.totalMinted`

It reads `totalMinted()` from the official Monad Cards deployment and converts the returned `uint256` bigint into a JSON-safe decimal string.

## Contract

- Address: `0x0000CA12D5c07085022eBC74867157449919Fd67`
- Official registry: https://github.com/monad-crypto/protocols/blob/main/mainnet/monad_cards.jsonc
- Verified contract: https://monadscan.com/address/0x0000CA12D5c07085022eBC74867157449919Fd67#code

## Implementation

- Added the public `@themoss/protocol-monad-cards` package
- Added the complete verified MonadScan ABI
- Added deterministic ABI regeneration and provenance tests
- Implemented the parameterless `totalMinted` Query
- Converted the returned value to a decimal string
- Registered the protocol in the default MCP composition
- Verified MCP `discover` and `load` integration
- Updated the English and Chinese protocol tables
- Added a minor changeset
- Updated `pnpm-lock.yaml`

No minting, claiming, Capability, transaction construction, or Receipt parsing is included.

## Query example

```json
{
  "protocol": "monad-cards",
  "method": "totalMinted",
  "account": "0x0000000000000000000000000000000000000000",
  "params": {}
}
```
Example response:
```json
{
  "kind": "query",
  "protocol": "monad-cards",
  "method": "totalMinted",
  "data": {
    "totalMinted": "1550"
  }
}
```
Testing

The following checks passed:

pnpm install
pnpm build
pnpm typecheck
pnpm lint
pnpm test:offline
pnpm --filter @themoss/protocol-monad-cards test
pnpm changeset status
git diff --check

Offline test result:

194 passed
10 skipped

The Monad mainnet read-only tests also passed and confirmed that the contract contains bytecode and responds successfully to totalMinted().
No wallet credentials or production funds were used.