### PR TITLE
ci: allow Pendle's market discovery API through the egress policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
             api.kuru.io:443
+            api-v2.pendle.finance:443
             rpc.monad.xyz:443
             moss-rpc.0xmon.dev:443
 

--- a/.github/workflows/live-verify.yml
+++ b/.github/workflows/live-verify.yml
@@ -55,6 +55,7 @@ jobs:
             nodejs.org:443
             registry.npmjs.org:443
             api.kuru.io:443
+            api-v2.pendle.finance:443
             rpc.monad.xyz:443
             moss-rpc.0xmon.dev:443
 


### PR DESCRIPTION
The Pendle adapter (#109) resolves candidate markets through `https://api-v2.pendle.finance` before verifying them on-chain, so its live suites cannot run under the block-mode egress policy without it. Without this the failure reads `Pendle market discovery failed at transport: fetch failed`, which looks like an adapter defect rather than a policy gap.

Added to `ci.yml` and `live-verify.yml` only. `abi-crosscheck.yml` runs `pnpm test:abi:online`, which reaches the explorer and RPC but never protocol discovery, so its list stays as narrow as its job.
