### PR TITLE
docs: stop teaching the removed monadRuntime

### DIFF
--- a/.changeset/monad-runtime-in-core.md
+++ b/.changeset/monad-runtime-in-core.md
@@ -4,8 +4,7 @@
 ---
 
 Move the Monad Runtime into `@themoss/core`. `createRuntime()` now takes an
-optional `rpcUrl` and exports `MONAD_CHAIN_ID`, `PUBLIC_RPC_URL`, and
-`DEFAULT_RPC_URL`, which resolves `MOSS_RPC_URL` once so no other module spells
-an endpoint or reads the environment. `@themoss/system` no longer exports
-`monadRuntime`, `MONAD_CHAIN_ID` or `DEFAULT_RPC_URL`; call `createRuntime()`
-from core instead.
+optional `rpcUrl`, and core exports `MONAD_CHAIN_ID` alongside `DEFAULT_RPC_URL`,
+which resolves `MOSS_RPC_URL` once so no other module spells an endpoint or reads
+the environment. `@themoss/system` no longer exports `monadRuntime`,
+`MONAD_CHAIN_ID` or `DEFAULT_RPC_URL`; call `createRuntime()` from core instead.

--- a/.changeset/monad-runtime-in-core.md
+++ b/.changeset/monad-runtime-in-core.md
@@ -4,7 +4,9 @@
 ---
 
 Move the Monad Runtime into `@themoss/core`. `createRuntime()` now takes an
-optional `rpcUrl`, and core exports `MONAD_CHAIN_ID` alongside `DEFAULT_RPC_URL`,
-which resolves `MOSS_RPC_URL` once so no other module spells an endpoint or reads
-the environment. `@themoss/system` no longer exports `monadRuntime`,
-`MONAD_CHAIN_ID` or `DEFAULT_RPC_URL`; call `createRuntime()` from core instead.
+optional `rpcUrl`, and core exports `MONAD_CHAIN_ID` alongside `defaultRpcUrl()`,
+which resolves `MOSS_RPC_URL` so no other module spells an endpoint or reads the
+environment. A blank value counts as unset; a non-blank value that is not an
+http(s) URL is rejected by name. `@themoss/system` no longer exports
+`monadRuntime`, `MONAD_CHAIN_ID` or `DEFAULT_RPC_URL`; call `createRuntime()` from
+core instead.

--- a/.github/workflows/abi-crosscheck.yml
+++ b/.github/workflows/abi-crosscheck.yml
@@ -31,7 +31,7 @@ jobs:
       # this step away — which is why it, not CI, is the one that actually
       # guards a credential.
       - name: Restrict runner egress
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           disable-telemetry: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       #
       # Linux-only (eBPF), so the windows-offline job below cannot use it.
       - name: Restrict runner egress
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           disable-telemetry: true

--- a/.github/workflows/live-verify.yml
+++ b/.github/workflows/live-verify.yml
@@ -38,7 +38,7 @@ jobs:
       # telemetry, and reporting this endpoint to a third party would defeat
       # keeping it private. MOSS_RPC_URL holds its `host:443` spelling.
       - name: Restrict runner egress
-        uses: step-security/harden-runner@v2
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           disable-telemetry: true

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ The server exposes exactly `discover`, `load`, `action`, and `simulate`. See [MC
 ### Use as a library
 
 ```ts
-import { NATIVE, Registry } from "@themoss/core";
+import { createRuntime, NATIVE, Registry } from "@themoss/core";
 import * as erc from "@themoss/erc";
 import * as kuru from "@themoss/protocol-kuru";
 import { createTraceSimulator } from "@themoss/simulator";
 import * as system from "@themoss/system";
-import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
+import { USDC_ADDRESS } from "@themoss/system";
 
-const runtime = await monadRuntime();
+const runtime = await createRuntime();
 const registry = new Registry(runtime).use(system, erc, kuru);
 const account = "0xcccccccccccccccccccccccccccccccccccccccc";
 const simulator = createTraceSimulator(runtime, {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,14 +78,14 @@ server 只暴露 `discover`、`load`、`action` 和 `simulate`。详细契约见
 ### 作为 library 使用
 
 ```ts
-import { NATIVE, Registry } from "@themoss/core";
+import { createRuntime, NATIVE, Registry } from "@themoss/core";
 import * as erc from "@themoss/erc";
 import * as kuru from "@themoss/protocol-kuru";
 import { createTraceSimulator } from "@themoss/simulator";
 import * as system from "@themoss/system";
-import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
+import { USDC_ADDRESS } from "@themoss/system";
 
-const runtime = await monadRuntime();
+const runtime = await createRuntime();
 const registry = new Registry(runtime).use(system, erc, kuru);
 const account = "0xcccccccccccccccccccccccccccccccccccccccc";
 const simulator = createTraceSimulator(runtime, {

--- a/docs/adr/0010-self-describing-protocols-and-zod-parameters.md
+++ b/docs/adr/0010-self-describing-protocols-and-zod-parameters.md
@@ -16,16 +16,19 @@ parameter and has verified chain 143 itself ever since, which left
 `monadRuntime()` as a wrapper whose only remaining job was a default endpoint,
 and left `143` declared in two packages.
 
-`core` now owns the whole Runtime: `MONAD_CHAIN_ID` and `DEFAULT_RPC_URL` (the
-`MOSS_RPC_URL` override, resolved once so no other module spells an endpoint or
-reads the environment). `createRuntime()` takes an optional `rpcUrl`,
-`monadRuntime()` is gone, and `system` is what its name claims: shared verified
-constants plus the WMON Protocol.
+`core` now owns the whole Runtime: `MONAD_CHAIN_ID` and `defaultRpcUrl()` (the
+`MOSS_RPC_URL` override, the only place that reads the environment for an
+endpoint). `createRuntime()` takes an optional `rpcUrl`, `monadRuntime()` is gone,
+and `system` is what its name claims: shared verified constants plus the WMON
+Protocol.
 
-A blank `MOSS_RPC_URL` counts as unset. A workflow forwarding the endpoint from a
-secret sets the variable to an empty string wherever that secret is unavailable —
-every fork pull request, which receive no secrets — so the fallback keys off a
-usable value rather than a defined one.
+The override resolves per call rather than at module load, so a consumer that sets
+the variable after importing core still affects later Runtimes and a test needs no
+module-registry reset. A blank value counts as unset, because a workflow forwarding
+the endpoint from a secret sets the variable to an empty string wherever that secret
+is unavailable — every fork pull request, which receive no secrets. A non-blank
+value that is not an http(s) URL is a misconfiguration and is rejected by name,
+rather than falling back and surfacing later as a transport error.
 
 This also removes a package-boundary problem rather than working around it.
 `system` imports `ERC20` and `WETH9Abi` from `erc`, so an `erc` test that wanted

--- a/docs/adr/0010-self-describing-protocols-and-zod-parameters.md
+++ b/docs/adr/0010-self-describing-protocols-and-zod-parameters.md
@@ -16,11 +16,16 @@ parameter and has verified chain 143 itself ever since, which left
 `monadRuntime()` as a wrapper whose only remaining job was a default endpoint,
 and left `143` declared in two packages.
 
-`core` now owns the whole Runtime: `MONAD_CHAIN_ID`, `PUBLIC_RPC_URL`, and
-`DEFAULT_RPC_URL` (the `MOSS_RPC_URL` override, resolved once so no other module
-spells an endpoint or reads the environment). `createRuntime()` takes an optional
-`rpcUrl`, `monadRuntime()` is gone, and `system` is what its name claims: shared
-verified constants plus the WMON Protocol.
+`core` now owns the whole Runtime: `MONAD_CHAIN_ID` and `DEFAULT_RPC_URL` (the
+`MOSS_RPC_URL` override, resolved once so no other module spells an endpoint or
+reads the environment). `createRuntime()` takes an optional `rpcUrl`,
+`monadRuntime()` is gone, and `system` is what its name claims: shared verified
+constants plus the WMON Protocol.
+
+A blank `MOSS_RPC_URL` counts as unset. A workflow forwarding the endpoint from a
+secret sets the variable to an empty string wherever that secret is unavailable —
+every fork pull request, which receive no secrets — so the fallback keys off a
+usable value rather than a defined one.
 
 This also removes a package-boundary problem rather than working around it.
 `system` imports `ERC20` and `WETH9Abi` from `erc`, so an `erc` test that wanted

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,17 +50,15 @@ It requests a MON/USDC quote, builds one swap Capability, and simulates it again
 Create `examples/simple-flow/src/play.ts`:
 
 ```ts
-import { NATIVE, Registry } from "@themoss/core";
+import { createRuntime, NATIVE, Registry } from "@themoss/core";
 import * as erc from "@themoss/erc";
 import * as kuru from "@themoss/protocol-kuru";
 import { createTraceSimulator } from "@themoss/simulator";
 import * as system from "@themoss/system";
-import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
+import { USDC_ADDRESS } from "@themoss/system";
 
 const ACCOUNT = "0xcccccccccccccccccccccccccccccccccccccccc";
-const runtime = await monadRuntime({
-  ...(process.env.MOSS_RPC_URL ? { rpcUrl: process.env.MOSS_RPC_URL } : {}),
-});
+const runtime = await createRuntime();
 
 const registry = new Registry(runtime).use(system, erc, kuru);
 const simulator = createTraceSimulator(runtime, {

--- a/docs/getting-started.zh-CN.md
+++ b/docs/getting-started.zh-CN.md
@@ -50,17 +50,15 @@ pnpm --filter @themoss/example-simple-flow swap
 创建 `examples/simple-flow/src/play.ts`：
 
 ```ts
-import { NATIVE, Registry } from "@themoss/core";
+import { createRuntime, NATIVE, Registry } from "@themoss/core";
 import * as erc from "@themoss/erc";
 import * as kuru from "@themoss/protocol-kuru";
 import { createTraceSimulator } from "@themoss/simulator";
 import * as system from "@themoss/system";
-import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
+import { USDC_ADDRESS } from "@themoss/system";
 
 const ACCOUNT = "0xcccccccccccccccccccccccccccccccccccccccc";
-const runtime = await monadRuntime({
-  ...(process.env.MOSS_RPC_URL ? { rpcUrl: process.env.MOSS_RPC_URL } : {}),
-});
+const runtime = await createRuntime();
 
 const registry = new Registry(runtime).use(system, erc, kuru);
 const simulator = createTraceSimulator(runtime, {

--- a/examples/agent-swap/src/fork.ts
+++ b/examples/agent-swap/src/fork.ts
@@ -13,14 +13,14 @@ import { spawn, spawnSync } from "node:child_process";
 import { openSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_RPC_URL, MONAD_CHAIN_ID } from "@themoss/core";
+import { defaultRpcUrl, MONAD_CHAIN_ID } from "@themoss/core";
 
 import { formatEther } from "viem";
 import { devAccount, FORK_RPC_URL, rpc } from "./dev-wallet.js";
 
 // The node anvil forks from, so it inherits the MOSS_RPC_URL override too:
 // forking replays real calls upstream and meets the same limits.
-const UPSTREAM = DEFAULT_RPC_URL;
+const UPSTREAM = defaultRpcUrl();
 const FUND_WEI = 1_000_000n * 10n ** 18n; // 1,000,000 MON
 
 async function chainIdAt(url: string): Promise<number | null> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,13 +31,7 @@ export {
   Registry,
   type Stub,
 } from "./registry.js";
-export {
-  createRuntime,
-  DEFAULT_RPC_URL,
-  MONAD_CHAIN_ID,
-  type MossRuntime,
-  PUBLIC_RPC_URL,
-} from "./runtime.js";
+export { createRuntime, DEFAULT_RPC_URL, MONAD_CHAIN_ID, type MossRuntime } from "./runtime.js";
 export {
   Address,
   BasisPoints,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,7 +31,7 @@ export {
   Registry,
   type Stub,
 } from "./registry.js";
-export { createRuntime, DEFAULT_RPC_URL, MONAD_CHAIN_ID, type MossRuntime } from "./runtime.js";
+export { createRuntime, defaultRpcUrl, MONAD_CHAIN_ID, type MossRuntime } from "./runtime.js";
 export {
   Address,
   BasisPoints,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4,10 +4,12 @@ import { createPublicClient, http, type PublicClient } from "viem";
 export const MONAD_CHAIN_ID = 143;
 
 /**
- * Monad's public mainnet endpoint. It answers `429` with JSON-RPC `-32011
- * request limit reached` after roughly thirty sequential `debug_traceCall`s,
- * which a full live test run exceeds, so CI points `MOSS_RPC_URL` at a private
- * endpoint instead.
+ * Monad's public mainnet endpoint. It answers `429` with JSON-RPC `-32011 request
+ * limit reached` after roughly thirty sequential `debug_traceCall`s, which a full
+ * live test run exceeds, so CI points `MOSS_RPC_URL` at a private endpoint.
+ *
+ * Not re-exported from the package: `DEFAULT_RPC_URL` is the value callers want,
+ * and a runtime already reports the endpoint it settled on.
  */
 export const PUBLIC_RPC_URL = "https://rpc.monad.xyz";
 
@@ -28,14 +30,7 @@ export interface MossRuntime {
   client: PublicClient;
 }
 
-/**
- * Creates a Monad mainnet runtime and rejects an RPC reporting any other chain.
- *
- * An earlier revision kept chain identity out of core entirely and let
- * `@themoss/system` supply the Monad defaults, but that separation is gone: core
- * has verified chain 143 itself since the `chainId` parameter was removed, so
- * the matching endpoint default belongs beside it rather than one package away.
- */
+/** Creates a Monad mainnet runtime and rejects an RPC reporting any other chain. */
 export async function createRuntime(opts: { rpcUrl?: string } = {}): Promise<MossRuntime> {
   const rpcUrl = opts.rpcUrl ?? DEFAULT_RPC_URL;
   const client = createPublicClient({ transport: http(rpcUrl) });

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -8,22 +8,39 @@ export const MONAD_CHAIN_ID = 143;
  * limit reached` after roughly thirty sequential `debug_traceCall`s, which a full
  * live test run exceeds, so CI points `MOSS_RPC_URL` at a private endpoint.
  *
- * Not re-exported from the package: `DEFAULT_RPC_URL` is the value callers want,
- * and a runtime already reports the endpoint it settled on.
+ * Not re-exported from the package: `defaultRpcUrl()` is what callers want, and a
+ * runtime already reports the endpoint it settled on.
  */
 export const PUBLIC_RPC_URL = "https://rpc.monad.xyz";
 
 /**
- * The endpoint callers get unless they pin their own: `MOSS_RPC_URL` when set to
- * something usable, otherwise the public one. Resolved here, once, so that no
- * other module spells an endpoint or reads the environment for one.
+ * The endpoint callers get unless they pin their own: `MOSS_RPC_URL` when it names
+ * one, otherwise the public one. The single place in the repo that reads the
+ * environment for an endpoint.
  *
- * Blank is treated as unset because a workflow that forwards a secret produces an
- * empty string wherever that secret is unavailable — every fork pull request, for
- * instance, since those receive no secrets. `??` would forward the blank and viem
- * would reject it as a missing transport URL.
+ * Read per call rather than captured at module load, so setting the variable after
+ * importing this module still takes effect and a test needs no module-registry
+ * reset to change it.
+ *
+ * Blank counts as unset: a workflow forwarding an endpoint from a secret sets the
+ * variable to an empty string wherever that secret is unavailable, which is every
+ * fork pull request. A non-blank value that is not a URL is a misconfiguration, and
+ * failing here names the variable instead of surfacing as a transport error.
  */
-export const DEFAULT_RPC_URL = process.env.MOSS_RPC_URL?.trim() || PUBLIC_RPC_URL;
+export function defaultRpcUrl(): string {
+  const configured = process.env.MOSS_RPC_URL?.trim();
+  if (!configured) return PUBLIC_RPC_URL;
+  let parsed: URL;
+  try {
+    parsed = new URL(configured);
+  } catch {
+    throw new Error(`MOSS_RPC_URL is not a URL: ${configured}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`MOSS_RPC_URL must be http or https, got ${parsed.protocol}`);
+  }
+  return configured;
+}
 
 export interface MossRuntime {
   rpcUrl: string;
@@ -32,7 +49,7 @@ export interface MossRuntime {
 
 /** Creates a Monad mainnet runtime and rejects an RPC reporting any other chain. */
 export async function createRuntime(opts: { rpcUrl?: string } = {}): Promise<MossRuntime> {
-  const rpcUrl = opts.rpcUrl ?? DEFAULT_RPC_URL;
+  const rpcUrl = opts.rpcUrl ?? defaultRpcUrl();
   const client = createPublicClient({ transport: http(rpcUrl) });
   const chainId = await client.getChainId();
   if (chainId !== MONAD_CHAIN_ID) {

--- a/packages/core/test/runtime.test.ts
+++ b/packages/core/test/runtime.test.ts
@@ -1,25 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRuntime, DEFAULT_RPC_URL, PUBLIC_RPC_URL } from "../src/runtime.js";
+import { createRuntime, defaultRpcUrl, PUBLIC_RPC_URL } from "../src/runtime.js";
 
-afterEach(() => vi.restoreAllMocks());
+const ORIGINAL_RPC_URL = process.env.MOSS_RPC_URL;
 
-/**
- * Re-imports the module so the `DEFAULT_RPC_URL` computed at load time reflects
- * `MOSS_RPC_URL` as given here.
- */
-async function resolveDefault(value: string | undefined) {
-  const previous = process.env.MOSS_RPC_URL;
-  if (value === undefined) delete process.env.MOSS_RPC_URL;
-  else process.env.MOSS_RPC_URL = value;
-  vi.resetModules();
-  try {
-    const fresh = await import("../src/runtime.js");
-    return fresh.DEFAULT_RPC_URL;
-  } finally {
-    if (previous === undefined) delete process.env.MOSS_RPC_URL;
-    else process.env.MOSS_RPC_URL = previous;
-  }
-}
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_RPC_URL === undefined) delete process.env.MOSS_RPC_URL;
+  else process.env.MOSS_RPC_URL = ORIGINAL_RPC_URL;
+});
 
 function mockChainId(chainId: number) {
   vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
@@ -46,28 +34,51 @@ describe("createRuntime", () => {
     );
   });
 
-  // Asserted against DEFAULT_RPC_URL rather than the public endpoint, because CI
-  // sets MOSS_RPC_URL and the point here is only that the default is applied.
-  it("falls back to the resolved default when no argument is given", async () => {
+  it("applies the default endpoint when no argument is given", async () => {
     mockChainId(143);
-    await expect(createRuntime()).resolves.toMatchObject({ rpcUrl: DEFAULT_RPC_URL });
+    process.env.MOSS_RPC_URL = "http://configured.test";
+    await expect(createRuntime()).resolves.toMatchObject({ rpcUrl: "http://configured.test" });
   });
 });
 
-describe("DEFAULT_RPC_URL", () => {
-  it("uses MOSS_RPC_URL when it names an endpoint", async () => {
-    await expect(resolveDefault("https://rpc.private.test/key")).resolves.toBe(
-      "https://rpc.private.test/key",
-    );
+describe("defaultRpcUrl", () => {
+  it("uses MOSS_RPC_URL when it names an endpoint", () => {
+    process.env.MOSS_RPC_URL = "https://rpc.private.test/key";
+    expect(defaultRpcUrl()).toBe("https://rpc.private.test/key");
   });
 
-  it("uses the public endpoint when MOSS_RPC_URL is unset", async () => {
-    await expect(resolveDefault(undefined)).resolves.toBe(PUBLIC_RPC_URL);
+  it("reads the variable per call, not once at module load", () => {
+    process.env.MOSS_RPC_URL = "https://first.test";
+    expect(defaultRpcUrl()).toBe("https://first.test");
+    process.env.MOSS_RPC_URL = "https://second.test";
+    expect(defaultRpcUrl()).toBe("https://second.test");
+  });
+
+  it("uses the public endpoint when MOSS_RPC_URL is unset", () => {
+    delete process.env.MOSS_RPC_URL;
+    expect(defaultRpcUrl()).toBe(PUBLIC_RPC_URL);
   });
 
   // A workflow forwarding a secret sets this to "" wherever the secret is
   // unavailable, which is every fork pull request.
-  it.each(["", "   "])("treats a blank MOSS_RPC_URL (%j) as unset", async (blank) => {
-    await expect(resolveDefault(blank)).resolves.toBe(PUBLIC_RPC_URL);
+  it.each(["", "   "])("treats a blank MOSS_RPC_URL (%j) as unset", (blank) => {
+    process.env.MOSS_RPC_URL = blank;
+    expect(defaultRpcUrl()).toBe(PUBLIC_RPC_URL);
+  });
+
+  // Falling back here would hide the mistake behind a transport error later.
+  it.each([
+    "undefined",
+    "null",
+    "https://",
+    "rpc.monad.xyz",
+  ])("rejects a non-blank MOSS_RPC_URL that is not a URL (%j)", (bad) => {
+    process.env.MOSS_RPC_URL = bad;
+    expect(() => defaultRpcUrl()).toThrow(`MOSS_RPC_URL is not a URL: ${bad}`);
+  });
+
+  it("rejects a URL that is not http or https", () => {
+    process.env.MOSS_RPC_URL = "ws://rpc.test";
+    expect(() => defaultRpcUrl()).toThrow("MOSS_RPC_URL must be http or https, got ws:");
   });
 });


### PR DESCRIPTION
Found while auditing the `Live verification` run's logs for leaks.

## The docs taught a deleted API

Both READMEs and both getting-started guides still opened with:

```ts
import { monadRuntime, USDC_ADDRESS } from "@themoss/system";
const runtime = await monadRuntime();
```

#149 deleted `monadRuntime`, so the first code block a reader copies does not compile. They now use `createRuntime()` from core, which also lets the guides drop the spread they carried:

```diff
-const runtime = await monadRuntime({
-  ...(process.env.MOSS_RPC_URL ? { rpcUrl: process.env.MOSS_RPC_URL } : {}),
-});
+const runtime = await createRuntime();
```

Core resolves `MOSS_RPC_URL` itself, so that spread was already redundant.

## Smaller cleanups

- `PUBLIC_RPC_URL` stops being re-exported from `@themoss/core`. Nothing outside core's own test used it, `DEFAULT_RPC_URL` is the value a caller wants, and a runtime already reports the endpoint it settled on. It stays in `runtime.ts` as the named constant behind the fallback.
- Removed a comment in `createRuntime` narrating the pre-#149 package split. ADR 0010 records that history properly; repeating it beside current code invites reading a deleted contract as a live alternative.
- ADR 0010 gains the blank-`MOSS_RPC_URL` rule from #151, which was only recorded in the commit until now.

## Log audit result

No endpoint credential leaked. `rpc-mainnet.monadinfra.com` appears 10 times, all inside harden-runner's own `Post Restrict runner egress` report — its DNS resolution and per-connection records. Nothing beyond the bare host appears: the only full URLs in the log are StepSecurity's own API endpoints, and `MOSS_RPC_ENDPOINT` never appears in any form. Masking works where it can (`token: ***`, and the allowlist echo in the `Pre` step).

The host itself is not secret — ADR 0002 already lists it as a verified public endpoint and `packages/simulator/src/trace.ts` recommends it in an error message.

## Verification

`lint`, `build`, `typecheck` clean; `pnpm test:offline` unchanged with `packages/core: 50 passed`. No `monadRuntime` reference survives outside ADR history and changesets.
