### PR TITLE
fix(core): treat a blank MOSS_RPC_URL as unset

### DIFF
--- a/.changeset/blank-rpc-url-falls-back.md
+++ b/.changeset/blank-rpc-url-falls-back.md
@@ -1,0 +1,9 @@
+---
+"@themoss/core": patch
+---
+
+Treat a blank `MOSS_RPC_URL` as unset when resolving `DEFAULT_RPC_URL`. A workflow
+that forwards an RPC endpoint from a secret sets the variable to an empty string
+wherever that secret is unavailable — every fork pull request, since those receive
+no secrets — and `??` forwarded the blank to viem, which rejected it with
+`UrlRequiredError: No URL was provided to the Transport`.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -12,11 +12,16 @@ export const MONAD_CHAIN_ID = 143;
 export const PUBLIC_RPC_URL = "https://rpc.monad.xyz";
 
 /**
- * The endpoint callers get unless they pin their own: `MOSS_RPC_URL` when set,
- * otherwise the public one. Resolved here, once, so that no other module spells
- * an endpoint or reads the environment for one.
+ * The endpoint callers get unless they pin their own: `MOSS_RPC_URL` when set to
+ * something usable, otherwise the public one. Resolved here, once, so that no
+ * other module spells an endpoint or reads the environment for one.
+ *
+ * Blank is treated as unset because a workflow that forwards a secret produces an
+ * empty string wherever that secret is unavailable — every fork pull request, for
+ * instance, since those receive no secrets. `??` would forward the blank and viem
+ * would reject it as a missing transport URL.
  */
-export const DEFAULT_RPC_URL = process.env.MOSS_RPC_URL ?? PUBLIC_RPC_URL;
+export const DEFAULT_RPC_URL = process.env.MOSS_RPC_URL?.trim() || PUBLIC_RPC_URL;
 
 export interface MossRuntime {
   rpcUrl: string;

--- a/packages/core/test/runtime.test.ts
+++ b/packages/core/test/runtime.test.ts
@@ -1,7 +1,25 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRuntime } from "../src/runtime.js";
+import { createRuntime, PUBLIC_RPC_URL } from "../src/runtime.js";
 
 afterEach(() => vi.restoreAllMocks());
+
+/**
+ * Re-imports the module so the `DEFAULT_RPC_URL` computed at load time reflects
+ * `MOSS_RPC_URL` as given here.
+ */
+async function resolveDefault(value: string | undefined) {
+  const previous = process.env.MOSS_RPC_URL;
+  if (value === undefined) delete process.env.MOSS_RPC_URL;
+  else process.env.MOSS_RPC_URL = value;
+  vi.resetModules();
+  try {
+    const fresh = await import("../src/runtime.js");
+    return fresh.DEFAULT_RPC_URL;
+  } finally {
+    if (previous === undefined) delete process.env.MOSS_RPC_URL;
+    else process.env.MOSS_RPC_URL = previous;
+  }
+}
 
 function mockChainId(chainId: number) {
   vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
@@ -26,5 +44,28 @@ describe("createRuntime", () => {
     await expect(createRuntime({ rpcUrl: "http://rpc.test" })).rejects.toThrow(
       "requires Monad mainnet chain ID 143; RPC reported 1",
     );
+  });
+
+  it("falls back to the public endpoint when no argument is given", async () => {
+    mockChainId(143);
+    await expect(createRuntime()).resolves.toMatchObject({ rpcUrl: PUBLIC_RPC_URL });
+  });
+});
+
+describe("DEFAULT_RPC_URL", () => {
+  it("uses MOSS_RPC_URL when it names an endpoint", async () => {
+    await expect(resolveDefault("https://rpc.private.test/key")).resolves.toBe(
+      "https://rpc.private.test/key",
+    );
+  });
+
+  it("uses the public endpoint when MOSS_RPC_URL is unset", async () => {
+    await expect(resolveDefault(undefined)).resolves.toBe(PUBLIC_RPC_URL);
+  });
+
+  // A workflow forwarding a secret sets this to "" wherever the secret is
+  // unavailable, which is every fork pull request.
+  it.each(["", "   "])("treats a blank MOSS_RPC_URL (%j) as unset", async (blank) => {
+    await expect(resolveDefault(blank)).resolves.toBe(PUBLIC_RPC_URL);
   });
 });

--- a/packages/core/test/runtime.test.ts
+++ b/packages/core/test/runtime.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRuntime, PUBLIC_RPC_URL } from "../src/runtime.js";
+import { createRuntime, DEFAULT_RPC_URL, PUBLIC_RPC_URL } from "../src/runtime.js";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -46,9 +46,11 @@ describe("createRuntime", () => {
     );
   });
 
-  it("falls back to the public endpoint when no argument is given", async () => {
+  // Asserted against DEFAULT_RPC_URL rather than the public endpoint, because CI
+  // sets MOSS_RPC_URL and the point here is only that the default is applied.
+  it("falls back to the resolved default when no argument is given", async () => {
     mockChainId(143);
-    await expect(createRuntime()).resolves.toMatchObject({ rpcUrl: PUBLIC_RPC_URL });
+    await expect(createRuntime()).resolves.toMatchObject({ rpcUrl: DEFAULT_RPC_URL });
   });
 });
 


### PR DESCRIPTION
Every fork pull request has been failing its live suites since #149 with:

```
UrlRequiredError: No URL was provided to the Transport
  at packages/core/src/runtime.ts
```

`ci.yml` forwards the private endpoint as `MOSS_RPC_URL: ${{ secrets.MOSS_RPC_ENDPOINT }}`. A fork receives no secrets, so the variable arrives as an **empty string** rather than absent, and `??` only falls back on `null`/`undefined`:

```ts
process.env.MOSS_RPC_URL ?? PUBLIC_RPC_URL   // "" passes through
```

`?.trim() ||` also covers a whitespace-only value, which is the same mistake in a harder-to-see form.

## Verification

`packages/core/test/runtime.test.ts` gains four cases for endpoint resolution. Reverting the source to `??` fails exactly the two blank cases:

```
× DEFAULT_RPC_URL > treats a blank MOSS_RPC_URL ("") as unset
× DEFAULT_RPC_URL > treats a blank MOSS_RPC_URL ("   ") as unset
  Tests  2 failed | 5 passed (7)
```

`lint`, `build` and `typecheck` are clean, and `MOSS_RPC_URL="" pnpm test:offline` reports `packages/core: 50 passed`.

Observed on run [30644000253](https://github.com/nishuzumi/moss/actions/runs/30644000253), fork PR #138.
