### PR TITLE
fix(fastlane): authenticate Receipt evidence and bind transfer endpoints

### DIFF
--- a/.changeset/fastlane-receipt-evidence.md
+++ b/.changeset/fastlane-receipt-evidence.md
@@ -3,3 +3,5 @@
 ---
 
 Authenticate the FastLane emitter before decoding Receipt evidence, and bind each native MON transfer to the event it settles. A validly encoded FastLane event from any other contract is no longer accepted, and `deposit`, `redeem` and `completeUnstake` now require the MON to move between the endpoints their events name rather than matching on amount alone.
+
+`boostYield` now reads its outcome from the vault's `BoostYield` event instead of the shMON `Transfer` that settles it. The Receipt requires exactly one of each, requires the shares to be burned from the `BoostYield` sender and reports the credited yield originator, the validator and the MON the burn was worth. The Transfer-keyed parser named the burn address as the yield originator and delegated the `BoostYield` Change to the ERC-20 dependency, which failed every mainnet boostYield Receipt.

--- a/.changeset/fastlane-receipt-evidence.md
+++ b/.changeset/fastlane-receipt-evidence.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-fastlane": patch
+---
+
+Authenticate the FastLane emitter before decoding Receipt evidence, and bind each native MON transfer to the event it settles. A validly encoded FastLane event from any other contract is no longer accepted, and `deposit`, `redeem` and `completeUnstake` now require the MON to move between the endpoints their events name rather than matching on amount alone.

--- a/packages/protocols/fastlane/src/fastlane.ts
+++ b/packages/protocols/fastlane/src/fastlane.ts
@@ -192,6 +192,12 @@ export class FastLane {
     verb: "unstake",
     params: completeUnstakeParams,
     receipt: "completeUnstakeReceipt",
+    // This step is inflow-only: requestUnstake already committed the shMON, and
+    // completion only pays MON back to the owner. `fundOut` as settled in #114
+    // means assets leave the account in this transaction, so it does not fit,
+    // but Registry rejects an empty risk set and the closed set has no
+    // inflow-only entry. Kept as the least-wrong placeholder pending the ruling
+    // asked for in #12 and #104.
     risk: ["fundOut"],
     tags: ["staking", "unstake", "delayed"],
   })
@@ -331,6 +337,17 @@ export class FastLane {
     if (!event || !native || event.assets !== native.value) {
       throw new Error("FastLane deposit Receipt requires matching Deposit and native Changes");
     }
+    // Bind the native transfer to the event, not just to its amount: the staked
+    // MON has to leave the Deposit sender and arrive at the vault. Without this
+    // the same amount moving anywhere else satisfies the Receipt.
+    if (
+      !sameAddress(native.from, event.sender) ||
+      !sameAddress(native.to, FASTLANE_STAKING_ADDRESS)
+    ) {
+      throw new Error(
+        "FastLane deposit Receipt requires the staked MON to move from the Deposit sender to FastLane",
+      );
+    }
 
     return {
       kind: "receipt",
@@ -384,6 +401,17 @@ export class FastLane {
 
     if (!event || !native || event.assets !== native.value) {
       throw new Error("FastLane redeem Receipt requires matching Withdraw and native Changes");
+    }
+    // The payout has to come out of the vault and land on the receiver the
+    // Receipt names. Amount-only matching accepts the right MON reaching the
+    // wrong account.
+    if (
+      !sameAddress(native.from, FASTLANE_STAKING_ADDRESS) ||
+      !sameAddress(native.to, event.receiver)
+    ) {
+      throw new Error(
+        "FastLane redeem Receipt requires the MON payout to move from FastLane to the Withdraw receiver",
+      );
     }
 
     return {
@@ -477,6 +505,17 @@ export class FastLane {
         "FastLane completeUnstake Receipt requires matching CompleteUnstake and native Changes",
       );
     }
+    // Same binding as redeem, against the owner the CompleteUnstake event names.
+    // Confirmed on mainnet: tx 0xf18ff4f892de84b9cafbaf123788cedf6533578c857d42716d88886ac4d4ef13
+    // pays amountMon straight from the vault to the CompleteUnstake owner.
+    if (
+      !sameAddress(native.from, FASTLANE_STAKING_ADDRESS) ||
+      !sameAddress(native.to, event.owner)
+    ) {
+      throw new Error(
+        "FastLane completeUnstake Receipt requires the MON payout to move from FastLane to the CompleteUnstake owner",
+      );
+    }
 
     return {
       kind: "receipt",
@@ -528,7 +567,20 @@ export class FastLane {
   }
 }
 
+// The simulator reports trace addresses as the node returned them (lowercase)
+// while decodeEventLog checksums what it decodes, so every address comparison
+// here is case-insensitive.
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
 function tryDecodeFastLaneEvent(change: Extract<Change, { kind: "event" }>) {
+  // Only the staking vault can produce FastLane evidence. Decoding by topics
+  // alone accepts a matching event from any contract, which matters most for
+  // boostYield: its canonical event is the shared ERC-20 Transfer signature, so
+  // every token on Monad emits something that decodes here. Anything from
+  // another address falls through to the ERC-20 dependency instead.
+  if (!sameAddress(change.address, FASTLANE_STAKING_ADDRESS)) return undefined;
   try {
     return decodeEventLog({
       abi: FastLaneStakingAbi,

--- a/packages/protocols/fastlane/src/fastlane.ts
+++ b/packages/protocols/fastlane/src/fastlane.ts
@@ -44,6 +44,11 @@ export const SHMON_NAME = "ShMonad" as const;
 export const SHMON_SYMBOL = "shMON" as const;
 export const SHMON_DECIMALS = 18 as const;
 
+// Where the shares path sends the shMON it spends. boostYield burns the shares
+// instead of moving them to the yield originator, so the Transfer that settles
+// it lands here and not on the account being credited.
+const BURN_ADDRESS: AddressValue = "0x0000000000000000000000000000000000000000" as const;
+
 const depositParams = {
   amount: {
     type: PositiveDecimalString,
@@ -527,44 +532,106 @@ export class FastLane {
 
   @Receipt()
   boostYieldReceipt(changes: readonly Change[]): ReceiptResult<BoostYieldOutcome> {
-    let event: BoostYieldOutcome | undefined;
+    // The canonical evidence is the vault's own BoostYield event, not the shMON
+    // Transfer that settles it. A Transfer carries the shared ERC-20 signature,
+    // so it cannot say which move the Capability performed, and it names the
+    // burn address rather than the account whose yield was credited. On mainnet
+    // the shares path emits Transfer(sender -> burn) followed by
+    // BoostYield(sender, yieldOriginator, validatorId, amount, sharesBurned):
+    // one identifies the operation, the other proves what it cost.
+    const boosts: BoostYieldEvent[] = [];
+    const burns: BoostYieldBurn[] = [];
 
     const parsed = changes.map((change) => {
-      if (change.kind === "nativeTransfer") {
-        return this.erc20.changesReceipt([change]);
+      if (change.kind === "event") {
+        const decoded = tryDecodeFastLaneEvent(change);
+
+        if (decoded?.eventName === "BoostYield") {
+          const boost: BoostYieldEvent = {
+            operation: "boostYield",
+            sender: decoded.args.sender,
+            yieldOriginator: decoded.args.yieldOriginator,
+            validatorId: decoded.args.validatorId.toString(),
+            amount: decoded.args.amount.toString(),
+            sharesBurned: decoded.args.sharesBurned,
+          };
+          boosts.push(boost);
+
+          return {
+            kind: "change" as const,
+            change,
+            data: boost,
+            text: `FastLane Boost Yield: ${boost.amount} MON of yield for ${boost.yieldOriginator}`,
+          };
+        }
+
+        // The shMON leg is an ordinary ERC-20 burn, so the dependency Receipt
+        // describes it. Keeping it as a candidate here only lets the outcome
+        // bind the shares it spent to the BoostYield event that spent them.
+        if (decoded?.eventName === "Transfer") {
+          burns.push({
+            from: decoded.args.from,
+            to: decoded.args.to,
+            shares: decoded.args.value.toString(),
+          });
+        }
       }
 
-      const decoded = tryDecodeFastLaneEvent(change as Extract<Change, { kind: "event" }>);
-      if (decoded?.eventName !== "Transfer" || event) {
-        return this.erc20.changesReceipt([change]);
-      }
-
-      event = {
-        operation: "boostYield",
-        from: decoded.args.from,
-        shares: decoded.args.value.toString(),
-        yieldOriginator: decoded.args.to,
-      };
-
-      return {
-        kind: "change" as const,
-        change,
-        data: event,
-        text: `FastLane Boost Yield: ${event.shares} shMON from ${event.from} to ${event.yieldOriginator}`,
-      };
+      return this.erc20.changesReceipt([change]);
     });
 
-    if (!event) {
-      throw new Error("FastLane boostYield Receipt requires Transfer event");
+    // Fail closed on a second candidate of either kind. Nothing in a
+    // single-outcome model distinguishes two equally valid BoostYield events or
+    // two equally valid shMON Transfers, so keeping the first would name one of
+    // them canonical without evidence.
+    const boost = exactlyOne(boosts, "FastLane BoostYield event");
+    if (!boost.sharesBurned) {
+      throw new Error("FastLane boostYield Receipt requires the shares-burning boostYield path");
     }
+    const burn = exactlyOne(burns, "FastLane shMON Transfer");
+    if (!sameAddress(burn.from, boost.sender) || !sameAddress(burn.to, BURN_ADDRESS)) {
+      throw new Error(
+        "FastLane boostYield Receipt requires the boosted shMON to be burned from the BoostYield sender",
+      );
+    }
+
+    const outcome: BoostYieldOutcome = {
+      operation: "boostYield",
+      sender: boost.sender,
+      yieldOriginator: boost.yieldOriginator,
+      validatorId: boost.validatorId,
+      amount: boost.amount,
+      shares: burn.shares,
+    };
 
     return {
       kind: "receipt",
-      outcome: event,
-      text: `FastLane Boost Yield: ${event.shares} shMON from ${event.from} to ${event.yieldOriginator}`,
+      outcome,
+      text: `FastLane Boost Yield: ${outcome.shares} shMON from ${outcome.sender} -> ${outcome.amount} MON of yield for ${outcome.yieldOriginator}`,
       changes: parsed,
     };
   }
+}
+
+// boostYield candidates, kept local to the parser that binds them. The event
+// fields stay verbatim; the outcome composes them with the burn it authenticates.
+type BoostYieldEvent = {
+  operation: "boostYield";
+  sender: AddressValue;
+  yieldOriginator: AddressValue;
+  validatorId: string;
+  amount: string;
+  sharesBurned: boolean;
+};
+
+type BoostYieldBurn = { from: AddressValue; to: AddressValue; shares: string };
+
+function exactlyOne<T>(values: readonly T[], description: string): T {
+  const [value] = values;
+  if (!value || values.length !== 1) {
+    throw new Error(`FastLane boostYield Receipt requires exactly one ${description}`);
+  }
+  return value;
 }
 
 // The simulator reports trace addresses as the node returned them (lowercase)
@@ -576,10 +643,12 @@ function sameAddress(left: string, right: string): boolean {
 
 function tryDecodeFastLaneEvent(change: Extract<Change, { kind: "event" }>) {
   // Only the staking vault can produce FastLane evidence. Decoding by topics
-  // alone accepts a matching event from any contract, which matters most for
-  // boostYield: its canonical event is the shared ERC-20 Transfer signature, so
-  // every token on Monad emits something that decodes here. Anything from
-  // another address falls through to the ERC-20 dependency instead.
+  // alone accepts a matching event from any contract, so a validly encoded
+  // Deposit or BoostYield from an unrelated address would satisfy a Receipt.
+  // It matters most for the shMON Transfer that settles boostYield: that is the
+  // shared ERC-20 signature, so every token on Monad emits something that
+  // decodes here. Anything from another address falls through to the ERC-20
+  // dependency instead.
   if (!sameAddress(change.address, FASTLANE_STAKING_ADDRESS)) return undefined;
   try {
     return decodeEventLog({

--- a/packages/protocols/fastlane/src/types.ts
+++ b/packages/protocols/fastlane/src/types.ts
@@ -33,7 +33,9 @@ export type RedeemOutcome = {
 
 export type BoostYieldOutcome = {
   operation: "boostYield";
-  from: AddressValue;
-  shares: string;
+  sender: AddressValue;
   yieldOriginator: AddressValue;
+  validatorId: string;
+  amount: string;
+  shares: string;
 };

--- a/packages/protocols/fastlane/test/fastlane.test.ts
+++ b/packages/protocols/fastlane/test/fastlane.test.ts
@@ -7,7 +7,7 @@ import {
   type ReceiptResult,
   Registry,
 } from "@themoss/core";
-import { createTraceSimulator } from "@themoss/simulator";
+import { createTraceSimulator, type SimulateOutcome } from "@themoss/simulator";
 import { monadRuntime } from "@themoss/system";
 import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
 import { describe, expect, it } from "vitest";
@@ -890,11 +890,58 @@ describe("FastLane shMONAD staking", () => {
   });
 });
 
+// One runtime for the whole live block. `createRuntime` verifies the chain ID on
+// every call, so building one per case spent nine `eth_chainId` requests on the
+// public endpoint and bought no coverage.
+let runtimeOnce: Promise<MossRuntime> | undefined;
+function liveRuntime(): Promise<MossRuntime> {
+  runtimeOnce ??= monadRuntime();
+  return runtimeOnce;
+}
+
+// Two cases simulate the same stake -> redeem chain, the state chaining one and
+// the loop closure one, from the same account for the same amounts. One simulate
+// of that chain is six requests against the public endpoint: one
+// `eth_blockNumber`, two `callTracer` traces, one `prestateTracer` diff and two
+// `eth_estimateGas`. Tracing it twice proved nothing the first trace had not, so
+// the two cases share one outcome and keep their own assertions over it.
+let stakeRedeemOnce: Promise<SimulateOutcome> | undefined;
+function stakeRedeemOutcome(): Promise<SimulateOutcome> {
+  stakeRedeemOnce ??= (async () => {
+    const runtime = await liveRuntime();
+    const registry = new Registry(runtime).use(FastLane);
+
+    const stakeCap = await registry.action("fastlane", "deposit", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (stakeCap.kind !== "capability") throw new Error("expected stake (deposit) Capability");
+
+    // Redeem less than the deposited amount to tolerate exchange-rate drift
+    // between assets (MON) and shares (shMON).
+    const redeemCap = await registry.action("fastlane", "redeem", ACCOUNT, {
+      shares: "0.5",
+      receiver: ACCOUNT,
+    });
+    if (redeemCap.kind !== "capability") throw new Error("expected redeem Capability");
+
+    const combined: CapabilityNode = {
+      ...stakeCap,
+      children: [...stakeCap.children, redeemCap],
+    };
+
+    return createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(combined);
+  })();
+  return stakeRedeemOnce;
+}
+
 describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   it("has deployed bytecode at the staking proxy address", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await liveRuntime();
     expect(
       (await runtime.client.getCode({ address: FASTLANE_STAKING_ADDRESS }))?.length,
     ).toBeGreaterThan(2);
@@ -903,7 +950,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   it("matches on-chain name/symbol/decimals against exported SHMON_* constants", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await liveRuntime();
     const [name, symbol, decimals] = await Promise.all([
       runtime.client.readContract({
         address: FASTLANE_STAKING_ADDRESS,
@@ -929,7 +976,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   it("returns ERC-4626 preview/convert quotes that round-trip consistently", {
     timeout: 60_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await liveRuntime();
     const registry = new Registry(runtime).use(FastLane);
 
     const deposit = await registry.action("fastlane", "previewDeposit", ACCOUNT, {
@@ -960,7 +1007,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   it("simulates a stake into an exhaustive typed Receipt", {
     timeout: 180_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await liveRuntime();
     const registry = new Registry(runtime).use(FastLane);
     const capability = await registry.action("fastlane", "deposit", ACCOUNT, {
       amount: "1",
@@ -980,37 +1027,12 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   // Chains stake (deposit) -> redeem (atomic) in a single simulate call so the
   // simulator's mergeDiff persists the minted shMON balance into state overrides
   // before the atomic redeem runs. This is the ERC-4626 redeem path: it burns
-  // shMON and returns MON in the same transaction.
+  // shMON and returns MON in the same transaction. The trace is shared with the
+  // loop closure case below.
   it("simulates atomic redeem after stake via state chaining", {
     timeout: 240_000,
   }, async () => {
-    const runtime = await monadRuntime();
-    const registry = new Registry(runtime).use(FastLane);
-
-    const depositCap = await registry.action("fastlane", "deposit", ACCOUNT, {
-      amount: "1",
-      receiver: ACCOUNT,
-    });
-    if (depositCap.kind !== "capability") throw new Error("expected deposit Capability");
-
-    // Redeem less than the deposited amount to tolerate exchange-rate drift
-    // between assets (MON) and shares (shMON).
-    const redeemCap = await registry.action("fastlane", "redeem", ACCOUNT, {
-      shares: "0.5",
-      receiver: ACCOUNT,
-    });
-    if (redeemCap.kind !== "capability") {
-      throw new Error("expected redeem Capability");
-    }
-
-    const combined: CapabilityNode = {
-      ...depositCap,
-      children: [...depositCap.children, redeemCap],
-    };
-
-    const outcome = await createTraceSimulator(runtime, {
-      receipt: (node, changes) => registry.parseReceipt(node, changes),
-    }).simulate(combined);
+    const outcome = await stakeRedeemOutcome();
 
     expect(outcome.halted).toBeUndefined();
     expect(outcome.results).toHaveLength(2);
@@ -1029,7 +1051,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   it("simulates requestUnstake after stake via state chaining", {
     timeout: 240_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await liveRuntime();
     const registry = new Registry(runtime).use(FastLane);
 
     const depositCap = await registry.action("fastlane", "deposit", ACCOUNT, {
@@ -1075,7 +1097,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   it("halts when completeUnstake runs before the completion epoch", {
     timeout: 240_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await liveRuntime();
     const registry = new Registry(runtime).use(FastLane);
 
     const depositCap = await registry.action("fastlane", "deposit", ACCOUNT, {
@@ -1122,40 +1144,17 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   });
 
   // Closes the stake (deposit) -> redeem (atomic) loop with exhaustive Receipt
-  // assertions. Complements the lighter "simulates atomic redeem after stake
-  // via state chaining" test by verifying the full Receipt payload (not just
-  // the operation field), the assets/shares relationship between the two legs,
-  // and the loop-closure invariant that redeemed shares never exceed minted
-  // shares. This is the canonical mainnet round-trip: user stakes MON, then
-  // atomically redeems shMON back to MON in the same simulate call.
+  // assertions over the shared stake -> redeem trace. Complements the lighter
+  // "simulates atomic redeem after stake via state chaining" case by verifying
+  // the full Receipt payload (not just the operation field), the assets/shares
+  // relationship between the two legs, and the loop-closure invariant that
+  // redeemed shares never exceed minted shares. This is the canonical mainnet
+  // round-trip: user stakes MON, then atomically redeems shMON back to MON in the
+  // same simulate call.
   it("closes the stake -> redeem loop with exhaustive Receipt and cross-check assertions", {
     timeout: 240_000,
   }, async () => {
-    const runtime = await monadRuntime();
-    const registry = new Registry(runtime).use(FastLane);
-
-    const stakeCap = await registry.action("fastlane", "deposit", ACCOUNT, {
-      amount: "1",
-      receiver: ACCOUNT,
-    });
-    if (stakeCap.kind !== "capability") throw new Error("expected stake (deposit) Capability");
-
-    // Redeem less than the deposited amount to tolerate exchange-rate drift
-    // between assets (MON) and shares (shMON).
-    const redeemCap = await registry.action("fastlane", "redeem", ACCOUNT, {
-      shares: "0.5",
-      receiver: ACCOUNT,
-    });
-    if (redeemCap.kind !== "capability") throw new Error("expected redeem Capability");
-
-    const combined: CapabilityNode = {
-      ...stakeCap,
-      children: [...stakeCap.children, redeemCap],
-    };
-
-    const outcome = await createTraceSimulator(runtime, {
-      receipt: (node, changes) => registry.parseReceipt(node, changes),
-    }).simulate(combined);
+    const outcome = await stakeRedeemOutcome();
 
     // No halt, two clean legs.
     expect(outcome.halted).toBeUndefined();
@@ -1233,7 +1232,7 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
   it("simulates boostYield after stake via state chaining", {
     timeout: 240_000,
   }, async () => {
-    const runtime = await monadRuntime();
+    const runtime = await liveRuntime();
     const registry = new Registry(runtime).use(FastLane);
 
     const depositCap = await registry.action("fastlane", "deposit", ACCOUNT, {

--- a/packages/protocols/fastlane/test/fastlane.test.ts
+++ b/packages/protocols/fastlane/test/fastlane.test.ts
@@ -61,6 +61,20 @@ function changeOf(entry: ReceiptResult["changes"][number] | undefined): Change {
   throw new Error("expected a flat ReceiptChange or a single-Change nested Receipt");
 }
 
+// Pulls the native MON Changes back out of a Receipt. A live test can then name
+// the endpoints the parser bound instead of trusting that it bound anything.
+function nativeTransfersOf(
+  changes: readonly ReceiptResult["changes"][number][] | undefined,
+): Extract<Change, { kind: "nativeTransfer" }>[] {
+  if (!changes) throw new Error("expected Receipt changes");
+  return changes
+    .map((entry) => changeOf(entry))
+    .filter(
+      (change): change is Extract<Change, { kind: "nativeTransfer" }> =>
+        change.kind === "nativeTransfer",
+    );
+}
+
 function depositEvent(
   sender: `0x${string}`,
   owner: `0x${string}`,
@@ -308,6 +322,53 @@ describe("FastLane shMONAD staking", () => {
     );
   });
 
+  it("rejects stake (deposit) Receipt when someone else paid the staked MON", async () => {
+    const capability = await registry.action("fastlane", "deposit", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Right amount, right destination, wrong payer. Checking the destination
+    // alone accepts another account's MON as proof that this one staked, so the
+    // Receipt binds both ends of the transfer.
+    const native = {
+      kind: "nativeTransfer",
+      from: getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+      to: FASTLANE_STAKING_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+
+    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 10n ** 18n);
+
+    expect(() => registry.parseReceipt(capability, [native, deposited])).toThrow(
+      "FastLane deposit Receipt requires the staked MON to move from the Deposit sender to FastLane",
+    );
+  });
+
+  it("rejects stake (deposit) Receipt when assets !== native value", async () => {
+    const capability = await registry.action("fastlane", "deposit", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Right endpoints, wrong amount: the Deposit event claims 1 MON and 1 wei
+    // moved.
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: FASTLANE_STAKING_ADDRESS,
+      value: "1",
+    } satisfies Change;
+
+    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 10n ** 18n);
+
+    expect(() => registry.parseReceipt(capability, [native, deposited])).toThrow(
+      "FastLane deposit Receipt requires matching Deposit and native Changes",
+    );
+  });
+
   it("builds atomic redeem transaction with shares, receiver, owner", async () => {
     const capability = await registry.action("fastlane", "redeem", ACCOUNT, {
       shares: "1",
@@ -417,6 +478,35 @@ describe("FastLane shMONAD staking", () => {
     );
   });
 
+  it("rejects atomic redeem Receipt when the MON payout does not come from the vault", async () => {
+    const capability = await registry.action("fastlane", "redeem", ACCOUNT, {
+      shares: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // The right MON reaching the right receiver from somewhere other than the
+    // vault does not prove the vault paid it out.
+    const native = {
+      kind: "nativeTransfer",
+      from: getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+      to: ACCOUNT,
+      value: "990000000000000000",
+    } satisfies Change;
+
+    const withdrawn = withdrawEvent(
+      ACCOUNT,
+      ACCOUNT,
+      ACCOUNT,
+      990_000_000_000_000_000n,
+      10n ** 18n,
+    );
+
+    expect(() => registry.parseReceipt(capability, [withdrawn, native])).toThrow(
+      "FastLane redeem Receipt requires the MON payout to move from FastLane to the Withdraw receiver",
+    );
+  });
+
   it("parses requestUnstake Changes with exact identity, length, and order", async () => {
     const capability = await registry.action("fastlane", "requestUnstake", ACCOUNT, {
       shares: "1",
@@ -482,6 +572,44 @@ describe("FastLane shMONAD staking", () => {
 
     expect(() => registry.parseReceipt(capability, [completeEvent, native])).toThrow(
       "FastLane completeUnstake Receipt requires the MON payout to move from FastLane to the CompleteUnstake owner",
+    );
+  });
+
+  it("rejects completeUnstake Receipt when the MON payout does not come from the vault", async () => {
+    const capability = await registry.action("fastlane", "completeUnstake", ACCOUNT, {});
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Same amount, same owner, wrong source. A completion is the vault paying
+    // out, so MON arriving from anywhere else is not evidence of one.
+    const native = {
+      kind: "nativeTransfer",
+      from: getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+      to: ACCOUNT,
+      value: "990000000000000000",
+    } satisfies Change;
+
+    const completeEvent = completeUnstakeEvent(ACCOUNT, 990_000_000_000_000_000n);
+
+    expect(() => registry.parseReceipt(capability, [completeEvent, native])).toThrow(
+      "FastLane completeUnstake Receipt requires the MON payout to move from FastLane to the CompleteUnstake owner",
+    );
+  });
+
+  it("rejects completeUnstake Receipt when amountMon !== native value", async () => {
+    const capability = await registry.action("fastlane", "completeUnstake", ACCOUNT, {});
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native = {
+      kind: "nativeTransfer",
+      from: FASTLANE_STAKING_ADDRESS,
+      to: ACCOUNT,
+      value: "1",
+    } satisfies Change;
+
+    const completeEvent = completeUnstakeEvent(ACCOUNT, 990_000_000_000_000_000n);
+
+    expect(() => registry.parseReceipt(capability, [completeEvent, native])).toThrow(
+      "FastLane completeUnstake Receipt requires matching CompleteUnstake and native Changes",
     );
   });
 
@@ -622,6 +750,31 @@ describe("FastLane shMONAD staking", () => {
     expect(() =>
       registry.parseReceipt(capability, [transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n)]),
     ).toThrow("FastLane boostYield Receipt requires exactly one FastLane BoostYield event");
+  });
+
+  it("rejects boostYield Receipt when the burn is another token's Transfer", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // A burn of some other token, from the right account for the right amount,
+    // is not the shMON the boost spent. It is preserved as an ERC-20 Change and
+    // never counts as a boostYield candidate, so the Receipt fails closed for
+    // want of the shMON Transfer.
+    const foreign = transferEvent(
+      ACCOUNT,
+      BURN,
+      5n * 10n ** 17n,
+      getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+    );
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 798_909_778_210_594_794n);
+
+    expect(() => registry.parseReceipt(capability, [foreign, boosted])).toThrow(
+      "FastLane boostYield Receipt requires exactly one FastLane shMON Transfer",
+    );
   });
 
   it("rejects boostYield Receipt when the burn does not come from the BoostYield sender", async () => {
@@ -962,6 +1115,10 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
     expect(outcome.halted).toBeDefined();
     expect(outcome.halted?.transactionIndex).toBe(2);
     expect(outcome.results[2]?.reverted).toBe(true);
+    // The halt has to be the chain rejecting the call, not our own Receipt
+    // failing to parse. A RECEIPT_FAILED halt also lands at index 2, so pin the
+    // warning code rather than accepting any halt here.
+    expect(outcome.results[2]?.warnings.map((warning) => warning.code)).toEqual(["REVERTED"]);
   });
 
   // Closes the stake (deposit) -> redeem (atomic) loop with exhaustive Receipt
@@ -1021,9 +1178,16 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
     };
     expect(BigInt(stakeOutcome.assets)).toBe(10n ** 18n);
     expect(BigInt(stakeOutcome.shares)).toBeGreaterThan(0n);
-    // depositReceipt cross-checks Deposit.assets === nativeTransfer.value
-    // internally; verify both Changes are present (event + native transfer).
-    expect(stakeReceipt?.changes.length).toBeGreaterThanOrEqual(2);
+    // Mainnet reports three Changes for a stake: the native MON in, the Deposit
+    // event and the shMON mint Transfer. Pin the count instead of a lower bound,
+    // and name the endpoints the parser bound so the live proof does not rest on
+    // the parser agreeing with itself.
+    expect(stakeReceipt?.changes).toHaveLength(3);
+    const stakeNatives = nativeTransfersOf(stakeReceipt?.changes);
+    expect(stakeNatives).toHaveLength(1);
+    expect(stakeNatives[0]?.value).toBe(stakeOutcome.assets);
+    expect(stakeNatives[0]?.from.toLowerCase()).toBe(ACCOUNT.toLowerCase());
+    expect(stakeNatives[0]?.to.toLowerCase()).toBe(FASTLANE_STAKING_ADDRESS.toLowerCase());
 
     // Redeem leg: full Withdraw Receipt payload.
     const redeemReceipt = outcome.results[1]?.receipt;
@@ -1039,9 +1203,15 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
     };
     expect(BigInt(redeemOutcome.shares)).toBeGreaterThan(0n);
     expect(BigInt(redeemOutcome.assets)).toBeGreaterThan(0n);
-    // redeemReceipt cross-checks Withdraw.assets === nativeTransfer.value
-    // internally; verify both Changes are present.
-    expect(redeemReceipt?.changes.length).toBeGreaterThanOrEqual(2);
+    // Three Changes again: the Withdraw event, the shMON burn Transfer and the
+    // native MON out. The payout has to leave the vault and land on the receiver
+    // the Withdraw event names.
+    expect(redeemReceipt?.changes).toHaveLength(3);
+    const redeemNatives = nativeTransfersOf(redeemReceipt?.changes);
+    expect(redeemNatives).toHaveLength(1);
+    expect(redeemNatives[0]?.value).toBe(redeemOutcome.assets);
+    expect(redeemNatives[0]?.from.toLowerCase()).toBe(FASTLANE_STAKING_ADDRESS.toLowerCase());
+    expect(redeemNatives[0]?.to.toLowerCase()).toBe(ACCOUNT.toLowerCase());
 
     // Loop-closure invariant: redeemed shares must not exceed minted shares.
     // In a well-formed vault with positive yield, redeemed shares are strictly
@@ -1108,7 +1278,10 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
       validatorId: string;
     };
     expect(BigInt(boosted.amount)).toBeGreaterThan(0n);
-    expect(boosted.validatorId).toMatch(/^\d+$/);
+    // The originator in this test is not registered against a validator, so the
+    // vault reports validator 0. A digit-shaped assertion could not fail:
+    // validatorId is always a stringified bigint.
+    expect(boosted.validatorId).toBe("0");
     expect(outcome.results[1]?.receipt?.changes).toHaveLength(2);
   });
 });

--- a/packages/protocols/fastlane/test/fastlane.test.ts
+++ b/packages/protocols/fastlane/test/fastlane.test.ts
@@ -486,8 +486,9 @@ describe("FastLane shMONAD staking", () => {
   });
 
   // Change order, addresses and amounts here are the ones a mainnet
-  // deposit -> boostYield run reports: the burn settles first, then the vault
-  // says whose yield it credited and what that was worth in MON.
+  // deposit -> boostYield run reported: the burn settles first, then the vault
+  // says whose yield it credited and what that was worth in MON. The MON figure
+  // follows the live exchange rate, so a fresh run reports a nearby number.
   it("parses boostYield Changes with exact identity, length, and order", async () => {
     const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
     const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {

--- a/packages/protocols/fastlane/test/fastlane.test.ts
+++ b/packages/protocols/fastlane/test/fastlane.test.ts
@@ -61,10 +61,11 @@ function depositEvent(
   owner: `0x${string}`,
   assets: bigint,
   shares: bigint,
+  emitter: `0x${string}` = FASTLANE_STAKING_ADDRESS,
 ): Change {
   return {
     kind: "event",
-    address: FASTLANE_STAKING_ADDRESS,
+    address: emitter,
     topics: encodeEventTopics({
       abi: FastLaneStakingAbi,
       eventName: "Deposit",
@@ -131,10 +132,15 @@ function completeUnstakeEvent(owner: `0x${string}`, amountMon: bigint): Change {
 // ERC-20 Transfer event: (from indexed, to indexed, value unindexed).
 // boostYield emits a Transfer moving shMON shares from the staker to the
 // yield originator.
-function transferEvent(from: `0x${string}`, to: `0x${string}`, value: bigint): Change {
+function transferEvent(
+  from: `0x${string}`,
+  to: `0x${string}`,
+  value: bigint,
+  emitter: `0x${string}` = FASTLANE_STAKING_ADDRESS,
+): Change {
   return {
     kind: "event",
-    address: FASTLANE_STAKING_ADDRESS,
+    address: emitter,
     topics: encodeEventTopics({
       abi: FastLaneStakingAbi,
       eventName: "Transfer",
@@ -192,6 +198,82 @@ describe("FastLane shMONAD staking", () => {
     expect(receipt.changes).toHaveLength(2);
     expect(changeOf(receipt.changes[0])).toBe(native);
     expect(changeOf(receipt.changes[1])).toBe(deposited);
+  });
+
+  // The simulator hands Receipt parsers the addresses the trace reported, which
+  // are lowercase, while decodeEventLog checksums the addresses it decodes. Both
+  // spellings name the same account, so endpoint binding compares them
+  // case-insensitively.
+  it("parses stake (deposit) Changes whose native endpoints are lowercase", async () => {
+    const capability = await registry.action("fastlane", "deposit", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT.toLowerCase() as `0x${string}`,
+      to: FASTLANE_STAKING_ADDRESS.toLowerCase() as `0x${string}`,
+      value: "1000000000000000000",
+    } satisfies Change;
+
+    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 10n ** 18n);
+
+    const receipt = registry.parseReceipt(capability, [native, deposited]);
+    expect(receipt.outcome).toMatchObject({ operation: "deposit", sender: ACCOUNT });
+  });
+
+  it("rejects stake (deposit) Receipt when the Deposit event comes from another emitter", async () => {
+    const capability = await registry.action("fastlane", "deposit", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: FASTLANE_STAKING_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+
+    // A validly encoded Deposit from any other contract is not FastLane
+    // evidence. Once the emitter check rejects it, the Change falls through to
+    // the ERC-20 dependency, which does not recognise a Deposit topic either.
+    const forged = depositEvent(
+      ACCOUNT,
+      ACCOUNT,
+      10n ** 18n,
+      10n ** 18n,
+      getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+    );
+
+    expect(() => registry.parseReceipt(capability, [native, forged])).toThrow(
+      "emitted an unsupported ERC-20 event",
+    );
+  });
+
+  it("rejects stake (deposit) Receipt when the staked MON does not reach FastLane", async () => {
+    const capability = await registry.action("fastlane", "deposit", ACCOUNT, {
+      amount: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Right amount, wrong destination: the MON never reaches the vault.
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+      value: "1000000000000000000",
+    } satisfies Change;
+
+    const deposited = depositEvent(ACCOUNT, ACCOUNT, 10n ** 18n, 10n ** 18n);
+
+    expect(() => registry.parseReceipt(capability, [native, deposited])).toThrow(
+      "FastLane deposit Receipt requires the staked MON to move from the Deposit sender to FastLane",
+    );
   });
 
   it("builds atomic redeem transaction with shares, receiver, owner", async () => {
@@ -273,6 +355,36 @@ describe("FastLane shMONAD staking", () => {
     );
   });
 
+  it("rejects atomic redeem Receipt when the MON payout goes to another recipient", async () => {
+    const capability = await registry.action("fastlane", "redeem", ACCOUNT, {
+      shares: "1",
+      receiver: ACCOUNT,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Right amount, wrong recipient. Matching on the amount alone lets this
+    // through and the Receipt then names the Withdraw receiver, not the account
+    // that actually got the MON.
+    const native = {
+      kind: "nativeTransfer",
+      from: FASTLANE_STAKING_ADDRESS,
+      to: getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+      value: "990000000000000000",
+    } satisfies Change;
+
+    const withdrawn = withdrawEvent(
+      ACCOUNT,
+      ACCOUNT,
+      ACCOUNT,
+      990_000_000_000_000_000n,
+      10n ** 18n,
+    );
+
+    expect(() => registry.parseReceipt(capability, [withdrawn, native])).toThrow(
+      "FastLane redeem Receipt requires the MON payout to move from FastLane to the Withdraw receiver",
+    );
+  });
+
   it("parses requestUnstake Changes with exact identity, length, and order", async () => {
     const capability = await registry.action("fastlane", "requestUnstake", ACCOUNT, {
       shares: "1",
@@ -321,6 +433,26 @@ describe("FastLane shMONAD staking", () => {
     expect(changeOf(receipt.changes[1])).toBe(native);
   });
 
+  it("rejects completeUnstake Receipt when the MON payout goes to another recipient", async () => {
+    const capability = await registry.action("fastlane", "completeUnstake", ACCOUNT, {});
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Right amount, wrong recipient. The owner named in the Receipt never
+    // receives the MON.
+    const native = {
+      kind: "nativeTransfer",
+      from: FASTLANE_STAKING_ADDRESS,
+      to: getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+      value: "990000000000000000",
+    } satisfies Change;
+
+    const completeEvent = completeUnstakeEvent(ACCOUNT, 990_000_000_000_000_000n);
+
+    expect(() => registry.parseReceipt(capability, [completeEvent, native])).toThrow(
+      "FastLane completeUnstake Receipt requires the MON payout to move from FastLane to the CompleteUnstake owner",
+    );
+  });
+
   it("parses boostYield Changes with exact identity, length, and order", async () => {
     const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
     const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
@@ -342,6 +474,30 @@ describe("FastLane shMONAD staking", () => {
     // Identity + length + order assertions
     expect(receipt.changes).toHaveLength(1);
     expect(changeOf(receipt.changes[0])).toBe(transferred);
+  });
+
+  it("rejects boostYield Receipt when the Transfer comes from another token", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // boostYield's canonical event is the shared ERC-20 Transfer signature, so
+    // any token's Transfer decodes. Only shMON's counts as FastLane evidence;
+    // another token's is delegated to the ERC-20 dependency and leaves the
+    // boostYield outcome unsatisfied.
+    const otherToken = transferEvent(
+      ACCOUNT,
+      yieldOriginator,
+      10n ** 18n,
+      getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+    );
+
+    expect(() => registry.parseReceipt(capability, [otherToken])).toThrow(
+      "FastLane boostYield Receipt requires Transfer event",
+    );
   });
 
   it("rejects boostYield Receipt when no Transfer event is present", async () => {

--- a/packages/protocols/fastlane/test/fastlane.test.ts
+++ b/packages/protocols/fastlane/test/fastlane.test.ts
@@ -21,6 +21,8 @@ import {
 } from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+// boostYield burns the shMON it spends, so the settling Transfer lands here.
+const BURN = getAddress("0x0000000000000000000000000000000000000000");
 
 // Mock client following Kuru's offlineRegistry() pattern. The mock returns
 // heterogeneous types per functionName, so we type the parameter structurally
@@ -48,12 +50,15 @@ function createMockClient(): MossRuntime["client"] {
   } as unknown as MossRuntime["client"];
 }
 
-// Extracts the original Change from a ReceiptChange entry. FastLane Receipts
-// are flat (no nested Receipts), so every entry has kind === "change".
+// Extracts the original Change from a ReceiptChange entry. FastLane describes
+// its own events inline and delegates the rest, so an entry is either a flat
+// ReceiptChange or a single-Change ERC-20 dependency Receipt.
 function changeOf(entry: ReceiptResult["changes"][number] | undefined): Change {
   if (!entry) throw new Error("expected a ReceiptChange entry");
   if (entry.kind === "change") return entry.change;
-  throw new Error("expected a flat ReceiptChange, not a nested Receipt");
+  const [nested] = entry.changes;
+  if (entry.changes.length === 1 && nested?.kind === "change") return nested.change;
+  throw new Error("expected a flat ReceiptChange or a single-Change nested Receipt");
 }
 
 function depositEvent(
@@ -130,8 +135,7 @@ function completeUnstakeEvent(owner: `0x${string}`, amountMon: bigint): Change {
 }
 
 // ERC-20 Transfer event: (from indexed, to indexed, value unindexed).
-// boostYield emits a Transfer moving shMON shares from the staker to the
-// yield originator.
+// boostYield settles with one of these, burning the staker's shMON.
 function transferEvent(
   from: `0x${string}`,
   to: `0x${string}`,
@@ -147,6 +151,34 @@ function transferEvent(
       args: { from, to }, // indexed only
     }) as readonly Hex[],
     data: encodeAbiParameters([{ type: "uint256" }], [value]),
+  };
+}
+
+// FastLane BoostYield event: (sender, yieldOriginator, validatorId indexed;
+// amount, sharesBurned unindexed). This is the canonical boostYield evidence:
+// it names the credited originator, which the burn Transfer cannot.
+function boostYieldEvent(
+  sender: `0x${string}`,
+  yieldOriginator: `0x${string}`,
+  amount: bigint,
+  options: {
+    validatorId?: bigint;
+    sharesBurned?: boolean;
+    emitter?: `0x${string}`;
+  } = {},
+): Change {
+  return {
+    kind: "event",
+    address: options.emitter ?? FASTLANE_STAKING_ADDRESS,
+    topics: encodeEventTopics({
+      abi: FastLaneStakingAbi,
+      eventName: "BoostYield",
+      args: { sender, yieldOriginator, validatorId: options.validatorId ?? 0n }, // indexed only
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "bool" }],
+      [amount, options.sharesBurned ?? true],
+    ),
   };
 }
 
@@ -453,6 +485,9 @@ describe("FastLane shMONAD staking", () => {
     );
   });
 
+  // Change order, addresses and amounts here are the ones a mainnet
+  // deposit -> boostYield run reports: the burn settles first, then the vault
+  // says whose yield it credited and what that was worth in MON.
   it("parses boostYield Changes with exact identity, length, and order", async () => {
     const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
     const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
@@ -461,22 +496,26 @@ describe("FastLane shMONAD staking", () => {
     });
     if (capability.kind !== "capability") throw new Error("expected capability");
 
-    const transferred = transferEvent(ACCOUNT, yieldOriginator, 10n ** 18n);
+    const burned = transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n);
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 798_909_778_210_594_794n);
 
-    const receipt = registry.parseReceipt(capability, [transferred]);
+    const receipt = registry.parseReceipt(capability, [burned, boosted]);
     expect(receipt.outcome).toEqual({
       operation: "boostYield",
-      from: ACCOUNT,
-      shares: "1000000000000000000",
+      sender: ACCOUNT,
       yieldOriginator,
+      validatorId: "0",
+      amount: "798909778210594794",
+      shares: "500000000000000000",
     });
 
     // Identity + length + order assertions
-    expect(receipt.changes).toHaveLength(1);
-    expect(changeOf(receipt.changes[0])).toBe(transferred);
+    expect(receipt.changes).toHaveLength(2);
+    expect(changeOf(receipt.changes[0])).toBe(burned);
+    expect(changeOf(receipt.changes[1])).toBe(boosted);
   });
 
-  it("rejects boostYield Receipt when the Transfer comes from another token", async () => {
+  it("preserves another token's Transfer through the ERC-20 dependency Receipt", async () => {
     const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
     const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
       shares: "1",
@@ -484,23 +523,27 @@ describe("FastLane shMONAD staking", () => {
     });
     if (capability.kind !== "capability") throw new Error("expected capability");
 
-    // boostYield's canonical event is the shared ERC-20 Transfer signature, so
-    // any token's Transfer decodes. Only shMON's counts as FastLane evidence;
-    // another token's is delegated to the ERC-20 dependency and leaves the
-    // boostYield outcome unsatisfied.
-    const otherToken = transferEvent(
+    const burned = transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n);
+    // Another token moving in the same transaction is not a boostYield
+    // candidate, so it neither competes with the burn nor gets dropped.
+    const unrelated = transferEvent(
       ACCOUNT,
       yieldOriginator,
-      10n ** 18n,
+      42n,
       getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
     );
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 798_909_778_210_594_794n);
 
-    expect(() => registry.parseReceipt(capability, [otherToken])).toThrow(
-      "FastLane boostYield Receipt requires Transfer event",
-    );
+    const receipt = registry.parseReceipt(capability, [burned, unrelated, boosted]);
+    expect(receipt.outcome).toMatchObject({
+      operation: "boostYield",
+      shares: "500000000000000000",
+    });
+    expect(receipt.changes).toHaveLength(3);
+    expect(changeOf(receipt.changes[1])).toBe(unrelated);
   });
 
-  it("rejects boostYield Receipt when no Transfer event is present", async () => {
+  it("rejects boostYield Receipt when the BoostYield event comes from another emitter", async () => {
     const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
     const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
       shares: "1",
@@ -508,10 +551,135 @@ describe("FastLane shMONAD staking", () => {
     });
     if (capability.kind !== "capability") throw new Error("expected capability");
 
-    // Empty Changes must not satisfy the boostYield Receipt, which requires a
-    // Transfer event as the canonical outcome source.
+    const burned = transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n);
+    // A validly encoded BoostYield from any other contract is not FastLane
+    // evidence. Once the emitter check rejects it, the Change falls through to
+    // the ERC-20 dependency, which does not recognise a BoostYield topic.
+    const forged = boostYieldEvent(ACCOUNT, yieldOriginator, 10n ** 18n, {
+      emitter: getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+    });
+
+    expect(() => registry.parseReceipt(capability, [burned, forged])).toThrow(
+      "emitted an unsupported ERC-20 event",
+    );
+  });
+
+  it("rejects boostYield Receipt when a second FastLane Transfer competes with the burn", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Two valid shMON Transfers with different recipients and amounts. Nothing
+    // in a single-outcome Receipt distinguishes them, so keeping the first would
+    // name it canonical without evidence.
+    const burned = transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n);
+    const second = transferEvent(ACCOUNT, yieldOriginator, 7n * 10n ** 17n);
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 798_909_778_210_594_794n);
+
+    expect(() => registry.parseReceipt(capability, [burned, second, boosted])).toThrow(
+      "FastLane boostYield Receipt requires exactly one FastLane shMON Transfer",
+    );
+  });
+
+  it("rejects boostYield Receipt when a second BoostYield event competes", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    const burned = transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n);
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 798_909_778_210_594_794n);
+    const other = boostYieldEvent(
+      ACCOUNT,
+      getAddress("0x2222222222222222222222222222222222222222"),
+      1n,
+    );
+
+    expect(() => registry.parseReceipt(capability, [burned, boosted, other])).toThrow(
+      "FastLane boostYield Receipt requires exactly one FastLane BoostYield event",
+    );
+  });
+
+  it("rejects boostYield Receipt when no BoostYield event is present", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Empty Changes must not satisfy the boostYield Receipt. Neither may a
+    // burn on its own: without the event nothing says whose yield it credited.
     expect(() => registry.parseReceipt(capability, [])).toThrow(
-      "FastLane boostYield Receipt requires Transfer event",
+      "FastLane boostYield Receipt requires exactly one FastLane BoostYield event",
+    );
+    expect(() =>
+      registry.parseReceipt(capability, [transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n)]),
+    ).toThrow("FastLane boostYield Receipt requires exactly one FastLane BoostYield event");
+  });
+
+  it("rejects boostYield Receipt when the burn does not come from the BoostYield sender", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // Right amount, wrong staker: someone else's shMON was burned, so the
+    // Receipt would credit this account for shares it never spent.
+    const burned = transferEvent(
+      getAddress("0xdddddddddddddddddddddddddddddddddddddddd"),
+      BURN,
+      5n * 10n ** 17n,
+    );
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 798_909_778_210_594_794n);
+
+    expect(() => registry.parseReceipt(capability, [burned, boosted])).toThrow(
+      "FastLane boostYield Receipt requires the boosted shMON to be burned from the BoostYield sender",
+    );
+  });
+
+  it("rejects boostYield Receipt when the shMON moves somewhere instead of being burned", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // A plain shMON transfer to the originator is what an unbound Receipt used
+    // to accept as the boostYield outcome. The shares path burns instead.
+    const moved = transferEvent(ACCOUNT, yieldOriginator, 5n * 10n ** 17n);
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 798_909_778_210_594_794n);
+
+    expect(() => registry.parseReceipt(capability, [moved, boosted])).toThrow(
+      "FastLane boostYield Receipt requires the boosted shMON to be burned from the BoostYield sender",
+    );
+  });
+
+  it("rejects boostYield Receipt when the event reports no shares were burned", async () => {
+    const yieldOriginator = getAddress("0x1111111111111111111111111111111111111111");
+    const capability = await registry.action("fastlane", "boostYield", ACCOUNT, {
+      shares: "1",
+      yieldOriginator,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+
+    // sharesBurned === false is the payable MON path, which this Capability
+    // never builds. Its Changes cannot be evidence for the shares call.
+    const burned = transferEvent(ACCOUNT, BURN, 5n * 10n ** 17n);
+    const boosted = boostYieldEvent(ACCOUNT, yieldOriginator, 10n ** 18n, {
+      sharesBurned: false,
+    });
+
+    expect(() => registry.parseReceipt(capability, [burned, boosted])).toThrow(
+      "FastLane boostYield Receipt requires the shares-burning boostYield path",
     );
   });
 
@@ -883,12 +1051,14 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
 
   // Chains stake (deposit) -> boostYield in a single simulate call so the
   // simulator's mergeDiff persists the minted shMON balance into state
-  // overrides before boostYield runs. boostYield transfers shMON shares from
-  // the staker to a yield originator. This verifies the boostYield transaction
-  // is constructed correctly and reaches the contract on Monad mainnet.
-  // boostYield may revert if the yield originator is not registered on-chain;
-  // a revert here proves correct ABI encoding and contract construction, not a
-  // client-side failure — mirroring the completeUnstake epoch-gate test pattern.
+  // overrides before boostYield runs. The shares path burns the staker's shMON
+  // and credits the yield originator, so mainnet reports two Changes from the
+  // vault: Transfer(staker -> zero address) then BoostYield naming the
+  // originator, the validator and the MON the burn was worth. The Receipt has
+  // to bind them, so this asserts a clean Receipt rather than tolerating a
+  // halt: an unbound parser dropped the BoostYield Change into the ERC-20
+  // dependency and halted the run with RECEIPT_FAILED, which a
+  // halt-tolerant assertion would have reported as a pass.
   it("simulates boostYield after stake via state chaining", {
     timeout: 240_000,
   }, async () => {
@@ -917,23 +1087,27 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("FastLane mainnet", () => {
       receipt: (node, changes) => registry.parseReceipt(node, changes),
     }).simulate(combined);
 
-    // stake (deposit) must always succeed with zero Warnings.
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results).toHaveLength(2);
     expect(outcome.results[0]?.warnings).toEqual([]);
     expect(outcome.results[0]?.receipt?.outcome).toMatchObject({ operation: "deposit" });
 
-    // boostYield either succeeds (zero Warnings, clean Receipt) or halts
-    // on-chain (e.g. insufficient uncommitted shares, unregistered yield
-    // originator, or estimation failure). A halt at index 1 proves the
-    // boostYield transaction was constructed correctly and reached the
-    // contract — the failure is due to on-chain state, not a client-side
-    // ABI encoding or construction error.
-    if (outcome.halted) {
-      expect(outcome.halted.transactionIndex).toBe(1);
-    } else {
-      expect(outcome.results[1]?.warnings).toEqual([]);
-      expect(outcome.results[1]?.receipt?.outcome).toMatchObject({
-        operation: "boostYield",
-      });
-    }
+    expect(outcome.results[1]?.reverted).toBe(false);
+    expect(outcome.results[1]?.warnings).toEqual([]);
+    // The burn is exactly the shares the Capability asked for; the MON it was
+    // worth follows the live exchange rate, so assert it is positive, not fixed.
+    expect(outcome.results[1]?.receipt?.outcome).toMatchObject({
+      operation: "boostYield",
+      sender: ACCOUNT,
+      yieldOriginator,
+      shares: "500000000000000000",
+    });
+    const boosted = outcome.results[1]?.receipt?.outcome as {
+      amount: string;
+      validatorId: string;
+    };
+    expect(BigInt(boosted.amount)).toBeGreaterThan(0n);
+    expect(boosted.validatorId).toMatch(/^\d+$/);
+    expect(outcome.results[1]?.receipt?.changes).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## What and why

Implements the two Receipt evidence gaps pillowtalk-Qy reported on
[#12](https://github.com/nishuzumi/moss/issues/12) (2026-07-22) against
`adapter/fastlane@97cc076`, plus the `boostYield` Receipt ambiguity they raised
reviewing this PR on 2026-08-01. Their third #12 finding, the `completeUnstake` risk
label, is left alone and raised as a question at the bottom. Targets `adapter/fastlane` per your
2026-07-21 note on #12.

**1. The decode path did not check the emitter.** `tryDecodeFastLaneEvent()` decoded by
topics and data only, so a validly encoded FastLane event from any other contract was
accepted as FastLane evidence. `boostYield` is the sharp edge: its canonical event is the
shared ERC-20 `Transfer` signature, which every token on Monad emits, so an unrelated
token movement in the same transaction could satisfy the Receipt and the Outcome would
report shMON shares that never moved. The decode path now rejects anything the staking
vault did not emit, and those Changes fall through to the ERC-20 dependency exactly as
unrecognised logs already did. Same shape as `kuru.ts:160` and `pancakeswap-v2.ts:198`.

**2. Native transfers were matched on amount alone.** `depositReceipt`, `redeemReceipt`
and `completeUnstakeReceipt` compared `nativeTransfer.value` to the event amount and
never looked at `from` or `to`. Redeem and completeUnstake therefore accepted the right
amount of MON reaching an unrelated account while the top-level Receipt still named the
`Withdraw` receiver or the `CompleteUnstake` owner. Each parser now binds the transfer to
its event, as proposed in the review:

- deposit: `Deposit.sender` -> FastLane
- redeem: FastLane -> `Withdraw.receiver`
- completeUnstake: FastLane -> `CompleteUnstake.owner`

Comparisons are case-insensitive. The simulator passes through the lowercase addresses
the trace reported while `decodeEventLog` checksums what it decodes, so `===` would pass
offline fixtures written with checksummed constants and then fail every live test. There
is a positive test pinning the lowercase path.

`requestUnstakeReceipt` is unchanged: it has no native transfer to bind, confirmed on
chain (below).

**3. `boostYield` read its outcome from the wrong event.** Raised reviewing this PR. The
Receipt keyed on the shMON `Transfer` and kept the first one it saw, so a second valid
FastLane `Transfer` only had to exist to be ignored. Tracing the flow the Capability
actually builds turned up more than the ambiguity. A mainnet `deposit` -> `boostYield`
run reports two Changes from the vault:

```
[0] Transfer(from=account, to=0x0000…0000, value=500000000000000000)
[1] BoostYield(sender=account, yieldOriginator=0x1111…1111, validatorId=0,
               amount=798909778210594794, sharesBurned=true)
```

The shares path burns the shMON, so `Transfer.to` is the burn address and the Outcome
reported `yieldOriginator: 0x0000…0000` on every call. And because `BoostYield` decoded
as a FastLane event that was not `Transfer`, it fell through to the ERC-20 dependency,
which threw `Unexpected Change: 0x1b6862…e19c emitted an unsupported ERC-20 event`. Every
mainnet `boostYield` Receipt failed that way, on `97cc076` and on `6e56fef`.

`boostYieldReceipt` now keys on `BoostYield`, which is FastLane specific and names the
account whose yield was credited, and requires:

- exactly one FastLane `BoostYield` event, so a second one cannot be quietly dropped
- exactly one FastLane shMON `Transfer`, which is the requirement in the review
- that Transfer burned from `BoostYield.sender`, binding the cost to the operation the
  same way finding 2 binds the native transfers
- `sharesBurned` true, since this Capability only ever builds the shares overload

Transfers from other emitters are untouched and still pass through the ERC-20 dependency
Receipt, with a test pinning that. The Outcome now carries `sender`, `yieldOriginator`,
`validatorId`, `amount` and `shares`.

The e2e test hid this. It asserted only that any halt landed at index 1, on the theory
that `boostYield` might revert for an unregistered originator. It does not revert: it
succeeds, and the halt was our own Receipt failing. That test now asserts no halt, zero
Warnings, a two-Change Receipt and burned shares equal to the requested amount.

## Type of change

- [x] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [x] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

`@themoss/protocol-fastlane` only. No Capability tree change, no Change ordering change.
One exported type changes: `BoostYieldOutcome` gains `sender`, `validatorId` and `amount`
and drops `from`, replacing a shape whose `yieldOriginator` was in fact the burn address.
The package is unreleased on this integration branch, so nothing downstream reads the old
shape. Receipt behavior is otherwise stricter: evidence that used to parse and should not
have now throws. Legitimate flows are untouched, which the live Monad-mainnet cases still
prove, and `boostYield` returns a clean mainnet Receipt where it previously could not.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

### Protocol changes

- [x] Parameters separate reusable Zod value types from field-purpose descriptions
- [x] Every Capability owns one direct TransactionNode and one typed Receipt
- [x] Receipt tests preserve every original Change object in exact length and order
- [x] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [x] Fixed addresses and ABIs include sources and verification
- [x] A live Monad happy path returns zero Warnings

## Evidence

**Both findings reproduce on `97cc076`.** I wrote a failing test per defect before
writing any fix. Five of five new negative tests failed to throw against the unmodified
branch:

```
× rejects stake (deposit) Receipt when the Deposit event comes from another emitter
× rejects stake (deposit) Receipt when the staked MON does not reach FastLane
× rejects atomic redeem Receipt when the MON payout goes to another recipient
× rejects completeUnstake Receipt when the MON payout goes to another recipient
× rejects boostYield Receipt when the Transfer comes from another token
```

That last test has since been replaced. Finding 3 moved the canonical evidence to
`BoostYield`, so the emitter check is now proven with a forged `BoostYield` from an
unrelated address instead of a forged `Transfer`.

**A second pass over the negatives** found the endpoint fixtures only covered the
destination of each native transfer. Three more fail to throw against `97cc076`, so they
pin bindings this branch adds:

```
× rejects stake (deposit) Receipt when someone else paid the staked MON
× rejects atomic redeem Receipt when the MON payout does not come from the vault
× rejects completeUnstake Receipt when the MON payout does not come from the vault
```

Two more pin the amount cross-check on deposit and completeUnstake, which only redeem had
a fixture for. Those throw on `97cc076` already: the guard predates this branch, it just
had no test. The sixth offers another token's burn as the boostYield shMON `Transfer`,
same account and same amount. On `97cc076` that parsed into a complete Receipt with no
FastLane Change in the transaction at all:

```
changes: [Transfer(from=account, to=0x0000…0000, value=500000000000000000)]
          emitted by 0xdddd…dddd, not by the vault

outcome: {"operation":"boostYield","from":"0xCcCC…ccC",
          "shares":"500000000000000000",
          "yieldOriginator":"0x0000000000000000000000000000000000000000"}
```

**Finding 3 reproduces the same way**, on the base branch and on the first round of this
PR. Same live `deposit` -> `boostYield` simulate, parsed with each revision of the
adapter:

```
97cc076  halted: {"transactionIndex":1,"reason":"Unexpected Change:
                  0x1b68626dca36c7fe922fd2d55e4f631d962de19c emitted an
                  unsupported ERC-20 event"}
         warnings: [{"code":"RECEIPT_FAILED", ...}]      outcome: null

8357d33  halted: undefined      warnings: []
         outcome: {"operation":"boostYield","sender":"0xCcCC…ccC",
                   "yieldOriginator":"0x1111…1111","validatorId":"0",
                   "amount":"798909783733367342","shares":"500000000000000000"}
```

`amount` tracks the vault exchange rate, so it lands on a nearby figure each run.

**Endpoints verified on Monad mainnet**, not assumed, via `eth_getLogs` +
`debug_traceTransaction` (`callTracer`, `withLog`) on `rpc.monad.xyz`:

- `Deposit`, tx `0x0395c5897737c1fc9f98310b5beca97502895e1992f47805787aa08b0fe0c30b`
  (block 92047658): `Deposit(sender=0xA0f75A…295c, assets=3000000000000000000)` with a
  single native frame `0xa0f75a…295c -> 0x1b6862…e19c` value `3000000000000000000`.
- `CompleteUnstake`, tx `0xf18ff4f892de84b9cafbaf123788cedf6533578c857d42716d88886ac4d4ef13`
  (block 92055123): `CompleteUnstake(owner=0xb0cEFB…4844, amountMon=50689525597041489268)`
  with the first native frame `0x1b6862…e19c -> 0xb0cefb…4844` value `50689525597041489268`.
  This one matters because the epoch gate makes a successful `completeUnstake`
  unreachable inside one simulate call, so a real completion is the only way to settle
  that binding.
- `RequestUnstake`, tx `0x179e0f02cf214b4649d22c9f4af58a75d491a52e49b97135924dcde286661594`
  (block 92036627): no native value frames, confirming `requestUnstakeReceipt` needs no
  binding.
- The atomic redeem endpoints come from the live state-chained simulate, which is the
  flow the Capability builds: `nativeTransfer 0x1b6862…e19c -> account`, value equal to
  `Withdraw.assets`.

**Test counts.** Baseline on `97cc076`: 208 passing, FastLane 23/23 with 9
Monad-mainnet cases (matches your 2026-07-22 numbers). After findings 1 and 2: 214
passing, FastLane 29/29. After finding 3: 220 passing, FastLane 35/35, the same 9 mainnet
cases green with zero Warnings on the stake, redeem and boostYield happy paths. The
boostYield mainnet case is a real pass now rather than a tolerated halt. After the second
pass over the negatives and three tightened live assertions: 226 passing across 25 files,
FastLane 41/41. `pnpm test:offline` is 209 passing with 17 skipped.

**Three live assertions could not fail**, so they are pinned now. The stake -> redeem loop
accepted `changes.length >= 2` per leg where mainnet reports three, and it now names both
endpoints of each native transfer from the Receipt instead of trusting the parser that
bound them. `boostYield` matched `validatorId` against `/^\d+$/`, which a stringified
bigint always satisfies, so it is pinned to `"0"`. The `completeUnstake` epoch-gate case
accepted a halt at index 2 with `reverted` true, which a `RECEIPT_FAILED` halt also
reaches, so the warning code is pinned to `REVERTED`.

`pnpm test:abi:online` was not run: `MONADSCAN_API_KEY` is unavailable here, the same
gap noted on #12. That suite covers ABI derivation and is untouched by this change.

## One question left open: `completeUnstake`'s risk label

pillowtalk-Qy's third finding. I have not changed the label, because I do not think the
closed set currently admits a correct answer and guessing at one seemed worse than
asking.

Reading the branch as it stands: `fundOut` was settled in #114 as "assets leave the
account in this transaction", and `completeUnstake` is inflow-only under that reading,
since `requestUnstake` already committed the shMON in an earlier transaction and the
mainnet trace above shows the only value flow pointing at the owner. But `RISK_LABELS` is
still `["fundOut", "approval", "priceImpact"]`, `registry.ts:293` rejects `risk: []`, and
#119's `debt` would not fit either: completion discharges an obligation rather than
creating one. (#119 has since landed on main. It only widened `RISK_LABELS` and touches no
fastlane file, so nothing here moves because of it.) tiyadegure raised the identical case
for aPriori's `claim` on #104.

So, either:

- **(a)** `fundOut` is deliberately broad enough to cover "this Capability is part of a
  flow where funds left", in which case say so and I will note it in a comment and close
  the question; or
- **(b)** the closed set needs a pure-inflow entry.

I would go with (b) and add `fundIn` in a separate core PR alongside #119's `debt`:
`fundOut` and `debt` both describe the account getting worse off, and there is currently
no way to say "this transaction only pays you". It covers FastLane `completeUnstake`,
aPriori `claim` and every future claim or harvest Capability, without relaxing the
non-empty invariant that makes `risk` worth reading. Relaxing Registry to allow
`risk: []` would fix this case by giving up the closed-set signal, so I would not pick
that. Happy to open that core PR, or to implement whatever you decide here.

For now the label is unchanged with a comment at the declaration recording why, mirroring
what #104 does for aPriori's `claim`.

---

AI assistance (Claude, Anthropic) was used in developing this change. The design, review
and verification were done by the author. Verified locally before submitting: `pnpm lint`
(biome, 136 files, clean), `pnpm build`, `pnpm typecheck` (all packages), and the full
live `pnpm test` suite at 226 passing across 25 files, with FastLane at 41/41 including 9
Monad-mainnet cases, plus `pnpm test:offline` at 209 passing with 17 skipped.
`pnpm test:abi:online` was not run for lack of a `MONADSCAN_API_KEY`.

---
