### PR TITLE
feat(protocols): add Beets Balancer V3 DEX adapter for Monad mainnet

### DIFF
--- a/.changeset/beets-adapter.md
+++ b/.changeset/beets-adapter.md
@@ -1,0 +1,13 @@
+---
+"@themoss/protocol-beets": minor
+"@themoss/mcp-server": minor
+---
+
+Add the Beets Balancer V3 DEX adapter for Monad mainnet and compose it into
+the MCP server. Exposes `swap` (`swapSingleTokenExactIn` /
+`swapSingleTokenExactOut`), `addLiquidity` (`addLiquidityUnbalanced`), and
+`removeLiquidity` (`removeLiquiditySingleTokenExactIn`) Capabilities against
+the canonical Balancer v3 Router with native MON wrap/unwrap, plus `quote`,
+`quoteAddLiquidity`, `quoteRemoveLiquidity`, and `pool` queries. ABIs are
+vendored from balancer/balancer-deployments at a pinned commit with SHA-256
+provenance and on-chain derivation checks (`pnpm test:abi:online`).

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,14 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!**/dist", "!**/node_modules", "!**/.changeset", "!**/src/abis"]
+    "includes": [
+      "**",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/.changeset",
+      "!**/src/abis",
+      "!**/abis-src"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -26,6 +26,7 @@
     "@themoss/core": "workspace:*",
     "@themoss/erc": "workspace:*",
     "@themoss/protocol-apriori": "workspace:*",
+    "@themoss/protocol-beets": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
     "@themoss/protocol-monad-cards": "workspace:*",
     "@themoss/protocol-pancakeswap": "workspace:*",

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -1,5 +1,6 @@
 import * as erc from "@themoss/erc";
 import * as apriori from "@themoss/protocol-apriori";
+import * as beets from "@themoss/protocol-beets";
 import * as kuru from "@themoss/protocol-kuru";
 import * as monadCards from "@themoss/protocol-monad-cards";
 import * as pancakeswap from "@themoss/protocol-pancakeswap";
@@ -10,6 +11,7 @@ export const defaultProtocolModules = [
   system,
   erc,
   apriori,
+  beets,
   kuru,
   monadCards,
   pancakeswap,

--- a/packages/mcp-server/test/server.test.ts
+++ b/packages/mcp-server/test/server.test.ts
@@ -135,6 +135,30 @@ describe("moss MCP server", () => {
     expect(unstakeLoaded[0]?.params.controller).toMatchObject({
       description: expect.stringContaining("controller"),
     });
+
+    const beetsSwap = parseText(
+      await client.callTool({
+        name: "discover",
+        arguments: { protocol: "beets", verb: "swap" },
+      }),
+    ) as { protocol: string; method: string; kind: string }[];
+    expect(beetsSwap).toEqual([
+      expect.objectContaining({ protocol: "beets", method: "swap", kind: "capability" }),
+    ]);
+    const beets = parseText(
+      await client.callTool({ name: "discover", arguments: { protocol: "beets" } }),
+    ) as { protocol: string; method: string; kind: string }[];
+    expect(beets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ protocol: "beets", method: "quote", kind: "query" }),
+        expect.objectContaining({ protocol: "beets", method: "addLiquidity", kind: "capability" }),
+        expect.objectContaining({
+          protocol: "beets",
+          method: "removeLiquidity",
+          kind: "capability",
+        }),
+      ]),
+    );
   });
 
   it("round-trips a Capability tree through action JSON", async () => {

--- a/packages/protocols/beets/README.md
+++ b/packages/protocols/beets/README.md
@@ -1,0 +1,49 @@
+# @themoss/protocol-beets
+
+Moss protocol adapter for [Beets](https://beets.fi) — the Balancer V3 DEX on Monad mainnet.
+
+## Surface
+
+- `swap` — single-pool `swapSingleTokenExactIn` / `swapSingleTokenExactOut` through the canonical Balancer v3 Router, with native MON wrap/unwrap (`wethIsEth`) on both sides.
+- `addLiquidity` — single-token `addLiquidityUnbalanced`.
+- `removeLiquidity` — single-token `removeLiquiditySingleTokenExactIn`.
+- Queries: `quote`, `quoteAddLiquidity`, `quoteRemoveLiquidity`, and `pool` (tokens, raw balances, static swap fee).
+- Receipts: Vault `Swap`, `LiquidityAdded`, and `LiquidityRemoved` events, normalising native MON round-trips.
+
+## Addresses
+
+Canonical Balancer v3 deployment on Monad mainnet, pinned from
+[balancer/balancer-deployments](https://github.com/balancer/balancer-deployments) at the commit
+recorded in `abis-src/VENDOR.json`:
+
+| Contract       | Address                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Router         | `0x9dA18982a33FD0c7051B19F0d7C76F2d5E7e017c`                                              |
+| Vault          | `0xbA1333333333a1BA1108E8412f11850A5C319bA9` |
+| VaultExtension | `0x0E8B07657D719B86e06bF0806D6729e3D528C9A9` |
+| VaultExplorer  | `0x043A2daD730d585C44FB79D2614F295D2d625412` |
+
+Pool view reads go through the read-only VaultExplorer: the VaultExtension rejects direct calls
+(`NotVaultDelegateCall`) and is only reachable through the Vault's delegatecall paths.
+
+## ABIs
+
+Deterministic pipeline, see the package scripts:
+
+- `pnpm gen:abis` — regenerate `src/abis/beets.ts` offline from `abis-src/`.
+- `pnpm update:abis [commit|latest]` — re-vendor upstream artifacts (verbatim, SHA-256 recorded in
+  `abis-src/VENDOR.json`) and regenerate.
+- `pnpm test:abi:online` — on-chain derivation checks (bytecode, contracts pinned, VaultExplorer
+  reads) against Monad mainnet.
+
+## Checks
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm lint
+pnpm test
+```
+
+Live Monad-mainnet behavior is covered by the `Beets mainnet` e2e suite (skipped when
+`MOSS_SKIP_E2E` is set).

--- a/packages/protocols/beets/abis-src/Router.json
+++ b/packages/protocols/beets/abis-src/Router.json
@@ -1,0 +1,1827 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "Router",
+  "sourceName": "contracts/Router.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IVault",
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IWETH",
+          "name": "weth",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IPermit2",
+          "name": "permit2",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "routerVersion",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        }
+      ],
+      "name": "AddressEmptyCode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "AddressInsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ErrorSelectorNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "EthTransfer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FailedInnerCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InputLengthMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InsufficientEth",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrancyGuardReentrantCall",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "bits",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "SafeCastOverflowedUintDowncast",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "SenderIsNotVault",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SwapDeadline",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "maxAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "addLiquidityCustom",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "maxAmountsIn",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBptAmountOut",
+              "type": "uint256"
+            },
+            {
+              "internalType": "enum AddLiquidityKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IRouterCommon.AddLiquidityHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "addLiquidityHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "maxAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "addLiquidityProportional",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "addLiquiditySingleTokenExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "exactAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "addLiquidityUnbalanced",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "donate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getPermit2",
+      "outputs": [
+        {
+          "internalType": "contract IPermit2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getSender",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getWeth",
+      "outputs": [
+        {
+          "internalType": "contract IWETH",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20[]",
+          "name": "tokens",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "exactAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20[]",
+              "name": "tokens",
+              "type": "address[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "exactAmountsIn",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBptAmountOut",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IRouter.InitializeHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "initializeHook",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "data",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "multicall",
+      "outputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "results",
+          "type": "bytes[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "owner",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "nonce",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IRouterCommon.PermitApproval[]",
+          "name": "permitBatch",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "permitSignatures",
+          "type": "bytes[]"
+        },
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "token",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint160",
+                  "name": "amount",
+                  "type": "uint160"
+                },
+                {
+                  "internalType": "uint48",
+                  "name": "expiration",
+                  "type": "uint48"
+                },
+                {
+                  "internalType": "uint48",
+                  "name": "nonce",
+                  "type": "uint48"
+                }
+              ],
+              "internalType": "struct IAllowanceTransfer.PermitDetails[]",
+              "name": "details",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "address",
+              "name": "spender",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "sigDeadline",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IAllowanceTransfer.PermitBatch",
+          "name": "permit2Batch",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "permit2Signature",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "multicallData",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "permitBatchAndCall",
+      "outputs": [
+        {
+          "internalType": "bytes[]",
+          "name": "results",
+          "type": "bytes[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "maxAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryAddLiquidityCustom",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "maxAmountsIn",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBptAmountOut",
+              "type": "uint256"
+            },
+            {
+              "internalType": "enum AddLiquidityKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IRouterCommon.AddLiquidityHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "queryAddLiquidityHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryAddLiquidityProportional",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryAddLiquiditySingleTokenExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "exactAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryAddLiquidityUnbalanced",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "minAmountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryRemoveLiquidityCustom",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "minAmountsOut",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxBptAmountIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "enum RemoveLiquidityKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IRouterCommon.RemoveLiquidityHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "queryRemoveLiquidityHook",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryRemoveLiquidityProportional",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "queryRemoveLiquidityRecovery",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "queryRemoveLiquidityRecoveryHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryRemoveLiquiditySingleTokenExactIn",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "queryRemoveLiquiditySingleTokenExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "enum SwapKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenIn",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenOut",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountGiven",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "limit",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IRouter.SwapSingleTokenHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "querySwapHook",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "querySwapSingleTokenExactIn",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountCalculated",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "querySwapSingleTokenExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountCalculated",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "minAmountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "removeLiquidityCustom",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "minAmountsOut",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxBptAmountIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "enum RemoveLiquidityKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IRouterCommon.RemoveLiquidityHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "removeLiquidityHook",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "minAmountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "removeLiquidityProportional",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "minAmountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "removeLiquidityRecovery",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "minAmountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "removeLiquidityRecoveryHook",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "removeLiquiditySingleTokenExactIn",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "removeLiquiditySingleTokenExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "swapSingleTokenExactIn",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "deadline",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "wethIsEth",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "swapSingleTokenExactOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "sender",
+              "type": "address"
+            },
+            {
+              "internalType": "enum SwapKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenIn",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenOut",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountGiven",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "limit",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "deadline",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "wethIsEth",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct IRouter.SwapSingleTokenHookParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "swapSingleTokenHook",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "version",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ],
+  "bytecode": "0x6101206040908082523461046557615cdc803803809161001f8285610484565b83398101916080828403126104655781516001600160a01b039283821682036104655760209081810151928584168403610465578482015195861686036104655760608201516001600160401b0392838211610465570190601f9088828401121561046557825184811161045157601f199388519a6100a4888787860116018d610484565b828c5287838301011161046557815f928c898080950191015e8b01015261010987516100cf81610469565b600b81526a14d95b99195c91dd585c9960aa1b878201528851906100f282610469565b600682526539b2b73232b960d11b888301526104a7565b60805260a0528751928311610451575f54916001928381811c91168015610447575b86821014610433578281116103f0575b50849184116001146103915750829182916101bb969798995f94610386575b50501b915f199060031b1c1916175f555b835161017681610469565b600c81526b2937baba32b921b7b6b6b7b760a11b82820152701a5cd4995d1d5c9b915d1a131bd8dad959607a1b8551926101af84610469565b601184528301526104a7565b60c05260e05261010091825251615782918261055a83396080518281816104ed0152818161099e01528181610bd20152818161111b015281816120ab0152818161291b01528181614d340152614e0a015260a0518281816103150152818161048c0152818161061a015281816107aa0152818161093e01528181610b9b01528181610d3f01528181610e9101528181610fa9015281816112b10152818161138f0152818161167601528181611ad801528181611c1801528181611cc101528181611de001528181611f89015281816121040152818161275e015281816128bb01528181612a6a01528181612b3701528181612d0201528181613644015281816138c10152818161394501528181613f0601528181614e7e015281816151df0152818161539f0152818161545c01526154ac015260c051828181614cbe0152615115015260e05182818160220152818161180e015281816118be01528181611ce201528181611d3601528181611f2b015281816122aa015281816124260152818161360201528181613af501528181613c750152818161547d0152615546015251818181611dbc015281816122d801528181612e93015281816130590152818161315b0152613b220152f35b015192505f8061015a565b83929316905f8052845f20915f5b8181106103db575098836101bb9798999a106103c3575b505050811b015f5561016b565b01515f1960f88460031b161c191690555f80806103b6565b8a83015184559285019291860191860161039f565b5f8052855f208380870160051c82019288881061042a575b0160051c019084905b82811061041f57505061013b565b5f8155018490610411565b92508192610408565b634e487b7160e01b5f52602260045260245ffd5b90607f169061012b565b634e487b7160e01b5f52604160045260245ffd5b5f80fd5b604081019081106001600160401b0382111761045157604052565b601f909101601f19168101906001600160401b0382119082101761045157604052565b90610514603a60209260405193849181808401977f62616c616e6365722d6c6162732e76332e73746f726167652e000000000000008952805191829101603986015e830190601760f91b60398301528051928391018583015e015f8382015203601a810184520182610484565b5190205f1981019081116105455760405190602082019081526020825261053a82610469565b9051902060ff191690565b634e487b7160e01b5f52601160045260245ffdfe60806040526004361015610072575b3615610018575f80fd5b6001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016330361004a57005b7f0540ddf6000000000000000000000000000000000000000000000000000000005f5260045ffd5b5f3560e01c8063026b3d9514613d25578063086fad661461391d57806308c04793146137ff5780630ca078ec146137675780630f71088814613626578063107c279f146135e3578063175d44081461350457806319c6989f14612eb75780631bbf2e2314612e745780631d56798d14612cd957806323b3924114612ad75780633ebc54e51461295a578063452db952146127d657806351682750146126c357806353d0bb981461260e57806354fd4d50146124d15780635b343791146120dc5780635e01eb5a146120975780635f9815ff14611f5457806368a24fe014611c59578063724dba3314611b4057806372657d17146119f5578063750283bc146119785780637b03c7ba1461164857806382bf2b241461157457806382cd54fb1461132c57806394e86ef8146111a15780639de9051814610f82578063ac9650d814610f3e578063b037ed3614610dad578063b24bd57114610c63578063be5ae84114610c0e578063bf6ee3fd14610a75578063c08bc851146109dd578063c330c7be14610816578063da001f7d14610685578063e7326def14610534578063ecb2182c146103965763efd85f140361000e57346103925761023136614177565b610239614e74565b6001600160a01b039061024e602082016146d3565b610257826146d3565b9261026560408401846146e7565b9093608081013593600585101561039257836102d0610311966060856102bb5f9c9b6102ab99878f9e61029e60c06102d79d018761473b565b9a909b6040519e8f614038565b168d521660208c0152369161408f565b604089015201356060870152608086016148ac565b3691614126565b60a08201526040519485809481937f4af29ec400000000000000000000000000000000000000000000000000000000835260048301614be4565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387575f905f925f9161035d575b50610359906040519384938461426b565b0390f35b9050610359925061038091503d805f833e6103788183614054565b81019061496f565b9092610348565b6040513d5f823e3d90fd5b5f80fd5b61044c6103c55f61043e816104886103ad366145d1565b97939a92999094916103be33614e05565b9a83615191565b9790946001600160a01b039b8c96604051946103e086613feb565b33865260209e8f9116908601526040850152606084015260016080840152151560a083015260c08201526040519283917f7b03c7ba000000000000000000000000000000000000000000000000000000008c84015260248301614a8c565b03601f198101835282614054565b6040519586809481937f48c894910000000000000000000000000000000000000000000000000000000083528b60048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1918215610387576104db926104d3915f91610512575b50858082518301019101614aea565b509050614bd0565b51906104ea575b604051908152f35b5f7f00000000000000000000000000000000000000000000000000000000000000005d6104e2565b61052e91503d805f833e6105268183614054565b8101906146ad565b866104c4565b61043e6105da5f8061061661056561054b366145d1565b9161055e9b959b9a949691939a33614e05565b9a8c615191565b50916001600160a01b03956040519361057d85613feb565b3385528760209d168d8601526040850152606084015260026080840152151560a083015260c08201526040519283917f7b03c7ba000000000000000000000000000000000000000000000000000000008b84015260248301614a8c565b6040519485809481937f48c894910000000000000000000000000000000000000000000000000000000083528a60048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af180156103875761065c915f9161066b575b50838082518301019101614aea565b5050906104ea57604051908152f35b61067f91503d805f833e6105268183614054565b8461064d565b346103925760806003193601126103925761069e613f7f565b67ffffffffffffffff602435818111610392576106bf9036906004016140dd565b906106c8613fc1565b606435918211610392576107a65f929161043e61076a6106f66106f08796369060040161415c565b93614e05565b966001600160a01b03936040519161070d83613feb565b3083528560209b168b8401526040830152866060830152600160808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000008b840152602483016148f2565b6040519485809481937fedfa35680000000000000000000000000000000000000000000000000000000083528a60048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387576107ec915f916107fc575b5083808251830101910161496f565b509190506104ea57604051908152f35b61081091503d805f833e6105268183614054565b846107dd565b346103925760a06003193601126103925761082f613f7f565b67ffffffffffffffff604435818111610392576108509036906004016140dd565b91610859613f95565b91608435908111610392575f9361043e6108fd869461088861088261093a96369060040161415c565b97614e05565b966001600160a01b039485604051936108a085613feb565b30855216602084015260408301526024356060830152600360808301528660a083015260c08201526040519283917fb24bd57100000000000000000000000000000000000000000000000000000000602084015260248301614a8c565b6040519586809481937fedfa3568000000000000000000000000000000000000000000000000000000008352602060048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af19182156103875761035992610986915f916109c3575b5060208082518301019101614aea565b9093919261099b575b604051938493846145a6565b5f7f00000000000000000000000000000000000000000000000000000000000000005d61098f565b6109d791503d805f833e6105268183614054565b84610976565b61043e6105da5f806107a66109f1366141dc565b610a019993919892949933614e05565b986001600160a01b039560405193610a1885613feb565b3385528760209d168d8601526040850152606084015260016080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000008b840152602483016148f2565b608060031936011261039257610a89613f7f565b67ffffffffffffffff9060243582811161039257610aab9036906004016140dd565b906044359283151580940361039257606435908111610392575f9261043e610b5a8594610adf610b9795369060040161415c565b610ae833614e05565b986001600160a01b03958660405194610b0086613feb565b33865216602085015260408401528760608401526003608084015260a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000006020840152602483016148f2565b6040519485809481937f48c89491000000000000000000000000000000000000000000000000000000008352602060048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1801561038757610bf4575b50610bcf57005b5f7f00000000000000000000000000000000000000000000000000000000000000005d005b610c07903d805f833e6105268183614054565b5081610bc8565b34610392576020610c36610c21366144fa565b610c29614e47565b610c31614e74565b61526b565b50505f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051908152f35b3461039257610c7136614177565b610c79614e74565b6001600160a01b03610c8d602083016146d3565b610c96836146d3565b91610ca460408501856146e7565b9490608082013593600485101561039257836102d0610d3b96610cf3610d01955f9b606089878f9e61029e60c0610cdc9e018461473b565b168d521660208c0152013560408a0152369161408f565b606087015260808601614a73565b60a08201526040519485809481937f2145789700000000000000000000000000000000000000000000000000000000835260048301614c54565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387575f905f925f91610d83575b5061035990604051938493846145a6565b90506103599250610da691503d805f833e610d9e8183614054565b810190614aea565b9092610d72565b3461039257604060031936011261039257610dc6613f7f565b6001600160a01b0360405190806020937f5f9815ff000000000000000000000000000000000000000000000000000000008585015216602483015230604483015260243560648301526064825260a082019082821067ffffffffffffffff831117610f1157815f91816040527fedfa35680000000000000000000000000000000000000000000000000000000082528560a486015281837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6087610e8c60c4820182614246565b0301927f0000000000000000000000000000000000000000000000000000000000000000165af190811561038757610ed5925f92610eea575b5050828082518301019101614886565b906103596040519282849384528301906141a9565b610f0a925060a0903d90815f853e610f028285614054565b0101906146ad565b8380610ec5565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b60206003193601126103925760043567ffffffffffffffff811161039257610f76610f70610359923690600401614352565b90614cb0565b604051918291826143b1565b3461039257610f9c610f9336614294565b92919390614e05565b916001600160a01b0390817f00000000000000000000000000000000000000000000000000000000000000001691604051937fca4f280300000000000000000000000000000000000000000000000000000000855216928360048201525f81602481865afa908115610387575f9161117f575b50519461101b86614a42565b955f5b81811061115a5750505f9261043e61109c8886956110d8956040519261104384613feb565b30845260209a8b850152604084015260608301528660808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000008a840152602483016148f2565b6040519485809481937fedfa35680000000000000000000000000000000000000000000000000000000083528960048401526024830190614246565b03925af18015610387576110fc915f91611140575b5082808251830101910161496f565b505091611118575b6103596040519282849384528301906141a9565b5f7f00000000000000000000000000000000000000000000000000000000000000005d611104565b61115491503d805f833e6105268183614054565b846110ed565b806fffffffffffffffffffffffffffffffff6111786001938b614bd0565b520161101e565b61119b91503d805f833e6111938183614054565b8101906149b8565b8661100f565b6111aa3661452d565b949095939193336111ba90614e05565b97604051996111c88b61401b565b338b5260208b01600190526001600160a01b031660408b01526001600160a01b031660608a01526001600160a01b0316608089015260a088015260c087015260e08601521515610100850152369061121f92614126565b6101208301526040517f68a24fe000000000000000000000000000000000000000000000000000000000602082015291829061125e9060248301614b3f565b03601f19810183526112709083614054565b60405180927f48c894910000000000000000000000000000000000000000000000000000000082526004820160209052602482016112ad91614246565b03827f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031691815a5f948591f1918215610387575f92611310575b5060208280518101031261039257602080920151906104ea57604051908152f35b6113259192503d805f833e6105268183614054565b90826112ef565b3461039257608060031936011261039257611345613f7f565b61134d613fab565b906064359067ffffffffffffffff8211610392576113726113e89236906004016140dd565b9061137b614e47565b611383614e74565b6001600160a01b035f817f00000000000000000000000000000000000000000000000000000000000000001693604051809681927fa07d60400000000000000000000000000000000000000000000000000000000083526044358a88600486016147f6565b038183875af1938415610387575f94611550575b5080604051927fca4f28030000000000000000000000000000000000000000000000000000000084521660048301525f82602481865afa918215610387575f92611534575b505f5b82518110156114f0576114578186614bd0565b519081611469575b6001915001611444565b826114748286614bd0565b5116853b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b039182166004820152908816602482015260448101929092525f8260648183895af1918215610387576001926114e1575b5061145f565b6114ea90614007565b876114db565b610359856114fd8861510c565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6040519182916020835260208301906141a9565b6115499192503d805f833e6111938183614054565b9085611441565b61156d9194503d805f833e6115658183614054565b810190614886565b92856113fc565b5f61043e8161093a61160b61158836614491565b9061159898949295939833614e05565b986001600160a01b039687604051956115b087613feb565b3387521660208601526040850152606084015260036080840152151560a083015260c08201526040519283917f7b03c7ba00000000000000000000000000000000000000000000000000000000602084015260248301614a8c565b6040519586809481937f48c89491000000000000000000000000000000000000000000000000000000008352602060048401526024830190614246565b346103925761165636614177565b61165e614e47565b611666614e74565b6001600160a01b039060208101907f0000000000000000000000000000000000000000000000000000000000000000908382166116a2846146d3565b946116ac836146d3565b6116b960408501856146e7565b979091608086013590600482101561039257846102d061171593610cf35f9761174d9e6116ea8d60c081019061473b565b969097816040519b6116fb8d614038565b168b521660208a015260608d013560408a0152369161408f565b60a0820152604051809881927f2145789700000000000000000000000000000000000000000000000000000000835260048301614c54565b038183865af1908115610387575f955f975f9361194f575b5061176f906146d3565b9681604051987fca4f2803000000000000000000000000000000000000000000000000000000008a521660048901525f88602481875afa978815610387575f98611933575b50919560a0850192905f5b89518110156118ee576117d28184614bd0565b519081156118e557846117e5828d614bd0565b51166117f0876147e9565b806118ba575b15611838575061183260019261180b8a6146d3565b8b7f0000000000000000000000000000000000000000000000000000000000000000615575565b016117bf565b611841896146d3565b883b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201529116602482015260448101929092525f82606481838b5af1918215610387576001926118ab575b50611832565b6118b490614007565b8b6118a5565b50857f00000000000000000000000000000000000000000000000000000000000000001681146117f6565b60019150611832565b50610359886119046118ff896146d3565b61510c565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051938493846145a6565b6119489198503d805f833e6111938183614054565b96886117b4565b90925061196c91975061176f96503d805f833e610d9e8183614054565b97919690979290611765565b6119813661452d565b9490959391933361199190614e05565b976040519961199f8b61401b565b338b5260208b015f90526001600160a01b031660408b01526001600160a01b031660608a01526001600160a01b0316608089015260a088015260c087015260e08601521515610100850152369061121f92614126565b60c060031936011261039257611a09613f7f565b611a11613fab565b611a196140fb565b60a4359067ffffffffffffffff8211610392575f611ad4611a3f8294369060040161415c565b9261043e61044c611a5d611a5233614e05565b98604435908b615191565b966001600160a01b039460405192611a7484613feb565b3384528660209d168d8501526040840152606435606084015260026080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000008c840152602483016148f2565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1918215610387576104db92611b1f915f91611b26575b5085808251830101910161496f565b5050614bd0565b611b3a91503d805f833e6105268183614054565b86611b10565b61043e611bd85f80611c14611b54366141dc565b611b65999391999892949833614e05565b996001600160a01b039560405193611b7c85613feb565b3385528760209c168c86015260408501526060840152876080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000008a840152602483016148f2565b6040519485809481937f48c894910000000000000000000000000000000000000000000000000000000083528960048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387576110fc915f91611140575082808251830101910161496f565b3461039257611c67366144fa565b611c6f614e47565b611c77614e74565b611c808161526b565b611c8e6060859395016146d3565b90611c98836146d3565b94610100840195611ca8876147e9565b80611f1f575b15611d9c575094611d2b91611d066020977f00000000000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000614f16565b611d0f856146d3565b91611d25611d1f608088016146d3565b916147e9565b92615443565b6001600160a01b03807f000000000000000000000000000000000000000000000000000000000000000016911614611d8a575b505f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051908152f35b6118ff611d96916146d3565b82611d5e565b81611db0575b5050602094611d2b91611d06565b6001600160a01b0390817f00000000000000000000000000000000000000000000000000000000000000001691807f00000000000000000000000000000000000000000000000000000000000000001691611e0a85614ed2565b93803b15610392576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039283166004820152848316602482015294821660448601529187161660648401525f908390608490829084905af1908115610387575f93602093611ed093611f10575b506040519485809481937f15afd4090000000000000000000000000000000000000000000000000000000083528a60048401602090939291936001600160a01b0360408201951681520152565b03925af1801561038757611ee5575b80611da2565b602090813d8311611f09575b611efb8183614054565b810103126103925785611edf565b503d611ef1565b611f1990614007565b8a611e83565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690851614611cae565b3461039257606060031936011261039257611f6d613f7f565b611f75613fab565b611f7d614e74565b6001600160a01b0390817f000000000000000000000000000000000000000000000000000000000000000016604051927fca4f2803000000000000000000000000000000000000000000000000000000008452841660048401525f83602481845afa938415610387575f611ffe612039968296839161207d575b5051614a42565b93604051968795869485937fa07d604000000000000000000000000000000000000000000000000000000000855260443591600486016147f6565b03925af1801561038757610359915f91612063575b506040519182916020835260208301906141a9565b61207791503d805f833e6115658183614054565b8261204e565b61209191503d8085833e6111938183614054565b88611ff7565b34610392575f6003193601126103925760207f00000000000000000000000000000000000000000000000000000000000000005c6001600160a01b0360405191168152f35b34610392576120ea36614177565b6120f2614e47565b6120fa614e74565b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000008181169260209081810190612137826146d3565b95612141826146d3565b9661214f60408401846146e7565b919098608085013591600583101561039257896102d0612193946121a26121f29e5f988d866121ba996121868f60c081019061473b565b99909a6040519d8e614038565b168c5216908a0152369161408f565b604087015260608901356060870152608086016148ac565b60a0820152604051809981927f4af29ec400000000000000000000000000000000000000000000000000000000835260048301614be4565b038183855af1958615610387575f935f985f986124a8575b50612214906146d3565b81604051917fca4f28030000000000000000000000000000000000000000000000000000000083521660048201525f81602481865afa908115610387575f9161248e575b50969760a0840197905f5b825181101561244d57836122778285614bd0565b51166122838289614bd0565b519081156123e0576122948c6147e9565b80612422575b156122d45750906122ce6001928b7f0000000000000000000000000000000000000000000000000000000000000000614f16565b01612263565b90857f00000000000000000000000000000000000000000000000000000000000000001690612302896146d3565b61230b82614ed2565b833b15610392576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201528a831660248201529082166044820152908416606482015292915f908490608490829084905af1918215610387576123cc938c93612413575b5060405193849283927f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03815f8a5af19081156103875789916123ea575b50506001906122ce565b813d831161240c575b6123fd8183614054565b8101031261039257878c6123e0565b503d6123f3565b61241c90614007565b8f612381565b50857f000000000000000000000000000000000000000000000000000000000000000016811461229a565b50856103598b61245f6118ff896146d3565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6040519384938461426b565b6124a291503d805f833e6111938183614054565b89612258565b9097506124c591985061221494503d805f833e6103788183614054565b9891949098979061220a565b34610392575f600319360112610392576040515f5f549060018260011c9160018416918215612604575b60209485851084146125d75785879486865291825f14612599575050600114612540575b5061252c92500383614054565b610359604051928284938452830190614246565b5f808052859250907f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5635b85831061258157505061252c93508201018561251f565b8054838901850152879450869390920191810161256a565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00168582015261252c95151560051b850101925087915061251f9050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b92607f16926124fb565b346103925761263f6126385f8061061661076a61043e61262d36614432565b95939a929990614e05565b988a615191565b506001600160a01b03936040519161265683613feb565b3083528560209b168b84015260408301526fffffffffffffffffffffffffffffffff6060830152600260808301528660a083015260c08201526040519283917fb24bd571000000000000000000000000000000000000000000000000000000008b84015260248301614a8c565b61043e611bd85f8061275a6126d736614491565b6126e79993949892919933614e05565b996001600160a01b0395604051936126fe85613feb565b3385528760209c168c86015260408501526060840152876080840152151560a083015260c08201526040519283917f7b03c7ba000000000000000000000000000000000000000000000000000000008a84015260248301614a8c565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387576127a0915f916127bc575b50828082518301019101614aea565b50929050611118576103596040519282849384528301906141a9565b6127d091503d805f833e6105268183614054565b84612791565b346103925760a0600319360112610392576127ef613f7f565b67ffffffffffffffff602435818111610392576128109036906004016140dd565b91612819613f95565b91608435908111610392575f9361043e6108fd86946128426108826128b796369060040161415c565b966001600160a01b0394856040519361285a85613feb565b30855216602084015260408301526044356060830152600460808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000006020840152602483016148f2565b03927f0000000000000000000000000000000000000000000000000000000000000000165af19182156103875761035992612903915f91612940575b506020808251830101910161496f565b90939192612918575b6040519384938461426b565b5f7f00000000000000000000000000000000000000000000000000000000000000005d61290c565b61295491503d805f833e6105268183614054565b846128f3565b3461039257612968366142e6565b906129769094939294614e05565b936001600160a01b038093816040519661298f8861401b565b3388528160209a8b8a015f905216604089015216606087015216608085015260a084015260c083015f905260e083016fffffffffffffffffffffffffffffffff905261010083015f905261012083015260405180928582017fbe5ae8410000000000000000000000000000000000000000000000000000000090526024820190612a1891614b3f565b03601f1981018352612a2a9083614054565b6040518080937fedfa356800000000000000000000000000000000000000000000000000000000825286600483015260248201612a6691614246565b03917f00000000000000000000000000000000000000000000000000000000000000001691815a5f948591f1908115610387575f91612abd575b50828180518101031261039257820151906104ea57604051908152f35b612ad191503d805f833e6105268183614054565b83612aa0565b346103925760a060031936011261039257612af0613f7f565b612af8613fc1565b90612b01613f95565b60843567ffffffffffffffff811161039257612b24612b2a91369060040161415c565b91614e05565b916001600160a01b0391827f0000000000000000000000000000000000000000000000000000000000000000169280604051937fc9c1661b0000000000000000000000000000000000000000000000000000000085521695866004850152166024830152604082604481865afa918215610387575f905f93612c9a575b505f9361043e612c368694612bbe612c7295614a42565b906001612bcb8984614bd0565b5260405191612bd983613feb565b30835260209b8c84015260408301526024356060830152600160808301528660a083015260c08201526040519283917fb24bd571000000000000000000000000000000000000000000000000000000008c84015260248301614a8c565b6040519586809481937fedfa35680000000000000000000000000000000000000000000000000000000083528b60048401526024830190614246565b03925af1918215610387576104db926104d3915f916105125750858082518301019101614aea565b925050916040823d604011612cd1575b81612cb760409383614054565b81010312610392578151602090920151909290915f612ba7565b3d9150612caa565b3461039257612cf5612cea36614432565b929490939193614e05565b926001600160a01b0392837f0000000000000000000000000000000000000000000000000000000000000000169380604051947fc9c1661b0000000000000000000000000000000000000000000000000000000086521696876004860152166024840152604083604481875afa928315610387575f905f94612e37575b509361043e612c365f9694612e0f94612d8b8997614a42565b916fffffffffffffffffffffffffffffffff612da78a85614bd0565b5260405192612db584613feb565b30845260209c8d85015260408401526060830152600260808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000008c840152602483016148f2565b03925af1918215610387576104db92611b1f915f91611b26575085808251830101910161496f565b9350506040833d604011612e6c575b81612e5360409383614054565b810103126103925782516020909301519261043e612d72565b3d9150612e46565b34610392575f6003193601126103925760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b60a06003193601126103925767ffffffffffffffff60043511610392573660236004350112156103925767ffffffffffffffff60043560040135116103925736602460c060043560040135026004350101116103925760243567ffffffffffffffff811161039257612f2d903690600401614352565b67ffffffffffffffff60443511610392576060600319604435360301126103925760643567ffffffffffffffff811161039257612f6e903690600401614383565b60843567ffffffffffffffff811161039257612f8e903690600401614352565b949093612f99614e47565b8060043560040135036134dc575f5b6004356004013581106132295750505060443560040135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd60443536030182121561039257816044350160048101359067ffffffffffffffff82116103925760248260071b36039101136103925761304c575b610359610f7686865f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d614cb0565b6001600160a01b039492947f0000000000000000000000000000000000000000000000000000000000000000163b1561039257604051947f2a2d80d10000000000000000000000000000000000000000000000000000000086523360048701526060602487015260c486019260443501602481019367ffffffffffffffff60048301351161039257600482013560071b360385136103925760606064890152600482013590529192869260e484019291905f905b600481013582106131ab5750505082915f9461314e926001600160a01b0361312c602460443501613fd7565b16608486015260448035013560a486015260031985840301604486015261478c565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19182156103875761035993610f769361319c575b82945081935061301c565b6131a590614007565b84613191565b9195945091926001600160a01b036131c287613fd7565b168152602080870135916001600160a01b038316809303610392576004926001928201526131f26040890161517e565b65ffffffffffff809116604083015261320d60608a0161517e565b1660608201526080809101970193019050889495939291613100565b6132376102d0828486614dee565b60405180606081011067ffffffffffffffff606083011117610f1157606081016040525f81526020915f838301525f60408301528281015190606060408201519101515f1a91835283830152604082015260c07fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdc818502600435013603011261039257604051906132c782614038565b6132da602460c086026004350101613fd7565b8083526132f0604460c087026004350101613fd7565b908185850152613309606460c088026004350101613fd7565b60408581019190915260043560c08802016084810135606087015260a4810135608087015260c4013560a086015283015183519386015160ff91909116926001600160a01b0383163b15610392575f6001600160a01b03809460e4948b98849860c460c06040519c8d9b8c9a7fd505accf000000000000000000000000000000000000000000000000000000008c521660048b01523060248b0152608482820260043501013560448b0152026004350101356064880152608487015260a486015260c4850152165af190816134cd575b506134c3576133e661514f565b906001600160a01b0381511690836001600160a01b0381830151166044604051809581937fdd62ed3e00000000000000000000000000000000000000000000000000000000835260048301523060248301525afa918215610387575f92613493575b50606001510361345e5750506001905b01612fa8565b80511561346b5780519101fd5b7fa7285689000000000000000000000000000000000000000000000000000000005f5260045ffd5b9091508381813d83116134bc575b6134ab8183614054565b810103126103925751906060613448565b503d6134a1565b5050600190613458565b6134d690614007565b8a6133d9565b7faaad13f7000000000000000000000000000000000000000000000000000000005f5260045ffd5b3461039257613512366142e6565b906135209094939294614e05565b936001600160a01b03809381604051966135398861401b565b3388528160209a8b8a016001905216604089015216606087015216608085015260a084015260c083016fffffffffffffffffffffffffffffffff905260e083017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff905261010083015f905261012083015260405180928582017fbe5ae8410000000000000000000000000000000000000000000000000000000090526024820190612a1891614b3f565b34610392575f6003193601126103925760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b3461039257613637610f9336614294565b926001600160a01b0392837f00000000000000000000000000000000000000000000000000000000000000001693604051937fca4f280300000000000000000000000000000000000000000000000000000000855216938460048501525f84602481845afa9384156103875761109c5f959461372a946136c3889761043e95899161374d575051614a42565b91604051926136d184613feb565b30845260209a8b850152604084015260608301528660808301528660a083015260c08201526040519283917fb24bd571000000000000000000000000000000000000000000000000000000008a84015260248301614a8c565b03925af18015610387576127a0915f916127bc5750828082518301019101614aea565b61376191503d808b833e6111938183614054565b8c611ff7565b5f61043e816128b761160b61377b366141dc565b9061378c9894929895939533614e05565b986001600160a01b039687604051956137a487613feb565b3387521660208601526040850152606084015260046080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000006020840152602483016148f2565b606060031936011261039257613813613f7f565b60443567ffffffffffffffff8111610392575f61043e61387a61383d6138b49436906004016140dd565b6040519283916020977f82cd54fb0000000000000000000000000000000000000000000000000000000089850152602435903390602486016147f6565b604051809381927f48c894910000000000000000000000000000000000000000000000000000000083528660048401526024830190614246565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af1801561038757610ed5915f91613903575b50828082518301019101614886565b61391791503d805f833e6105268183614054565b836138f4565b346103925761392b36614177565b613933614e47565b61393b614e74565b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000006020826139728583016146d3565b9461397c816146d3565b95604082019661398c88846146e7565b9061399a60608601866146e7565b939092806139ab60c089018961473b565b6040517fba8a2be0000000000000000000000000000000000000000000000000000000008152988e1660048a01529c909316602488015260c0604488015260c487015294999460e48b0192905f5b8a828210613d0657505050506003198a83030160648b01528382527f07ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8411610392578794858b9594613a6d94879660051b8092848301370160808901356084870152601c8682030160a4870152019161478c565b03815f8689165af1948515610387575f95613cd7575b50939460a0850194905f5b613a9882846146e7565b9050811015613c9e57613abd613ab882613ab285876146e7565b906147ac565b6146d3565b613ace82613ab260608701876146e7565b35908115613c2f57613adf896147e9565b80613c71575b15613b1f575090613b19600192887f0000000000000000000000000000000000000000000000000000000000000000614f16565b01613a8e565b857f00000000000000000000000000000000000000000000000000000000000000001691613b4c866146d3565b613b5582614ed2565b843b15610392576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039283166004820152898c168316602482015290821660448201528389169091166064820152925f908490608490829084905af191821561038757613c19938993613c62575060405193849283927f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03815f898c165af1908115610387578691613c39575b5050600190613b19565b813d8311613c5b575b613c4c8183614054565b81010312610392578489613c2f565b503d613c42565b613c6b90614007565b8c612381565b50857f00000000000000000000000000000000000000000000000000000000000000001686821614613ae5565b8488613cac6118ff866146d3565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051908152f35b9094508281813d8311613cff575b613cef8183614054565b8101031261039257519386613a83565b503d613ce5565b8084968c613d176001959697613fd7565b1681520195019291016139f9565b60c060031936011261039257613d39613f7f565b6024359067ffffffffffffffff808311610392573660238401121561039257826004013591613d6783614077565b92613d756040519485614054565b80845260209460248686019260051b82010191368311610392576024879201905b838210613f68575050505060443582811161039257613db99036906004016140dd565b92613dc26140fb565b9260a43590811161039257613ddb90369060040161415c565b93613de533614e05565b946001600160a01b039460405192613dfc84613feb565b338452868985019616865260408401948552606084019081526080840194606435865260a08501921515835260c0850193845287604051977f086fad66000000000000000000000000000000000000000000000000000000008c8a01528b60248a0152816101248a0197511660448a015251166064880152519360e0608488015284518091528961014488019501905f5b8b828210613f5257505050509461043e613f02955f989583956105da95613ee28c9b51937fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbc94858983030160a48a0152614634565b935160c487015251151560e4860152519084830301610104850152614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1908115610387575f91612abd5750828180518101031261039257820151906104ea57604051908152f35b83518b1688529687019690920191600101613e8d565b828091613f7484613fd7565b815201910190613d96565b600435906001600160a01b038216820361039257565b606435906001600160a01b038216820361039257565b602435906001600160a01b038216820361039257565b604435906001600160a01b038216820361039257565b35906001600160a01b038216820361039257565b60e0810190811067ffffffffffffffff821117610f1157604052565b67ffffffffffffffff8111610f1157604052565b610140810190811067ffffffffffffffff821117610f1157604052565b60c0810190811067ffffffffffffffff821117610f1157604052565b90601f601f19910116810190811067ffffffffffffffff821117610f1157604052565b67ffffffffffffffff8111610f115760051b60200190565b929161409a82614077565b916140a86040519384614054565b829481845260208094019160051b810192831161039257905b8282106140ce5750505050565b813581529083019083016140c1565b9080601f83011215610392578160206140f89335910161408f565b90565b60843590811515820361039257565b67ffffffffffffffff8111610f1157601f01601f191660200190565b9291926141328261410a565b916141406040519384614054565b829481845281830111610392578281602093845f960137010152565b9080601f83011215610392578160206140f893359101614126565b60031990602082820112610392576004359167ffffffffffffffff8311610392578260e0920301126103925760040190565b9081518082526020808093019301915f5b8281106141c8575050505090565b8351855293810193928101926001016141ba565b9060a0600319830112610392576004356001600160a01b0381168103610392579167ffffffffffffffff90602435828111610392578161421e916004016140dd565b926044359260643580151581036103925792608435918211610392576140f89160040161415c565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b6142816140f894926060835260608301906141a9565b9260208201526040818403910152614246565b6080600319820112610392576001600160a01b03906004358281168103610392579260243592604435908116810361039257916064359067ffffffffffffffff8211610392576140f89160040161415c565b60c0600319820112610392576001600160a01b0391600435838116810361039257926024358181168103610392579260443582811681036103925792606435926084359081168103610392579160a4359067ffffffffffffffff8211610392576140f89160040161415c565b9181601f840112156103925782359167ffffffffffffffff8311610392576020808501948460051b01011161039257565b9181601f840112156103925782359167ffffffffffffffff8311610392576020838186019501011161039257565b6020808201906020835283518092526040830192602060408460051b8301019501935f915b8483106143e65750505050505090565b9091929394958480614422837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc086600196030187528a51614246565b98019301930191949392906143d6565b9060a0600319830112610392576001600160a01b03600435818116810361039257926024358281168103610392579260443592606435908116810361039257916084359067ffffffffffffffff8211610392576140f89160040161415c565b60a0600319820112610392576004356001600160a01b038116810361039257916024359167ffffffffffffffff9160443583811161039257826144d6916004016140dd565b9260643580151581036103925792608435918211610392576140f89160040161415c565b60031990602082820112610392576004359167ffffffffffffffff83116103925782610140920301126103925760040190565b610100600319820112610392576001600160a01b0390600435828116810361039257926024358381168103610392579260443590811681036103925791606435916084359160a4359160c4358015158103610392579160e4359067ffffffffffffffff8211610392576145a291600401614383565b9091565b916145c3906140f8949284526060602085015260608401906141a9565b916040818403910152614246565b60c0600319820112610392576001600160a01b0390600435828116810361039257926024359260443590811681036103925791606435916084358015158103610392579160a4359067ffffffffffffffff8211610392576140f89160040161415c565b9081518082526020808093019301915f5b828110614653575050505090565b835185529381019392810192600101614645565b81601f820112156103925780519061467e8261410a565b9261468c6040519485614054565b8284526020838301011161039257815f9260208093018386015e8301015290565b9060208282031261039257815167ffffffffffffffff8111610392576140f89201614667565b356001600160a01b03811681036103925790565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215610392570180359067ffffffffffffffff821161039257602001918160051b3603831361039257565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215610392570180359067ffffffffffffffff82116103925760200191813603831361039257565b601f8260209493601f1993818652868601375f8582860101520116010190565b91908110156147bc5760051b0190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b3580151581036103925790565b90926140f894936080936001600160a01b038092168452166020830152604082015281606082015201906141a9565b9080601f830112156103925781519060209161484081614077565b9361484e6040519586614054565b81855260208086019260051b82010192831161039257602001905b828210614877575050505090565b81518152908301908301614869565b9060208282031261039257815167ffffffffffffffff8111610392576140f89201614825565b60058210156148b85752565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b9060058210156148b85752565b906140f891602081526001600160a01b03808351166020830152602083015116604082015260c0614933604084015160e06060850152610100840190614634565b9260608101516080840152614950608082015160a08501906148e5565b60a081015115158284015201519060e0601f1982850301910152614246565b90916060828403126103925781519167ffffffffffffffff92838111610392578461499b918301614825565b936020820151936040830151908111610392576140f89201614667565b60209081818403126103925780519067ffffffffffffffff821161039257019180601f840112156103925782516149ee81614077565b936149fc6040519586614054565b818552838086019260051b820101928311610392578301905b828210614a23575050505090565b81516001600160a01b0381168103610392578152908301908301614a15565b90614a4c82614077565b614a596040519182614054565b828152601f19614a698294614077565b0190602036910137565b60048210156148b85752565b9060048210156148b85752565b906140f891602081526001600160a01b03808351166020830152602083015116604082015260c0614acd604084015160e06060850152610100840190614634565b9260608101516080840152614950608082015160a0850190614a7f565b916060838303126103925782519260208101519267ffffffffffffffff938481116103925781614b1b918401614825565b936040830151908111610392576140f89201614667565b9060028210156148b85752565b6101606140f892602083526001600160a01b03808251166020850152614b6d60208301516040860190614b32565b80604083015116606085015280606083015116608085015260808201511660a084015260a081015160c084015260c081015160e084015260e081015161010090818501528101519061012091151582850152015191610140808201520190614246565b80518210156147bc5760209160051b010190565b906140f891602081526001600160a01b03808351166020830152602083015116604082015260a0614c24604084015160c0606085015260e0840190614634565b9260608101516080840152614c406080820151838501906148e5565b01519060c0601f1982850301910152614246565b906140f891602081526001600160a01b0380835116602083015260208301511660408201526040820151606082015260a0614c9e606084015160c0608085015260e0840190614634565b92614c40608082015183850190614a7f565b9190614cbb33614e05565b907f000000000000000000000000000000000000000000000000000000000000000093845c614dc6576001906001865d614cf483614077565b92614d026040519485614054565b808452601f19614d1182614077565b015f5b818110614db55750505f5b818110614d6c5750505050905f614d6192945d7f0000000000000000000000000000000000000000000000000000000000000000805c91614d63575b5061510c565b565b5f905d5f614d5b565b80614d995f80614d816102d08996888a614dee565b602081519101305af4614d9261514f565b90306156e8565b614da38288614bd0565b52614dae8187614bd0565b5001614d1f565b806060602080938901015201614d14565b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b908210156147bc576145a29160051b81019061473b565b905f917f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03815c1615614e3d575050565b909192505d600190565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c614dc6576001905d565b6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000163303614ea657565b7f089676d5000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b6001600160a01b0390818111614ee6571690565b7f6dfcc650000000000000000000000000000000000000000000000000000000005f5260a060045260245260445ffd5b9190918147106150e4576001600160a01b0380911692833b15610392576040918251917fd0e30db00000000000000000000000000000000000000000000000000000000083525f925f81600481898b5af180156150da576150c7575b501692825194602095868101907fa9059cbb000000000000000000000000000000000000000000000000000000008252866024820152836044820152604481526080810181811067ffffffffffffffff821117610f1157865251614fe7918591829182865af1614fe061514f565b90836156e8565b80518781151591826150a2575b5050905061507757906044869284865197889485937f15afd409000000000000000000000000000000000000000000000000000000008552600485015260248401525af191821561506d575050615049575050565b813d8311615066575b61505c8183614054565b8101031261039257565b503d615052565b51903d90823e3d90fd5b7f5274afe7000000000000000000000000000000000000000000000000000000008352600452602482fd5b83809293500103126150c3578601518015908115036150c35780875f614ff4565b8380fd5b6150d2919350614007565b5f915f614f72565b85513d5f823e3d90fd5b7fa01a9df6000000000000000000000000000000000000000000000000000000005f5260045ffd5b47801561514b577f00000000000000000000000000000000000000000000000000000000000000005c61514b576001600160a01b03614d61921661566c565b5050565b3d15615179573d906151608261410a565b9161516e6040519384614054565b82523d5f602084013e565b606090565b359065ffffffffffff8216820361039257565b916044929391936001600160a01b03604094859282808551998a9586947fc9c1661b0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa938415615261575f935f9561522a575b50506152276152208594614a42565b9485614bd0565b52565b809295508194503d831161525a575b6152438183614054565b810103126103925760208251920151925f80615211565b503d615239565b83513d5f823e3d90fd5b60e0810135421161541b576001600160a01b0360208201359160028310156103925760409261529b8285016146d3565b928060609485938486016152ae906146d3565b956152bb608082016146d3565b90846152cb61012083018361473b565b91908c51956152d987613feb565b8652816020870197168752818d87019b168b52818a870195168552608086019260a0850135845260a087019460c001358552369061531692614126565b9360c08601948552818d519b8c9a8b998a997f2bfb780c000000000000000000000000000000000000000000000000000000008b5260048b016020905260248b0190519061536391614b32565b5116604489015251166064870152511660848501525160a48401525160c48301525160e4820160e09052610104820161539b91614246565b03917f0000000000000000000000000000000000000000000000000000000000000000165a905f91f1908115615261575f935f935f936153de575b505050909192565b92509250809350813d8311615414575b6153f88183614054565b81010312610392578151602083015191909201515f80806153d6565b503d6153ee565b7fe08b8af0000000000000000000000000000000000000000000000000000000005f5260045ffd5b92821561556f578061553a575b156154a15750614d61917f00000000000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000615575565b906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016803b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03938416600482015293909216602484015260448301525f908290606490829084905af18015610387576155315750565b614d6190614007565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690821614615450565b50505050565b9392916001600160a01b03809216803b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081525f816064818388819c16968760048401523060248401528a60448401525af1801561038757615659575b508086913b156156555781906024604051809481937f2e1a7d4d0000000000000000000000000000000000000000000000000000000083528960048401525af1801561564a57615632575b50614d619394501661566c565b61563c8691614007565b6156465784615625565b8480fd5b6040513d88823e3d90fd5b5080fd5b615664919650614007565b5f945f6155da565b8147106156bc575f8080936001600160a01b038294165af161568c61514f565b501561569457565b7f1425ea42000000000000000000000000000000000000000000000000000000005f5260045ffd5b7fcd786059000000000000000000000000000000000000000000000000000000005f523060045260245ffd5b906156fd575080511561569457805190602001fd5b81511580615743575b61570e575090565b6001600160a01b03907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b50803b1561570656fea26469706673582212204e7d6ff674984d91fa2ea97e805c1b2a23fe7676d6d8a92cac923b6993f6f51964736f6c634300081b0033",
+  "deployedBytecode": "0x60806040526004361015610072575b3615610018575f80fd5b6001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016330361004a57005b7f0540ddf6000000000000000000000000000000000000000000000000000000005f5260045ffd5b5f3560e01c8063026b3d9514613d25578063086fad661461391d57806308c04793146137ff5780630ca078ec146137675780630f71088814613626578063107c279f146135e3578063175d44081461350457806319c6989f14612eb75780631bbf2e2314612e745780631d56798d14612cd957806323b3924114612ad75780633ebc54e51461295a578063452db952146127d657806351682750146126c357806353d0bb981461260e57806354fd4d50146124d15780635b343791146120dc5780635e01eb5a146120975780635f9815ff14611f5457806368a24fe014611c59578063724dba3314611b4057806372657d17146119f5578063750283bc146119785780637b03c7ba1461164857806382bf2b241461157457806382cd54fb1461132c57806394e86ef8146111a15780639de9051814610f82578063ac9650d814610f3e578063b037ed3614610dad578063b24bd57114610c63578063be5ae84114610c0e578063bf6ee3fd14610a75578063c08bc851146109dd578063c330c7be14610816578063da001f7d14610685578063e7326def14610534578063ecb2182c146103965763efd85f140361000e57346103925761023136614177565b610239614e74565b6001600160a01b039061024e602082016146d3565b610257826146d3565b9261026560408401846146e7565b9093608081013593600585101561039257836102d0610311966060856102bb5f9c9b6102ab99878f9e61029e60c06102d79d018761473b565b9a909b6040519e8f614038565b168d521660208c0152369161408f565b604089015201356060870152608086016148ac565b3691614126565b60a08201526040519485809481937f4af29ec400000000000000000000000000000000000000000000000000000000835260048301614be4565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387575f905f925f9161035d575b50610359906040519384938461426b565b0390f35b9050610359925061038091503d805f833e6103788183614054565b81019061496f565b9092610348565b6040513d5f823e3d90fd5b5f80fd5b61044c6103c55f61043e816104886103ad366145d1565b97939a92999094916103be33614e05565b9a83615191565b9790946001600160a01b039b8c96604051946103e086613feb565b33865260209e8f9116908601526040850152606084015260016080840152151560a083015260c08201526040519283917f7b03c7ba000000000000000000000000000000000000000000000000000000008c84015260248301614a8c565b03601f198101835282614054565b6040519586809481937f48c894910000000000000000000000000000000000000000000000000000000083528b60048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1918215610387576104db926104d3915f91610512575b50858082518301019101614aea565b509050614bd0565b51906104ea575b604051908152f35b5f7f00000000000000000000000000000000000000000000000000000000000000005d6104e2565b61052e91503d805f833e6105268183614054565b8101906146ad565b866104c4565b61043e6105da5f8061061661056561054b366145d1565b9161055e9b959b9a949691939a33614e05565b9a8c615191565b50916001600160a01b03956040519361057d85613feb565b3385528760209d168d8601526040850152606084015260026080840152151560a083015260c08201526040519283917f7b03c7ba000000000000000000000000000000000000000000000000000000008b84015260248301614a8c565b6040519485809481937f48c894910000000000000000000000000000000000000000000000000000000083528a60048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af180156103875761065c915f9161066b575b50838082518301019101614aea565b5050906104ea57604051908152f35b61067f91503d805f833e6105268183614054565b8461064d565b346103925760806003193601126103925761069e613f7f565b67ffffffffffffffff602435818111610392576106bf9036906004016140dd565b906106c8613fc1565b606435918211610392576107a65f929161043e61076a6106f66106f08796369060040161415c565b93614e05565b966001600160a01b03936040519161070d83613feb565b3083528560209b168b8401526040830152866060830152600160808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000008b840152602483016148f2565b6040519485809481937fedfa35680000000000000000000000000000000000000000000000000000000083528a60048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387576107ec915f916107fc575b5083808251830101910161496f565b509190506104ea57604051908152f35b61081091503d805f833e6105268183614054565b846107dd565b346103925760a06003193601126103925761082f613f7f565b67ffffffffffffffff604435818111610392576108509036906004016140dd565b91610859613f95565b91608435908111610392575f9361043e6108fd869461088861088261093a96369060040161415c565b97614e05565b966001600160a01b039485604051936108a085613feb565b30855216602084015260408301526024356060830152600360808301528660a083015260c08201526040519283917fb24bd57100000000000000000000000000000000000000000000000000000000602084015260248301614a8c565b6040519586809481937fedfa3568000000000000000000000000000000000000000000000000000000008352602060048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af19182156103875761035992610986915f916109c3575b5060208082518301019101614aea565b9093919261099b575b604051938493846145a6565b5f7f00000000000000000000000000000000000000000000000000000000000000005d61098f565b6109d791503d805f833e6105268183614054565b84610976565b61043e6105da5f806107a66109f1366141dc565b610a019993919892949933614e05565b986001600160a01b039560405193610a1885613feb565b3385528760209d168d8601526040850152606084015260016080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000008b840152602483016148f2565b608060031936011261039257610a89613f7f565b67ffffffffffffffff9060243582811161039257610aab9036906004016140dd565b906044359283151580940361039257606435908111610392575f9261043e610b5a8594610adf610b9795369060040161415c565b610ae833614e05565b986001600160a01b03958660405194610b0086613feb565b33865216602085015260408401528760608401526003608084015260a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000006020840152602483016148f2565b6040519485809481937f48c89491000000000000000000000000000000000000000000000000000000008352602060048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1801561038757610bf4575b50610bcf57005b5f7f00000000000000000000000000000000000000000000000000000000000000005d005b610c07903d805f833e6105268183614054565b5081610bc8565b34610392576020610c36610c21366144fa565b610c29614e47565b610c31614e74565b61526b565b50505f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051908152f35b3461039257610c7136614177565b610c79614e74565b6001600160a01b03610c8d602083016146d3565b610c96836146d3565b91610ca460408501856146e7565b9490608082013593600485101561039257836102d0610d3b96610cf3610d01955f9b606089878f9e61029e60c0610cdc9e018461473b565b168d521660208c0152013560408a0152369161408f565b606087015260808601614a73565b60a08201526040519485809481937f2145789700000000000000000000000000000000000000000000000000000000835260048301614c54565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387575f905f925f91610d83575b5061035990604051938493846145a6565b90506103599250610da691503d805f833e610d9e8183614054565b810190614aea565b9092610d72565b3461039257604060031936011261039257610dc6613f7f565b6001600160a01b0360405190806020937f5f9815ff000000000000000000000000000000000000000000000000000000008585015216602483015230604483015260243560648301526064825260a082019082821067ffffffffffffffff831117610f1157815f91816040527fedfa35680000000000000000000000000000000000000000000000000000000082528560a486015281837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6087610e8c60c4820182614246565b0301927f0000000000000000000000000000000000000000000000000000000000000000165af190811561038757610ed5925f92610eea575b5050828082518301019101614886565b906103596040519282849384528301906141a9565b610f0a925060a0903d90815f853e610f028285614054565b0101906146ad565b8380610ec5565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b60206003193601126103925760043567ffffffffffffffff811161039257610f76610f70610359923690600401614352565b90614cb0565b604051918291826143b1565b3461039257610f9c610f9336614294565b92919390614e05565b916001600160a01b0390817f00000000000000000000000000000000000000000000000000000000000000001691604051937fca4f280300000000000000000000000000000000000000000000000000000000855216928360048201525f81602481865afa908115610387575f9161117f575b50519461101b86614a42565b955f5b81811061115a5750505f9261043e61109c8886956110d8956040519261104384613feb565b30845260209a8b850152604084015260608301528660808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000008a840152602483016148f2565b6040519485809481937fedfa35680000000000000000000000000000000000000000000000000000000083528960048401526024830190614246565b03925af18015610387576110fc915f91611140575b5082808251830101910161496f565b505091611118575b6103596040519282849384528301906141a9565b5f7f00000000000000000000000000000000000000000000000000000000000000005d611104565b61115491503d805f833e6105268183614054565b846110ed565b806fffffffffffffffffffffffffffffffff6111786001938b614bd0565b520161101e565b61119b91503d805f833e6111938183614054565b8101906149b8565b8661100f565b6111aa3661452d565b949095939193336111ba90614e05565b97604051996111c88b61401b565b338b5260208b01600190526001600160a01b031660408b01526001600160a01b031660608a01526001600160a01b0316608089015260a088015260c087015260e08601521515610100850152369061121f92614126565b6101208301526040517f68a24fe000000000000000000000000000000000000000000000000000000000602082015291829061125e9060248301614b3f565b03601f19810183526112709083614054565b60405180927f48c894910000000000000000000000000000000000000000000000000000000082526004820160209052602482016112ad91614246565b03827f00000000000000000000000000000000000000000000000000000000000000006001600160a01b031691815a5f948591f1918215610387575f92611310575b5060208280518101031261039257602080920151906104ea57604051908152f35b6113259192503d805f833e6105268183614054565b90826112ef565b3461039257608060031936011261039257611345613f7f565b61134d613fab565b906064359067ffffffffffffffff8211610392576113726113e89236906004016140dd565b9061137b614e47565b611383614e74565b6001600160a01b035f817f00000000000000000000000000000000000000000000000000000000000000001693604051809681927fa07d60400000000000000000000000000000000000000000000000000000000083526044358a88600486016147f6565b038183875af1938415610387575f94611550575b5080604051927fca4f28030000000000000000000000000000000000000000000000000000000084521660048301525f82602481865afa918215610387575f92611534575b505f5b82518110156114f0576114578186614bd0565b519081611469575b6001915001611444565b826114748286614bd0565b5116853b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b039182166004820152908816602482015260448101929092525f8260648183895af1918215610387576001926114e1575b5061145f565b6114ea90614007565b876114db565b610359856114fd8861510c565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6040519182916020835260208301906141a9565b6115499192503d805f833e6111938183614054565b9085611441565b61156d9194503d805f833e6115658183614054565b810190614886565b92856113fc565b5f61043e8161093a61160b61158836614491565b9061159898949295939833614e05565b986001600160a01b039687604051956115b087613feb565b3387521660208601526040850152606084015260036080840152151560a083015260c08201526040519283917f7b03c7ba00000000000000000000000000000000000000000000000000000000602084015260248301614a8c565b6040519586809481937f48c89491000000000000000000000000000000000000000000000000000000008352602060048401526024830190614246565b346103925761165636614177565b61165e614e47565b611666614e74565b6001600160a01b039060208101907f0000000000000000000000000000000000000000000000000000000000000000908382166116a2846146d3565b946116ac836146d3565b6116b960408501856146e7565b979091608086013590600482101561039257846102d061171593610cf35f9761174d9e6116ea8d60c081019061473b565b969097816040519b6116fb8d614038565b168b521660208a015260608d013560408a0152369161408f565b60a0820152604051809881927f2145789700000000000000000000000000000000000000000000000000000000835260048301614c54565b038183865af1908115610387575f955f975f9361194f575b5061176f906146d3565b9681604051987fca4f2803000000000000000000000000000000000000000000000000000000008a521660048901525f88602481875afa978815610387575f98611933575b50919560a0850192905f5b89518110156118ee576117d28184614bd0565b519081156118e557846117e5828d614bd0565b51166117f0876147e9565b806118ba575b15611838575061183260019261180b8a6146d3565b8b7f0000000000000000000000000000000000000000000000000000000000000000615575565b016117bf565b611841896146d3565b883b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201529116602482015260448101929092525f82606481838b5af1918215610387576001926118ab575b50611832565b6118b490614007565b8b6118a5565b50857f00000000000000000000000000000000000000000000000000000000000000001681146117f6565b60019150611832565b50610359886119046118ff896146d3565b61510c565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051938493846145a6565b6119489198503d805f833e6111938183614054565b96886117b4565b90925061196c91975061176f96503d805f833e610d9e8183614054565b97919690979290611765565b6119813661452d565b9490959391933361199190614e05565b976040519961199f8b61401b565b338b5260208b015f90526001600160a01b031660408b01526001600160a01b031660608a01526001600160a01b0316608089015260a088015260c087015260e08601521515610100850152369061121f92614126565b60c060031936011261039257611a09613f7f565b611a11613fab565b611a196140fb565b60a4359067ffffffffffffffff8211610392575f611ad4611a3f8294369060040161415c565b9261043e61044c611a5d611a5233614e05565b98604435908b615191565b966001600160a01b039460405192611a7484613feb565b3384528660209d168d8501526040840152606435606084015260026080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000008c840152602483016148f2565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1918215610387576104db92611b1f915f91611b26575b5085808251830101910161496f565b5050614bd0565b611b3a91503d805f833e6105268183614054565b86611b10565b61043e611bd85f80611c14611b54366141dc565b611b65999391999892949833614e05565b996001600160a01b039560405193611b7c85613feb565b3385528760209c168c86015260408501526060840152876080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000008a840152602483016148f2565b6040519485809481937f48c894910000000000000000000000000000000000000000000000000000000083528960048401526024830190614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387576110fc915f91611140575082808251830101910161496f565b3461039257611c67366144fa565b611c6f614e47565b611c77614e74565b611c808161526b565b611c8e6060859395016146d3565b90611c98836146d3565b94610100840195611ca8876147e9565b80611f1f575b15611d9c575094611d2b91611d066020977f00000000000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000614f16565b611d0f856146d3565b91611d25611d1f608088016146d3565b916147e9565b92615443565b6001600160a01b03807f000000000000000000000000000000000000000000000000000000000000000016911614611d8a575b505f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051908152f35b6118ff611d96916146d3565b82611d5e565b81611db0575b5050602094611d2b91611d06565b6001600160a01b0390817f00000000000000000000000000000000000000000000000000000000000000001691807f00000000000000000000000000000000000000000000000000000000000000001691611e0a85614ed2565b93803b15610392576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039283166004820152848316602482015294821660448601529187161660648401525f908390608490829084905af1908115610387575f93602093611ed093611f10575b506040519485809481937f15afd4090000000000000000000000000000000000000000000000000000000083528a60048401602090939291936001600160a01b0360408201951681520152565b03925af1801561038757611ee5575b80611da2565b602090813d8311611f09575b611efb8183614054565b810103126103925785611edf565b503d611ef1565b611f1990614007565b8a611e83565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690851614611cae565b3461039257606060031936011261039257611f6d613f7f565b611f75613fab565b611f7d614e74565b6001600160a01b0390817f000000000000000000000000000000000000000000000000000000000000000016604051927fca4f2803000000000000000000000000000000000000000000000000000000008452841660048401525f83602481845afa938415610387575f611ffe612039968296839161207d575b5051614a42565b93604051968795869485937fa07d604000000000000000000000000000000000000000000000000000000000855260443591600486016147f6565b03925af1801561038757610359915f91612063575b506040519182916020835260208301906141a9565b61207791503d805f833e6115658183614054565b8261204e565b61209191503d8085833e6111938183614054565b88611ff7565b34610392575f6003193601126103925760207f00000000000000000000000000000000000000000000000000000000000000005c6001600160a01b0360405191168152f35b34610392576120ea36614177565b6120f2614e47565b6120fa614e74565b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000008181169260209081810190612137826146d3565b95612141826146d3565b9661214f60408401846146e7565b919098608085013591600583101561039257896102d0612193946121a26121f29e5f988d866121ba996121868f60c081019061473b565b99909a6040519d8e614038565b168c5216908a0152369161408f565b604087015260608901356060870152608086016148ac565b60a0820152604051809981927f4af29ec400000000000000000000000000000000000000000000000000000000835260048301614be4565b038183855af1958615610387575f935f985f986124a8575b50612214906146d3565b81604051917fca4f28030000000000000000000000000000000000000000000000000000000083521660048201525f81602481865afa908115610387575f9161248e575b50969760a0840197905f5b825181101561244d57836122778285614bd0565b51166122838289614bd0565b519081156123e0576122948c6147e9565b80612422575b156122d45750906122ce6001928b7f0000000000000000000000000000000000000000000000000000000000000000614f16565b01612263565b90857f00000000000000000000000000000000000000000000000000000000000000001690612302896146d3565b61230b82614ed2565b833b15610392576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201528a831660248201529082166044820152908416606482015292915f908490608490829084905af1918215610387576123cc938c93612413575b5060405193849283927f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03815f8a5af19081156103875789916123ea575b50506001906122ce565b813d831161240c575b6123fd8183614054565b8101031261039257878c6123e0565b503d6123f3565b61241c90614007565b8f612381565b50857f000000000000000000000000000000000000000000000000000000000000000016811461229a565b50856103598b61245f6118ff896146d3565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d6040519384938461426b565b6124a291503d805f833e6111938183614054565b89612258565b9097506124c591985061221494503d805f833e6103788183614054565b9891949098979061220a565b34610392575f600319360112610392576040515f5f549060018260011c9160018416918215612604575b60209485851084146125d75785879486865291825f14612599575050600114612540575b5061252c92500383614054565b610359604051928284938452830190614246565b5f808052859250907f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e5635b85831061258157505061252c93508201018561251f565b8054838901850152879450869390920191810161256a565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00168582015261252c95151560051b850101925087915061251f9050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b92607f16926124fb565b346103925761263f6126385f8061061661076a61043e61262d36614432565b95939a929990614e05565b988a615191565b506001600160a01b03936040519161265683613feb565b3083528560209b168b84015260408301526fffffffffffffffffffffffffffffffff6060830152600260808301528660a083015260c08201526040519283917fb24bd571000000000000000000000000000000000000000000000000000000008b84015260248301614a8c565b61043e611bd85f8061275a6126d736614491565b6126e79993949892919933614e05565b996001600160a01b0395604051936126fe85613feb565b3385528760209c168c86015260408501526060840152876080840152151560a083015260c08201526040519283917f7b03c7ba000000000000000000000000000000000000000000000000000000008a84015260248301614a8c565b03927f0000000000000000000000000000000000000000000000000000000000000000165af18015610387576127a0915f916127bc575b50828082518301019101614aea565b50929050611118576103596040519282849384528301906141a9565b6127d091503d805f833e6105268183614054565b84612791565b346103925760a0600319360112610392576127ef613f7f565b67ffffffffffffffff602435818111610392576128109036906004016140dd565b91612819613f95565b91608435908111610392575f9361043e6108fd86946128426108826128b796369060040161415c565b966001600160a01b0394856040519361285a85613feb565b30855216602084015260408301526044356060830152600460808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000006020840152602483016148f2565b03927f0000000000000000000000000000000000000000000000000000000000000000165af19182156103875761035992612903915f91612940575b506020808251830101910161496f565b90939192612918575b6040519384938461426b565b5f7f00000000000000000000000000000000000000000000000000000000000000005d61290c565b61295491503d805f833e6105268183614054565b846128f3565b3461039257612968366142e6565b906129769094939294614e05565b936001600160a01b038093816040519661298f8861401b565b3388528160209a8b8a015f905216604089015216606087015216608085015260a084015260c083015f905260e083016fffffffffffffffffffffffffffffffff905261010083015f905261012083015260405180928582017fbe5ae8410000000000000000000000000000000000000000000000000000000090526024820190612a1891614b3f565b03601f1981018352612a2a9083614054565b6040518080937fedfa356800000000000000000000000000000000000000000000000000000000825286600483015260248201612a6691614246565b03917f00000000000000000000000000000000000000000000000000000000000000001691815a5f948591f1908115610387575f91612abd575b50828180518101031261039257820151906104ea57604051908152f35b612ad191503d805f833e6105268183614054565b83612aa0565b346103925760a060031936011261039257612af0613f7f565b612af8613fc1565b90612b01613f95565b60843567ffffffffffffffff811161039257612b24612b2a91369060040161415c565b91614e05565b916001600160a01b0391827f0000000000000000000000000000000000000000000000000000000000000000169280604051937fc9c1661b0000000000000000000000000000000000000000000000000000000085521695866004850152166024830152604082604481865afa918215610387575f905f93612c9a575b505f9361043e612c368694612bbe612c7295614a42565b906001612bcb8984614bd0565b5260405191612bd983613feb565b30835260209b8c84015260408301526024356060830152600160808301528660a083015260c08201526040519283917fb24bd571000000000000000000000000000000000000000000000000000000008c84015260248301614a8c565b6040519586809481937fedfa35680000000000000000000000000000000000000000000000000000000083528b60048401526024830190614246565b03925af1918215610387576104db926104d3915f916105125750858082518301019101614aea565b925050916040823d604011612cd1575b81612cb760409383614054565b81010312610392578151602090920151909290915f612ba7565b3d9150612caa565b3461039257612cf5612cea36614432565b929490939193614e05565b926001600160a01b0392837f0000000000000000000000000000000000000000000000000000000000000000169380604051947fc9c1661b0000000000000000000000000000000000000000000000000000000086521696876004860152166024840152604083604481875afa928315610387575f905f94612e37575b509361043e612c365f9694612e0f94612d8b8997614a42565b916fffffffffffffffffffffffffffffffff612da78a85614bd0565b5260405192612db584613feb565b30845260209c8d85015260408401526060830152600260808301528660a083015260c08201526040519283917fefd85f14000000000000000000000000000000000000000000000000000000008c840152602483016148f2565b03925af1918215610387576104db92611b1f915f91611b26575085808251830101910161496f565b9350506040833d604011612e6c575b81612e5360409383614054565b810103126103925782516020909301519261043e612d72565b3d9150612e46565b34610392575f6003193601126103925760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b60a06003193601126103925767ffffffffffffffff60043511610392573660236004350112156103925767ffffffffffffffff60043560040135116103925736602460c060043560040135026004350101116103925760243567ffffffffffffffff811161039257612f2d903690600401614352565b67ffffffffffffffff60443511610392576060600319604435360301126103925760643567ffffffffffffffff811161039257612f6e903690600401614383565b60843567ffffffffffffffff811161039257612f8e903690600401614352565b949093612f99614e47565b8060043560040135036134dc575f5b6004356004013581106132295750505060443560040135907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd60443536030182121561039257816044350160048101359067ffffffffffffffff82116103925760248260071b36039101136103925761304c575b610359610f7686865f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d614cb0565b6001600160a01b039492947f0000000000000000000000000000000000000000000000000000000000000000163b1561039257604051947f2a2d80d10000000000000000000000000000000000000000000000000000000086523360048701526060602487015260c486019260443501602481019367ffffffffffffffff60048301351161039257600482013560071b360385136103925760606064890152600482013590529192869260e484019291905f905b600481013582106131ab5750505082915f9461314e926001600160a01b0361312c602460443501613fd7565b16608486015260448035013560a486015260031985840301604486015261478c565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af19182156103875761035993610f769361319c575b82945081935061301c565b6131a590614007565b84613191565b9195945091926001600160a01b036131c287613fd7565b168152602080870135916001600160a01b038316809303610392576004926001928201526131f26040890161517e565b65ffffffffffff809116604083015261320d60608a0161517e565b1660608201526080809101970193019050889495939291613100565b6132376102d0828486614dee565b60405180606081011067ffffffffffffffff606083011117610f1157606081016040525f81526020915f838301525f60408301528281015190606060408201519101515f1a91835283830152604082015260c07fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdc818502600435013603011261039257604051906132c782614038565b6132da602460c086026004350101613fd7565b8083526132f0604460c087026004350101613fd7565b908185850152613309606460c088026004350101613fd7565b60408581019190915260043560c08802016084810135606087015260a4810135608087015260c4013560a086015283015183519386015160ff91909116926001600160a01b0383163b15610392575f6001600160a01b03809460e4948b98849860c460c06040519c8d9b8c9a7fd505accf000000000000000000000000000000000000000000000000000000008c521660048b01523060248b0152608482820260043501013560448b0152026004350101356064880152608487015260a486015260c4850152165af190816134cd575b506134c3576133e661514f565b906001600160a01b0381511690836001600160a01b0381830151166044604051809581937fdd62ed3e00000000000000000000000000000000000000000000000000000000835260048301523060248301525afa918215610387575f92613493575b50606001510361345e5750506001905b01612fa8565b80511561346b5780519101fd5b7fa7285689000000000000000000000000000000000000000000000000000000005f5260045ffd5b9091508381813d83116134bc575b6134ab8183614054565b810103126103925751906060613448565b503d6134a1565b5050600190613458565b6134d690614007565b8a6133d9565b7faaad13f7000000000000000000000000000000000000000000000000000000005f5260045ffd5b3461039257613512366142e6565b906135209094939294614e05565b936001600160a01b03809381604051966135398861401b565b3388528160209a8b8a016001905216604089015216606087015216608085015260a084015260c083016fffffffffffffffffffffffffffffffff905260e083017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff905261010083015f905261012083015260405180928582017fbe5ae8410000000000000000000000000000000000000000000000000000000090526024820190612a1891614b3f565b34610392575f6003193601126103925760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b3461039257613637610f9336614294565b926001600160a01b0392837f00000000000000000000000000000000000000000000000000000000000000001693604051937fca4f280300000000000000000000000000000000000000000000000000000000855216938460048501525f84602481845afa9384156103875761109c5f959461372a946136c3889761043e95899161374d575051614a42565b91604051926136d184613feb565b30845260209a8b850152604084015260608301528660808301528660a083015260c08201526040519283917fb24bd571000000000000000000000000000000000000000000000000000000008a84015260248301614a8c565b03925af18015610387576127a0915f916127bc5750828082518301019101614aea565b61376191503d808b833e6111938183614054565b8c611ff7565b5f61043e816128b761160b61377b366141dc565b9061378c9894929895939533614e05565b986001600160a01b039687604051956137a487613feb565b3387521660208601526040850152606084015260046080840152151560a083015260c08201526040519283917f5b343791000000000000000000000000000000000000000000000000000000006020840152602483016148f2565b606060031936011261039257613813613f7f565b60443567ffffffffffffffff8111610392575f61043e61387a61383d6138b49436906004016140dd565b6040519283916020977f82cd54fb0000000000000000000000000000000000000000000000000000000089850152602435903390602486016147f6565b604051809381927f48c894910000000000000000000000000000000000000000000000000000000083528660048401526024830190614246565b0381836001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af1801561038757610ed5915f91613903575b50828082518301019101614886565b61391791503d805f833e6105268183614054565b836138f4565b346103925761392b36614177565b613933614e47565b61393b614e74565b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000006020826139728583016146d3565b9461397c816146d3565b95604082019661398c88846146e7565b9061399a60608601866146e7565b939092806139ab60c089018961473b565b6040517fba8a2be0000000000000000000000000000000000000000000000000000000008152988e1660048a01529c909316602488015260c0604488015260c487015294999460e48b0192905f5b8a828210613d0657505050506003198a83030160648b01528382527f07ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8411610392578794858b9594613a6d94879660051b8092848301370160808901356084870152601c8682030160a4870152019161478c565b03815f8689165af1948515610387575f95613cd7575b50939460a0850194905f5b613a9882846146e7565b9050811015613c9e57613abd613ab882613ab285876146e7565b906147ac565b6146d3565b613ace82613ab260608701876146e7565b35908115613c2f57613adf896147e9565b80613c71575b15613b1f575090613b19600192887f0000000000000000000000000000000000000000000000000000000000000000614f16565b01613a8e565b857f00000000000000000000000000000000000000000000000000000000000000001691613b4c866146d3565b613b5582614ed2565b843b15610392576040517f36c785160000000000000000000000000000000000000000000000000000000081526001600160a01b039283166004820152898c168316602482015290821660448201528389169091166064820152925f908490608490829084905af191821561038757613c19938993613c62575060405193849283927f15afd40900000000000000000000000000000000000000000000000000000000845260048401602090939291936001600160a01b0360408201951681520152565b03815f898c165af1908115610387578691613c39575b5050600190613b19565b813d8311613c5b575b613c4c8183614054565b81010312610392578489613c2f565b503d613c42565b613c6b90614007565b8c612381565b50857f00000000000000000000000000000000000000000000000000000000000000001686821614613ae5565b8488613cac6118ff866146d3565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d604051908152f35b9094508281813d8311613cff575b613cef8183614054565b8101031261039257519386613a83565b503d613ce5565b8084968c613d176001959697613fd7565b1681520195019291016139f9565b60c060031936011261039257613d39613f7f565b6024359067ffffffffffffffff808311610392573660238401121561039257826004013591613d6783614077565b92613d756040519485614054565b80845260209460248686019260051b82010191368311610392576024879201905b838210613f68575050505060443582811161039257613db99036906004016140dd565b92613dc26140fb565b9260a43590811161039257613ddb90369060040161415c565b93613de533614e05565b946001600160a01b039460405192613dfc84613feb565b338452868985019616865260408401948552606084019081526080840194606435865260a08501921515835260c0850193845287604051977f086fad66000000000000000000000000000000000000000000000000000000008c8a01528b60248a0152816101248a0197511660448a015251166064880152519360e0608488015284518091528961014488019501905f5b8b828210613f5257505050509461043e613f02955f989583956105da95613ee28c9b51937fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbc94858983030160a48a0152614634565b935160c487015251151560e4860152519084830301610104850152614246565b03927f0000000000000000000000000000000000000000000000000000000000000000165af1908115610387575f91612abd5750828180518101031261039257820151906104ea57604051908152f35b83518b1688529687019690920191600101613e8d565b828091613f7484613fd7565b815201910190613d96565b600435906001600160a01b038216820361039257565b606435906001600160a01b038216820361039257565b602435906001600160a01b038216820361039257565b604435906001600160a01b038216820361039257565b35906001600160a01b038216820361039257565b60e0810190811067ffffffffffffffff821117610f1157604052565b67ffffffffffffffff8111610f1157604052565b610140810190811067ffffffffffffffff821117610f1157604052565b60c0810190811067ffffffffffffffff821117610f1157604052565b90601f601f19910116810190811067ffffffffffffffff821117610f1157604052565b67ffffffffffffffff8111610f115760051b60200190565b929161409a82614077565b916140a86040519384614054565b829481845260208094019160051b810192831161039257905b8282106140ce5750505050565b813581529083019083016140c1565b9080601f83011215610392578160206140f89335910161408f565b90565b60843590811515820361039257565b67ffffffffffffffff8111610f1157601f01601f191660200190565b9291926141328261410a565b916141406040519384614054565b829481845281830111610392578281602093845f960137010152565b9080601f83011215610392578160206140f893359101614126565b60031990602082820112610392576004359167ffffffffffffffff8311610392578260e0920301126103925760040190565b9081518082526020808093019301915f5b8281106141c8575050505090565b8351855293810193928101926001016141ba565b9060a0600319830112610392576004356001600160a01b0381168103610392579167ffffffffffffffff90602435828111610392578161421e916004016140dd565b926044359260643580151581036103925792608435918211610392576140f89160040161415c565b90601f19601f602080948051918291828752018686015e5f8582860101520116010190565b6142816140f894926060835260608301906141a9565b9260208201526040818403910152614246565b6080600319820112610392576001600160a01b03906004358281168103610392579260243592604435908116810361039257916064359067ffffffffffffffff8211610392576140f89160040161415c565b60c0600319820112610392576001600160a01b0391600435838116810361039257926024358181168103610392579260443582811681036103925792606435926084359081168103610392579160a4359067ffffffffffffffff8211610392576140f89160040161415c565b9181601f840112156103925782359167ffffffffffffffff8311610392576020808501948460051b01011161039257565b9181601f840112156103925782359167ffffffffffffffff8311610392576020838186019501011161039257565b6020808201906020835283518092526040830192602060408460051b8301019501935f915b8483106143e65750505050505090565b9091929394958480614422837fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc086600196030187528a51614246565b98019301930191949392906143d6565b9060a0600319830112610392576001600160a01b03600435818116810361039257926024358281168103610392579260443592606435908116810361039257916084359067ffffffffffffffff8211610392576140f89160040161415c565b60a0600319820112610392576004356001600160a01b038116810361039257916024359167ffffffffffffffff9160443583811161039257826144d6916004016140dd565b9260643580151581036103925792608435918211610392576140f89160040161415c565b60031990602082820112610392576004359167ffffffffffffffff83116103925782610140920301126103925760040190565b610100600319820112610392576001600160a01b0390600435828116810361039257926024358381168103610392579260443590811681036103925791606435916084359160a4359160c4358015158103610392579160e4359067ffffffffffffffff8211610392576145a291600401614383565b9091565b916145c3906140f8949284526060602085015260608401906141a9565b916040818403910152614246565b60c0600319820112610392576001600160a01b0390600435828116810361039257926024359260443590811681036103925791606435916084358015158103610392579160a4359067ffffffffffffffff8211610392576140f89160040161415c565b9081518082526020808093019301915f5b828110614653575050505090565b835185529381019392810192600101614645565b81601f820112156103925780519061467e8261410a565b9261468c6040519485614054565b8284526020838301011161039257815f9260208093018386015e8301015290565b9060208282031261039257815167ffffffffffffffff8111610392576140f89201614667565b356001600160a01b03811681036103925790565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215610392570180359067ffffffffffffffff821161039257602001918160051b3603831361039257565b9035907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe181360301821215610392570180359067ffffffffffffffff82116103925760200191813603831361039257565b601f8260209493601f1993818652868601375f8582860101520116010190565b91908110156147bc5760051b0190565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b3580151581036103925790565b90926140f894936080936001600160a01b038092168452166020830152604082015281606082015201906141a9565b9080601f830112156103925781519060209161484081614077565b9361484e6040519586614054565b81855260208086019260051b82010192831161039257602001905b828210614877575050505090565b81518152908301908301614869565b9060208282031261039257815167ffffffffffffffff8111610392576140f89201614825565b60058210156148b85752565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b9060058210156148b85752565b906140f891602081526001600160a01b03808351166020830152602083015116604082015260c0614933604084015160e06060850152610100840190614634565b9260608101516080840152614950608082015160a08501906148e5565b60a081015115158284015201519060e0601f1982850301910152614246565b90916060828403126103925781519167ffffffffffffffff92838111610392578461499b918301614825565b936020820151936040830151908111610392576140f89201614667565b60209081818403126103925780519067ffffffffffffffff821161039257019180601f840112156103925782516149ee81614077565b936149fc6040519586614054565b818552838086019260051b820101928311610392578301905b828210614a23575050505090565b81516001600160a01b0381168103610392578152908301908301614a15565b90614a4c82614077565b614a596040519182614054565b828152601f19614a698294614077565b0190602036910137565b60048210156148b85752565b9060048210156148b85752565b906140f891602081526001600160a01b03808351166020830152602083015116604082015260c0614acd604084015160e06060850152610100840190614634565b9260608101516080840152614950608082015160a0850190614a7f565b916060838303126103925782519260208101519267ffffffffffffffff938481116103925781614b1b918401614825565b936040830151908111610392576140f89201614667565b9060028210156148b85752565b6101606140f892602083526001600160a01b03808251166020850152614b6d60208301516040860190614b32565b80604083015116606085015280606083015116608085015260808201511660a084015260a081015160c084015260c081015160e084015260e081015161010090818501528101519061012091151582850152015191610140808201520190614246565b80518210156147bc5760209160051b010190565b906140f891602081526001600160a01b03808351166020830152602083015116604082015260a0614c24604084015160c0606085015260e0840190614634565b9260608101516080840152614c406080820151838501906148e5565b01519060c0601f1982850301910152614246565b906140f891602081526001600160a01b0380835116602083015260208301511660408201526040820151606082015260a0614c9e606084015160c0608085015260e0840190614634565b92614c40608082015183850190614a7f565b9190614cbb33614e05565b907f000000000000000000000000000000000000000000000000000000000000000093845c614dc6576001906001865d614cf483614077565b92614d026040519485614054565b808452601f19614d1182614077565b015f5b818110614db55750505f5b818110614d6c5750505050905f614d6192945d7f0000000000000000000000000000000000000000000000000000000000000000805c91614d63575b5061510c565b565b5f905d5f614d5b565b80614d995f80614d816102d08996888a614dee565b602081519101305af4614d9261514f565b90306156e8565b614da38288614bd0565b52614dae8187614bd0565b5001614d1f565b806060602080938901015201614d14565b7f3ee5aeb5000000000000000000000000000000000000000000000000000000005f5260045ffd5b908210156147bc576145a29160051b81019061473b565b905f917f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03815c1615614e3d575050565b909192505d600190565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c614dc6576001905d565b6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000163303614ea657565b7f089676d5000000000000000000000000000000000000000000000000000000005f523360045260245ffd5b6001600160a01b0390818111614ee6571690565b7f6dfcc650000000000000000000000000000000000000000000000000000000005f5260a060045260245260445ffd5b9190918147106150e4576001600160a01b0380911692833b15610392576040918251917fd0e30db00000000000000000000000000000000000000000000000000000000083525f925f81600481898b5af180156150da576150c7575b501692825194602095868101907fa9059cbb000000000000000000000000000000000000000000000000000000008252866024820152836044820152604481526080810181811067ffffffffffffffff821117610f1157865251614fe7918591829182865af1614fe061514f565b90836156e8565b80518781151591826150a2575b5050905061507757906044869284865197889485937f15afd409000000000000000000000000000000000000000000000000000000008552600485015260248401525af191821561506d575050615049575050565b813d8311615066575b61505c8183614054565b8101031261039257565b503d615052565b51903d90823e3d90fd5b7f5274afe7000000000000000000000000000000000000000000000000000000008352600452602482fd5b83809293500103126150c3578601518015908115036150c35780875f614ff4565b8380fd5b6150d2919350614007565b5f915f614f72565b85513d5f823e3d90fd5b7fa01a9df6000000000000000000000000000000000000000000000000000000005f5260045ffd5b47801561514b577f00000000000000000000000000000000000000000000000000000000000000005c61514b576001600160a01b03614d61921661566c565b5050565b3d15615179573d906151608261410a565b9161516e6040519384614054565b82523d5f602084013e565b606090565b359065ffffffffffff8216820361039257565b916044929391936001600160a01b03604094859282808551998a9586947fc9c1661b0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa938415615261575f935f9561522a575b50506152276152208594614a42565b9485614bd0565b52565b809295508194503d831161525a575b6152438183614054565b810103126103925760208251920151925f80615211565b503d615239565b83513d5f823e3d90fd5b60e0810135421161541b576001600160a01b0360208201359160028310156103925760409261529b8285016146d3565b928060609485938486016152ae906146d3565b956152bb608082016146d3565b90846152cb61012083018361473b565b91908c51956152d987613feb565b8652816020870197168752818d87019b168b52818a870195168552608086019260a0850135845260a087019460c001358552369061531692614126565b9360c08601948552818d519b8c9a8b998a997f2bfb780c000000000000000000000000000000000000000000000000000000008b5260048b016020905260248b0190519061536391614b32565b5116604489015251166064870152511660848501525160a48401525160c48301525160e4820160e09052610104820161539b91614246565b03917f0000000000000000000000000000000000000000000000000000000000000000165a905f91f1908115615261575f935f935f936153de575b505050909192565b92509250809350813d8311615414575b6153f88183614054565b81010312610392578151602083015191909201515f80806153d6565b503d6153ee565b7fe08b8af0000000000000000000000000000000000000000000000000000000005f5260045ffd5b92821561556f578061553a575b156154a15750614d61917f00000000000000000000000000000000000000000000000000000000000000007f0000000000000000000000000000000000000000000000000000000000000000615575565b906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016803b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081526001600160a01b03938416600482015293909216602484015260448301525f908290606490829084905af18015610387576155315750565b614d6190614007565b506001600160a01b03807f00000000000000000000000000000000000000000000000000000000000000001690821614615450565b50505050565b9392916001600160a01b03809216803b15610392576040517fae6393290000000000000000000000000000000000000000000000000000000081525f816064818388819c16968760048401523060248401528a60448401525af1801561038757615659575b508086913b156156555781906024604051809481937f2e1a7d4d0000000000000000000000000000000000000000000000000000000083528960048401525af1801561564a57615632575b50614d619394501661566c565b61563c8691614007565b6156465784615625565b8480fd5b6040513d88823e3d90fd5b5080fd5b615664919650614007565b5f945f6155da565b8147106156bc575f8080936001600160a01b038294165af161568c61514f565b501561569457565b7f1425ea42000000000000000000000000000000000000000000000000000000005f5260045ffd5b7fcd786059000000000000000000000000000000000000000000000000000000005f523060045260245ffd5b906156fd575080511561569457805190602001fd5b81511580615743575b61570e575090565b6001600160a01b03907f9996b315000000000000000000000000000000000000000000000000000000005f521660045260245ffd5b50803b1561570656fea26469706673582212204e7d6ff674984d91fa2ea97e805c1b2a23fe7676d6d8a92cac923b6993f6f51964736f6c634300081b0033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/packages/protocols/beets/abis-src/VENDOR.json
+++ b/packages/protocols/beets/abis-src/VENDOR.json
@@ -1,0 +1,12 @@
+{
+  "name": "balancer/balancer-deployments",
+  "branch": "master",
+  "commit": "c1c3038a4fa214231af9099e4438998fccc30d59",
+  "fileSha256": {
+    "Router.json": "cf269cf3a24e3d30182e4ba4ed7ccd5cc9f0bd8306ae3f4daa42e1fe8a466ed8",
+    "Vault.json": "c4bdb00e1e3d2372a6a5073aa7cb63ef9b9e6fce093f50bfccfc52002fbf6f32",
+    "VaultExtension.json": "be467f1e2aa2c7f775c7170b7851eca4329a3b6e2b03b53f6b78dd0f0fe2857d",
+    "VaultExplorer.json": "05a2a259bb1924ec542a2abfae20aaba9159a9028b0679b721fa3a30ce755868"
+  },
+  "vendoredAt": "2026-07-29"
+}

--- a/packages/protocols/beets/abis-src/Vault.json
+++ b/packages/protocols/beets/abis-src/Vault.json
@@ -1,0 +1,2129 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "Vault",
+  "sourceName": "contracts/Vault.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IVaultExtension",
+          "name": "vaultExtension",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IAuthorizer",
+          "name": "authorizer",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IProtocolFeeController",
+          "name": "protocolFeeController",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        }
+      ],
+      "name": "AddressEmptyCode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "AddressInsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterAddLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterInitializeHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterRemoveLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterSwapHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AllZeroInputs",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AmountGivenZero",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "AmountInAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "AmountOutBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BalanceNotSettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BalanceOverflow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeAddLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeInitializeHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeRemoveLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeSwapHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "BptAmountInAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "BptAmountOutBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "BufferAlreadyInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "BufferNotInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BufferSharesInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BufferSharesInvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        }
+      ],
+      "name": "BufferTotalSupplyTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CannotReceiveEth",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CannotSwapSameToken",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportAddLiquidityCustom",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportDonation",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportRemoveLiquidityCustom",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportUnbalancedLiquidity",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DynamicSwapFeeHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FailedInnerCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FeePrecisionTooHigh",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "HookAdjustedAmountInAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "HookAdjustedAmountOutBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "limit",
+          "type": "uint256"
+        }
+      ],
+      "name": "HookAdjustedSwapLimit",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "poolHooksContract",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "poolFactory",
+          "type": "address"
+        }
+      ],
+      "name": "HookRegistrationFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InputLengthMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidAddLiquidityKind",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRemoveLiquidityKind",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidToken",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTokenConfiguration",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTokenDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTokenType",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "InvalidUnderlyingToken",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "invariantRatio",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxInvariantRatio",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvariantRatioAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "invariantRatio",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minInvariantRatio",
+          "type": "uint256"
+        }
+      ],
+      "name": "InvariantRatioBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "issuedShares",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minIssuedShares",
+          "type": "uint256"
+        }
+      ],
+      "name": "IssuedSharesBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MaxTokens",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MinTokens",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MultipleNonZeroInputs",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotEnoughBufferShares",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expectedUnderlyingAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actualUnderlyingAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughUnderlying",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expectedWrappedAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actualWrappedAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughWrapped",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotStaticCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotVaultDelegateCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PauseBufferPeriodDurationTooLarge",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PercentageAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolAlreadyInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolAlreadyRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolInRecoveryMode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotInRecoveryMode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolPauseWindowExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        }
+      ],
+      "name": "PoolTotalSupplyTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ProtocolFeesExceedTotalCollected",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "QueriesDisabled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "QueriesDisabledPermanently",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "QuoteResultSpoofed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrancyGuardReentrantCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RouterNotTrusted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "int256",
+          "name": "value",
+          "type": "int256"
+        }
+      ],
+      "name": "SafeCastOverflowedIntToUint",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "SafeCastOverflowedUintToInt",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "SafeERC20FailedOperation",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "SenderIsNotVault",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SwapFeePercentageTooHigh",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SwapFeePercentageTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "limit",
+          "type": "uint256"
+        }
+      ],
+      "name": "SwapLimit",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "TokenAlreadyRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "TokenNotRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "expectedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "actualToken",
+          "type": "address"
+        }
+      ],
+      "name": "TokensMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TradeAmountTooSmall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultBuffersArePaused",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultIsNotUnlocked",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultNotPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultPauseWindowDurationTooLarge",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultPauseWindowExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "WrapAmountTooSmall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "WrongProtocolFeeControllerDeployment",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "underlyingToken",
+          "type": "address"
+        }
+      ],
+      "name": "WrongUnderlyingToken",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "WrongVaultAdminDeployment",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "WrongVaultExtensionDeployment",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroDivision",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "aggregateSwapFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "AggregateSwapFeePercentageChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "aggregateYieldFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "AggregateYieldFeePercentageChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IAuthorizer",
+          "name": "newAuthorizer",
+          "type": "address"
+        }
+      ],
+      "name": "AuthorizerChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "burnedShares",
+          "type": "uint256"
+        }
+      ],
+      "name": "BufferSharesBurned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "issuedShares",
+          "type": "uint256"
+        }
+      ],
+      "name": "BufferSharesMinted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "liquidityProvider",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum AddLiquidityKind",
+          "name": "kind",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "amountsAddedRaw",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "swapFeeAmountsRaw",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "LiquidityAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountWrapped",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "LiquidityAddedToBuffer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "liquidityProvider",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum RemoveLiquidityKind",
+          "name": "kind",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "amountsRemovedRaw",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "swapFeeAmountsRaw",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "LiquidityRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountWrapped",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "LiquidityRemovedFromBuffer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "PoolPausedStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "recoveryMode",
+          "type": "bool"
+        }
+      ],
+      "name": "PoolRecoveryModeStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "factory",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "contract IERC20",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "internalType": "enum TokenType",
+              "name": "tokenType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "contract IRateProvider",
+              "name": "rateProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "paysYieldFees",
+              "type": "bool"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct TokenConfig[]",
+          "name": "tokenConfig",
+          "type": "tuple[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "pauseWindowEndTime",
+          "type": "uint32"
+        },
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "pauseManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "swapFeeManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "poolCreator",
+              "type": "address"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct PoolRoleAccounts",
+          "name": "roleAccounts",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "enableHookAdjustedAmounts",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallComputeDynamicSwapFee",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "address",
+              "name": "hooksContract",
+              "type": "address"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct HooksConfig",
+          "name": "hooksConfig",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "disableUnbalancedLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableAddLiquidityCustom",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableRemoveLiquidityCustom",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableDonation",
+              "type": "bool"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct LiquidityManagement",
+          "name": "liquidityManagement",
+          "type": "tuple"
+        }
+      ],
+      "name": "PoolRegistered",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IProtocolFeeController",
+          "name": "newProtocolFeeController",
+          "type": "address"
+        }
+      ],
+      "name": "ProtocolFeeControllerChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeeAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "Swap",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "SwapFeePercentageChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "burnedShares",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "withdrawnUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Unwrap",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "eventKey",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "eventData",
+          "type": "bytes"
+        }
+      ],
+      "name": "VaultAuxiliary",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "VaultBuffersPausedStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "VaultPausedStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "VaultQueriesDisabled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "VaultQueriesEnabled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "depositedUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "mintedShares",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Wrap",
+      "type": "event"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "fallback"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "maxAmountsIn",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBptAmountOut",
+              "type": "uint256"
+            },
+            {
+              "internalType": "enum AddLiquidityKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct AddLiquidityParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "addLiquidity",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "enum SwapKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "enum WrappingDirection",
+              "name": "direction",
+              "type": "uint8"
+            },
+            {
+              "internalType": "contract IERC4626",
+              "name": "wrappedToken",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountGivenRaw",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "limitRaw",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct BufferWrapOrUnwrapParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "erc4626BufferWrapOrUnwrap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountCalculatedRaw",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountInRaw",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOutRaw",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokenCountAndIndexOfToken",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getVaultExtension",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "reentrancyGuardEntered",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "from",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "maxBptAmountIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "minAmountsOut",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "enum RemoveLiquidityKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct RemoveLiquidityParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "removeLiquidity",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOut",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "bytes",
+          "name": "returnData",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "sendTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountHint",
+          "type": "uint256"
+        }
+      ],
+      "name": "settle",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "credit",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "enum SwapKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "pool",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenIn",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC20",
+              "name": "tokenOut",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountGivenRaw",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "limitRaw",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct VaultSwapParams",
+          "name": "vaultSwapParams",
+          "type": "tuple"
+        }
+      ],
+      "name": "swap",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountCalculated",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "unlock",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ],
+  "bytecode": "0x6101e06040908082523461036b576060816165dd803803809161002282856104d1565b83398101031261036b5780516001600160a01b0380821680830361036b5760208085015194838616860361036b5786015183811680910361036b57610086875161006b816104a2565b600a8152691a5cd55b9b1bd8dad95960b21b8482015261052f565b60c0526100b98751610097816104a2565b60118152701b9bdb96995c9bd1195b1d1850dbdd5b9d607a1b8482015261052f565b60e0526100e687516100ca816104a2565b600b81526a746f6b656e44656c74617360a81b8482015261052f565b9661010097885261011e81516100fb816104a2565b6012815271185919131a5c5d5a591a5d1e50d85b1b195960721b8582015261052f565b9661012097885261014d8251610133816104a2565b60098152681cd95cdcda5bdb925960ba1b8682015261052f565b9261014093845282519663fbfa77cf60e01b9081895260049887818b818c5afa9081156103af575f91610485575b50813091160361047757845191825286828a81865afa9182156103e8575f92610448575b503091160361043a576101c0978852600a80546001600160a01b0319169190911790558151634546891d60e11b81529380858881895afa948515610430575f95610411575b506101609485528251631060fdbd60e11b815296818882818a5afa978815610376575f986103f2575b506101a0978852835163cd51c12f60e01b81529682888381845afa9788156103e8575f986103b9575b506101809788528451630716585d60e51b815283818481855afa9081156103af57908492915f91610380575b5060805285516329cab55160e11b815292839182905afa918215610376575f92610344575b505060a05260098054610100600160a81b03191660089290921b610100600160a81b031691909117905551615fda97909690886106038939608051886152c0015260a051886135f8015260c0518881816111d401526114dd015260e051888181611215015281816146a601526146e8015251876146640152518681816112e60152612389015251858181611241015281816112b2015261235501525184505051836118730152518261190901525181818161096f01526114470152f35b90809250813d831161036f575b61035b81836104d1565b8101031261036b57515f80610287565b5f80fd5b503d610351565b84513d5f823e3d90fd5b83819492503d83116103a8575b61039781836104d1565b8101031261036b578391515f610262565b503d61038d565b86513d5f823e3d90fd5b6103da919850833d85116103e1575b6103d281836104d1565b810190610513565b965f610236565b503d6103c8565b85513d5f823e3d90fd5b61040a919850823d84116103e1576103d281836104d1565b965f61020d565b816104299296503d87116103e1576103d281836104d1565b935f6101e4565b83513d5f823e3d90fd5b86631bbe95c760e01b5f525ffd5b610469919250873d8911610470575b61046181836104d1565b8101906104f4565b905f61019f565b503d610457565b886301ab9d9d60e41b5f525ffd5b61049c9150883d8a116104705761046181836104d1565b5f61017b565b604081019081106001600160401b038211176104bd57604052565b634e487b7160e01b5f52604160045260245ffd5b601f909101601f19168101906001600160401b038211908210176104bd57604052565b9081602091031261036b57516001600160a01b038116810361036b5790565b9081602091031261036b575163ffffffff8116810361036b5790565b6040519061053c826104a2565b600c82526105bd603a602084016b5661756c7453746f7261676560a01b81526020604051948592828401977f62616c616e6365722d6c6162732e76332e73746f726167652e000000000000008952518091603986015e830190601760f91b60398301528051928391018583015e015f8382015203601a8101845201826104d1565b5190205f1981019081116105ee576040519060208201908152602082526105e3826104a2565b9051902060ff191690565b634e487b7160e01b5f52601160045260245ffdfe60806040526004361015610018575b3661143057611421565b5f3560e01c806315afd409146100d757806315dacbea146100d257806321457897146100cd5780632bfb780c146100c857806343583be5146100c357806348c89491146100be5780634af29ec4146100b9578063ae639329146100b4578063b9a8effa146100af578063beabacc8146100aa578063c9c1661b146100a55763d2c725e00361000e57610aae565b6109c9565b610993565b610950565b610866565b610796565b6106fd565b610671565b610599565b6104b4565b61020f565b6100fe565b6001600160a01b038116036100ed57565b5f80fd5b35906100fc826100dc565b565b346100ed5760403660031901126100ed5760043561011b816100dc565b60243561012661147a565b61012e6114db565b6001600160a01b0382165f818152600860209081526040918290205491516370a0823160e01b8152306004820152919492829060249082905afa93841561020a576101cd946101a1925f916101db575b508061019b856001600160a01b03165f52600860205260405f2090565b55610b28565b918083116101d1575b50816101b591611513565b6101bd6114b6565b6040519081529081906020820190565b0390f35b91506101b56101aa565b6101fd915060203d602011610203575b6101f581836102cd565b810190610aec565b5f61017e565b503d6101eb565b610afb565b346100ed5760803660031901126100ed5761025d60043561022f816100dc565b60243561023b816100dc565b60443590610248826100dc565b61025760643580948333611535565b336116b5565b602060405160018152f35b634e487b7160e01b5f52604160045260245ffd5b67ffffffffffffffff811161029057604052565b610268565b60e0810190811067ffffffffffffffff82111761029057604052565b6060810190811067ffffffffffffffff82111761029057604052565b90601f8019910116810190811067ffffffffffffffff82111761029057604052565b6040519060c0820182811067ffffffffffffffff82111761029057604052565b604051906100fc82610295565b60405190610180820182811067ffffffffffffffff82111761029057604052565b67ffffffffffffffff81116102905760051b60200190565b9080601f830112156100ed57602090823561036f8161033d565b9361037d60405195866102cd565b81855260208086019260051b8201019283116100ed57602001905b8282106103a6575050505090565b81358152908301908301610398565b359060048210156100ed57565b67ffffffffffffffff811161029057601f01601f191660200190565b9291926103ea826103c2565b916103f860405193846102cd565b8294818452818301116100ed578281602093845f960137010152565b9080601f830112156100ed5781602061042f933591016103de565b90565b9081518082526020808093019301915f5b828110610451575050505090565b835185529381019392810192600101610443565b805180835260209291819084018484015e5f828201840152601f01601f1916010190565b916104a69061042f94928452606060208501526060840190610432565b916040818403910152610465565b346100ed576003196020368201126100ed5760043567ffffffffffffffff918282116100ed5760c09082360301126100ed576104ee6102ef565b6104fa826004016100f1565b8152610508602483016100f1565b60208201526044820135604082015260648201358381116100ed576105339060043691850101610355565b6060820152610544608483016103b5565b608082015260a48201359283116100ed5761056b6105759260046101cd9536920101610414565b60a0820152610b35565b60409391935193849384610489565b600211156100ed57565b35906100fc82610584565b346100ed576003196020368201126100ed5760043567ffffffffffffffff918282116100ed5760e09082360301126100ed576105d361030f565b6105df8260040161058e565b81526105ed602483016100f1565b60208201526105fe604483016100f1565b604082015261060f606483016100f1565b60608201526084820135608082015260a482013560a082015260c48201359283116100ed5761064a6106549260046101cd9536920101610414565b60c0820152610cbf565b604080519384526020840192909252908201529081906060820190565b346100ed5760a03660031901126100ed5760405160a0810181811067ffffffffffffffff821117610290576101cd91610654916040526004356106b381610584565b81526024356106c181610584565b60208201526044356106d2816100dc565b604082015260643560608201526084356080820152610f03565b90602061042f928181520190610465565b346100ed5760203660031901126100ed5767ffffffffffffffff6004358181116100ed57366023820112156100ed5780600401359182116100ed5736602483830101116100ed576101cd91602461075492016111c9565b604051918291826106ec565b359060058210156100ed57565b61078361042f9492606083526060830190610432565b9260208201526040818403910152610465565b346100ed576003196020368201126100ed5760043567ffffffffffffffff918282116100ed5760c09082360301126100ed576107d06102ef565b6107dc826004016100f1565b81526107ea602483016100f1565b602082015260448201358381116100ed5761080b9060043691850101610355565b60408201526064820135606082015261082660848301610760565b608082015260a48201359283116100ed5761084d6108579260046101cd9536920101610414565b60a082015261127d565b6040939193519384938461076d565b346100ed5760603660031901126100ed57600435610883816100dc565b60243590610890826100dc565b6044359061089c61147a565b6108a46114db565b6108b66108b083614618565b82614654565b6001600160a01b0381165f52600860205260405f208054938385039485116109415793905560405163a9059cbb60e01b60208201526001600160a01b03909316602484015260448084019290925290825261091c91906109176064836102cd565b615b9b565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d005b610b06565b5f9103126100ed57565b346100ed575f3660031901126100ed5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b346100ed5760603660031901126100ed5761025d6004356109b3816100dc565b6024356109bf816100dc565b60443591336116b5565b346100ed5760403660031901126100ed576004356109e6816100dc565b602435906109f3826100dc565b6001600160a01b0380911691825f525f602052600192600160405f20541615610a9c575f93929352600360205260405f20926040519283602086549182815201955f5260205f20925f905b828210610a6f5786610a5c87610a56838c03846102cd565b826145cb565b9051604080519182526020820192909252f35b90919280610a9086998483985416906001600160a01b036020921681520190565b98019493920190610a3e565b6327946f5760e21b5f5260045260245ffd5b346100ed575f3660031901126100ed5760207f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6040519015158152f35b908160209103126100ed575190565b6040513d5f823e3d90fd5b634e487b7160e01b5f52601160045260245ffd5b5f1981019190821161094157565b9190820391821161094157565b90610b3e6114db565b610b516001600160a01b03835116611837565b610b6a610b6583516001600160a01b031690565b61186b565b610b83610b7e83516001600160a01b031690565b611961565b90610bd7602083015151610b9e606086019182515190611e0c565b805160c0850190610bb882519160a0880192835191611e7c565b92610bc8875160019060101c1690565b610c50575b50505084846122bc565b9490919586610beb835160019060111c1690565b610bf9575b50505050929190565b84975093610c4694610c3c610c2f610c1885516001600160a01b031690565b6001600160a01b03165f52600260205260405f2090565b546001600160a01b031690565b94845133906129c4565b925f808080610bf0565b610c78610cb794888a610c70610c2f610c1883516001600160a01b031690565b923390611f8b565b610cac610ca6610c8f8a516001600160a01b031690565b6001600160a01b03165f52600560205260405f2090565b88612043565b519151905191611e7c565b5f8080610bcd565b90610cc86114db565b60208201906001600160a01b03610ce181845116611837565b610cf5610b6584516001600160a01b031690565b608084015115610ed15760408401516001600160a01b031690610d31610d2560608701516001600160a01b031690565b6001600160a01b031690565b911614610ec257610d4c610b7e83516001600160a01b031690565b92610d578482612b33565b90610d63858383612bca565b8551600c1c600116610e47575b8551610d8a9190600b1c600116610e06575b868484612f05565b9791979490978397610da18451600190600d1c1690565b610dd1575b505050505051610db581610ef4565b610dbe81610ef4565b610dc9575081929190565b918093509190565b85985090610df0610c2f610c18610dfb9894516001600160a01b031690565b94845191339261338a565b925f80808080610da6565b85516001600160a01b0316610e4060608601918251610e39610c2f836001600160a01b03165f52600260205260405f2090565b9185612e43565b9052610d82565b610e8090610e5c86516001600160a01b031690565b610e7a610c2f826001600160a01b03165f52600260205260405f2090565b91612d01565b610e9d610e97610c8f86516001600160a01b031690565b86612043565b610ea8828683612d88565b6040830152610d8a610ebb868484612bca565b9050610d70565b63a54b181d60e01b5f5260045ffd5b6357a456b760e01b5f5260045ffd5b634e487b7160e01b5f52602160045260245ffd5b60021115610efe57565b610ee0565b610f0b6114db565b600160075460021c166111a55760408101916001600160a01b03928381511693845f52600e6020528060405f205416156111925760049450610f4b61147a565b6020610f61610d2584516001600160a01b031690565b6040516338d52e0f60e01b815296879182905afa801561020a576080955f91611163575b5016610fa181610f9c84516001600160a01b031690565b6135b8565b81516001600160a01b031690610fbd60608601928351906135f5565b60016020860151610fcd81610ef4565b610fd681610ef4565b036110f857610ffe91855191610feb83610ef4565b84516001600160a01b0316915192613a34565b7feeb740c90bf2b18c9532eb7d473137767036d893dff3e009f32718f821b2a4c0829692979397968861105c61103e610d2589516001600160a01b031690565b94604051938493846040919493926060820195825260208201520152565b0390a25b805161106b81610ef4565b61107481610ef4565b6110c75701518084106110ad57506110a061109b91849283915b516001600160a01b031690565b6135f5565b6110a86114b6565b929190565b63e2ea151b60e01b5f52600484905260245260445ffd5b5ffd5b01518085116110e157506110a061109b918592839161108e565b63e2ea151b60e01b5f52600485905260245260445ffd5b61111b9185519161110883610ef4565b84516001600160a01b031691519261366e565b7f3771d13c67011e31e12031c54bb59b0bf544a80b81d280a3711e172aa8b7f47b829692979397968861115b61103e610d2589516001600160a01b031690565b0390a2611060565b611185915060203d60201161118b575b61117d81836102cd565b8101906111b4565b5f610f85565b503d611173565b846385f4129960e01b5f5260045260245ffd5b630f27df0960e01b5f5260045ffd5b908160209103126100ed575161042f816100dc565b91909161120b6112057f000000000000000000000000000000000000000000000000000000000000000092835c159586611274575b36916103de565b336156cc565b926112135750565b7f00000000000000000000000000000000000000000000000000000000000000005c611265575f905d6100fc7f0000000000000000000000000000000000000000000000000000000000000000613d31565b6320f1d86d60e01b5f5260045ffd5b6001855d6111fe565b906112866114db565b6112996001600160a01b03835116611837565b6112ad610b6583516001600160a01b031690565b61130a7f00000000000000000000000000000000000000000000000000000000000000005c6112e384516001600160a01b031690565b907f0000000000000000000000000000000000000000000000000000000000000000613d42565b61132361131e83516001600160a01b031690565b611bf0565b9061137760208301515161133e604086019182515190611e0c565b805160c085019061135882519160a0880192835191613d5b565b926113688751600190600e1c1690565b6113ca575b5050508484613f6a565b949095868461138b8451600190600f1c1690565b61139a575b5050505050929190565b6113c095506113b6610c2f610c1885516001600160a01b031690565b948451339061445b565b5f80808681611390565b6113f161141994888a6113ea610c2f610c1883516001600160a01b031690565b9233613e39565b61140e611408610c8f8a516001600160a01b031690565b886120a7565b519151905191613d5b565b5f808061136d565b637911c44b60e11b5f5260045ffd5b3461142157365f80375f8036816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af43d5f803e15611476573d5ff35b3d5ffd5b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c6114a7576001905d565b633ee5aeb560e01b5f5260045ffd5b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d565b7f00000000000000000000000000000000000000000000000000000000000000005c1561150457565b63604dd39b60e11b5f5260045ffd5b9061151d90614618565b90600160ff1b8214610941576100fc915f0390614654565b92919091611544828486614715565b60018101611554575b5050505050565b8082116116935703906001600160a01b03928381169384156116775780831695861561165b57846115b48561159e8661159e866001600160a01b03165f52601060205260405f2090565b906001600160a01b03165f5260205260405f2090565b551692833b156100ed57604051630ad0fe5760e31b81526001600160a01b039283166004820152919092166024820152604481018290527fa0175360a15bca328baf7ea85c7b784d58b222a50d0ce760b10dba336d226a6191611635915f8180606481015b038183895af1611642575b506040519081529081906020820190565b0390a45f8080808061154d565b8061164f6116559261027c565b80610946565b5f611624565b634a1406b160e11b5f526001600160a01b03841660045260245ffd5b63e602df0560e01b5f526001600160a01b03821660045260245ffd5b6001600160a01b0383637dc7a0d960e11b5f521660045260245260445260645ffd5b929091926001600160a01b039081841691821561181b578086169182156117ff576116f58661159e836001600160a01b03165f52600f60205260405f2090565b548086116117db5785900361171f8761159e846001600160a01b03165f52600f60205260405f2090565b5561173f8761159e836001600160a01b03165f52600f60205260405f2090565b8581540190551691827fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f6040518061177c88829190602083019252565b0390a4803b156100ed576040516323de665160e01b81526001600160a01b03938416600482015293909216602484015260448301525f908290818381606481015b03925af1801561020a576117ce5750565b8061164f6100fc9261027c565b63391434e360e21b5f526001600160a01b038716600452602452604485905260645ffd5b63ec442f0560e01b5f526001600160a01b03871660045260245ffd5b634b637e8f60e11b5f526001600160a01b03851660045260245ffd5b6001600160a01b0316805f525f602052600160405f2054811c16156118595750565b634bdace1360e01b5f5260045260245ffd5b63ffffffff807f00000000000000000000000000000000000000000000000000000000000000001642111580611953575b611944576001600160a01b0382165f525f60205260405f20549060018260021c16906118c6605a90565b906028820180921161094157826118fe575b505090506118e35750565b63d971f59760e01b5f526001600160a01b031660045260245ffd5b6119309250611939937f0000000000000000000000000000000000000000000000000000000000000000921c16615f8c565b63ffffffff1690565b421115805f806118d8565b6336a7e2cd60e21b5f5260045ffd5b506001600754811c1661189c565b60409081519161197083610295565b5f8352826020810191606080845281830190808252808401908082526080936080860182815260a0870183815260c088019384526119ac61147a565b6001600160a01b038a165f526005602052825f20935f602052835f20549260046020526119e8855f20946003602052865f209081549c52614761565b8b526119f38a6147b8565b88526119fe8a611e22565b8752611a098a611e22565b9052611a16898d51615bf2565b9052611a2188611e22565b81528a5191600199600184811c169384611bdc575b5083611bca575b5f5b8d8b8210611a9d575050505050505050505050505080611a8e611a76611a95936001600160a01b03165f52600560205260405f2090565b916001600160a01b03165f52600660205260405f2090565b9083614846565b61042f6114b6565b908a8d92828c8c8c611aff84611aeb81611add611ad88f8f61108e85611ac39251611e54565b6001600160a01b03165f5260205260405f2090565b614807565b94905f5260205260405f2090565b54945183611af98383611e54565b52611e54565b50611b09816149a1565b611b14858d51611e54565b52611b296001600160801b0384168587614a40565b878d8d15611bbd5782015115159182611b9f575b5050611b50575b50505050505b01611a3f565b82611b7392611b6a82611b638851615c4e565b9451611e54565b51961c85615c71565b9283611b83575b8e93508c611b44565b611b9693611b9091610b28565b91614a40565b5f8f8282611b7a565b90915051611bac81610ef4565b611bb581610ef4565b14875f611b3d565b5050505050505050611b4a565b8c5190935060031c6001161592611a3d565b611be7919450615c4e565b1515925f611a36565b604090815191611bff83610295565b5f8352826020810191606080845281830190808252808401908082526080936080860182815260a0870183815260c08801938452611c3b61147a565b6001600160a01b038a165f526005602052825f20935f602052835f2054926004602052611c77855f20946003602052865f209081549c52614761565b8b52611c828a6147b8565b8852611c8d8a611e22565b8752611c988a611e22565b9052611ca5898d51615bf2565b9052611cb088611e22565b81528a5191600199600184811c169384611df8575b5083611de6575b5f5b8d8b8210611d05575050505050505050505050505080611a8e611a76611a95936001600160a01b03165f52600560205260405f2090565b908a8d92828c8c8c611d2b84611aeb81611add611ad88f8f61108e85611ac39251611e54565b50611d35816149a1565b611d40858d51611e54565b52611d556001600160801b0384168587614a8d565b878d8d15611dd95782015115159182611dbb575b5050611d7c575b50505050505b01611cce565b82611d8f92611b6a82611b638851615c4e565b9283611d9f575b8e93508c611d70565b611db293611dac91610b28565b91614a8d565b5f8f8282611d96565b90915051611dc881610ef4565b611dd181610ef4565b14875f611d69565b5050505050505050611d76565b8c5190935060031c6001161592611ccc565b611e03919450615c4e565b1515925f611cc5565b03611e1357565b63aaad13f760e01b5f5260045ffd5b90611e2c8261033d565b611e3960405191826102cd565b8281528092611e4a601f199161033d565b0190602036910137565b8051821015611e685760209160051b010190565b634e487b7160e01b5f52603260045260245ffd5b9190825191611e8f825182519085614952565b611e9883611e22565b935f5b848110611eaa57505050505090565b80611edf611eba60019385611e54565b51611eda611ec88489611e54565b51611ed38589611e54565b519261498e565b614f33565b611ee98289611e54565b5201611e9b565b60041115610efe57565b519081151582036100ed57565b908160209103126100ed5761042f90611efa565b906004821015610efe5752565b959293611f59611f7d9561042f999793611f6f956001600160a01b038092168b521660208a01526040890190611f1b565b606087015260e0608087015260e0860190610432565b9084820360a0860152610432565b9160c0818403910152610465565b5f6001600160a01b036020959693611fea611fad87516001600160a01b031690565b94608088015197611fbd89611ef0565b60a0608060408301519c0151910151916040519b8c9a8b998a976302e97e7d60e61b895260048901611f28565b0393165af190811561020a575f91612014575b501561200557565b631557c43360e11b5f5260045ffd5b612036915060203d60201161203c575b61202e81836102cd565b810190611f07565b5f611ffd565b503d612024565b60208082015151925f5b84811061205b575050505050565b6001906120a16001600160801b03604061208161207b85838b0151611e54565b516149a1565b61208f8560a08b0151611e54565b52835f528587525f2054168287614a40565b0161204d565b60208082015151925f5b8481106120bf575050505050565b6001906120ff6001600160801b0360406120df61207b85838b0151611e54565b6120ed8560a08b0151611e54565b52835f528587525f2054168287614a8d565b016120b1565b60405190612112826102b1565b5f6040838281528260208201520152565b9080601f830112156100ed5781519060209161213e8161033d565b9361214c60405195866102cd565b81855260208086019260051b8201019283116100ed57602001905b828210612175575050505090565b81518152908301908301612167565b81601f820112156100ed5780519061219b826103c2565b926121a960405194856102cd565b828452602083830101116100ed57815f9260208093018386015e8301015290565b6080818303126100ed5780519260208201519167ffffffffffffffff928381116100ed57846121fa918301612123565b9360408201518481116100ed5781612213918401612123565b9360608301519081116100ed5761042f9201612184565b939061042f9593612268936001600160a01b0361225a93168752602087015260a0604087015260a0860190610432565b908482036060860152610432565b916080818403910152610465565b906001820180921161094157565b9190820180921161094157565b916122ae9061042f94928452606060208501526060840190610432565b916040818403910152610432565b926122c561147a565b6060916122d0612105565b9260208601906122e4825151808752611e22565b90608084019687516122f581611ef0565b6122fe81611ef0565b61270157506040840151906123138751611e22565b9561234f8360808c01516123496123318a516001600160a01b031690565b6001600160a01b03165f52601160205260405f205490565b90614ee2565b926123c07f00000000000000000000000000000000000000000000000000000000000000005c61238689516001600160a01b031690565b907f0000000000000000000000000000000000000000000000000000000000000000905f5260205260405f20905f5260205260405f205c90565b612684575b604087015180821161266c57506123de819a999a614f55565b60208a01985f5b8b51811015612527578c6123f98288611e54565b5161240381614f55565b61240d838a611e54565b5161251557816124338460a061242a8260c061243a980151611e54565b51930151611e54565b5191614f66565b80612445838a611e54565b525b61245561108e838b51611e54565b60608b01612464848251611e54565b5183106124e257508e83611b908f8f8f966124d6916124be866124b6818b60019e9d612493886124dc9f611513565b6124af6124a08489611e54565b5191516001600160a01b031690565b908d614f95565b875292611e54565b526124cd856060880151611e54565b51925190612284565b90610b28565b016123e5565b916124f1846110c49451611e54565b516317bc2f2360e11b5f526001600160a01b03909216600452602452604452606490565b50506125218188611e54565b51612447565b5093995095945095929861254d91975061254885516001600160a01b031690565b615097565b7ffbe5b0d79fb94f1e81c0a92bf86ae9d3a19e9d1bf6202c0d3e75120f65d5d8a561257f84516001600160a01b031690565b926125a186602087019561259a87516001600160a01b031690565b3391611535565b6125a96150fa565b612641575b6125d4866125c387516001600160a01b031690565b86516001600160a01b031690615161565b6126086123316125fc6125ee88516001600160a01b031690565b96516001600160a01b031690565b94519661108e88611ef0565b926126306001600160a01b039261261e88611ef0565b8c846040519586951698169684612291565b0390a461263b6114b6565b93929190565b6126678661265687516001600160a01b031690565b86516001600160a01b03169061510f565b6125ae565b6331d38e0b60e01b5f5260049190915260245260445ffd5b9894916126978b97949995929b51614b64565b9a5f5b86518110156126f157808b6126ea8f936126e46126d38f83906126c96001996126c3848a611e54565b51614f33565b611af98383611e54565b516126de8386611e54565b51610b28565b92611e54565b520161269a565b5091949893969a509194986123c5565b94906001885161271081611ef0565b61271981611ef0565b0361279d576127288951614aec565b60408501519186928a61279761278d8b8a60406127486060830151614b07565b92019482865286608082015193612787610d2561277961277261233188516001600160a01b031690565b9551614b64565b95516001600160a01b031690565b94614de5565b909251909a611e54565b526123c5565b600288969296516127ad81611ef0565b6127b681611ef0565b03612849576127c58951614aec565b6128428260608701906127e96127db8351614b07565b60408c019381855251611e54565b516127f5835188611e54565b528b612808608082015193518093611e54565b516128276128206123318c516001600160a01b031690565b9251614b64565b9261283c610d258c516001600160a01b031690565b94614bbb565b96906123c5565b50936003875161285881611ef0565b61286181611ef0565b03612909576128708851614ad0565b5f612888610d25610d2587516001600160a01b031690565b60408681015160808c015160a08901519251632ada38a360e21b8152998a94938593879385936128bd9392336004870161222a565b03925af194851561020a575f915f965f925f916128de575b509196926123c5565b92505095506128ff91503d805f833e6128f781836102cd565b8101906121ca565b919690915f6128d5565b63137a9a3960e01b5f5260045ffd5b9190916040818403126100ed5761292e81611efa565b92602082015167ffffffffffffffff81116100ed5761042f9201612123565b96939461042f9896926129b6966129876129a89661299a95610100948d6001600160a01b0380931690521660208d015260408c0190611f1b565b60608a01528060808a0152880190610432565b9086820360a0880152610432565b9084820360c0860152610432565b9160e0818403910152610465565b9493959296919084516129dd906001600160a01b031690565b906080860151926129ed84611ef0565b60808601518a60a0890151926040519b8c978897632754888d60e01b89526004890197612a199861294d565b03916001600160a01b031691815a5f948591f193841561020a575f905f95612b0c575b50158015612b00575b612af1576001809360091c1615612a635792935090915f835b612a6a575b5050505090565b8451811015612aec57612a7d8186611e54565b516060840190612a8e838351611e54565b5111612a9d5750830183612a5e565b612ac882612ac081612aba61108e8b9760206110c49a0151611e54565b95611e54565b519251611e54565b51633ef629c960e21b5f526001600160a01b03909216600452602452604452606490565b612a63565b6303a6723b60e31b5f5260045ffd5b50835185511415612a45565b9050612b2b9194503d805f833e612b2381836102cd565b810190612918565b93905f612a3c565b6040519291608084019067ffffffffffffffff82118583101761029057612bba916040525f855260208501945f8652612bb260408201915f83528360608201965f88528299612bab60208401805190612b9b6001600160a01b039283604088015116906145cb565b87525190606085015116906145cb565b9052612d88565b905251614b64565b9052565b612bc782610ef4565b52565b919091606060c0604051612bdd81610295565b5f81525f60208201528260408201525f838201525f60808201525f60a08201520152805192612c0b84610ef4565b6080604082015193015160c06020835193015193015193612c34612c2d61030f565b9687612bbe565b60208601526040850152606084015260808301523360a083015260c082015290565b90612bc782610ef4565b919060e08101908351612c7281610ef4565b8152602080850151602083015260408501519260e060408401528351809152602061010084019401915f5b828110612ced575050505060c084606061042f95960151606084015260808101516080840152612cdd60a082015160a08501906001600160a01b03169052565b01519060c0818403910152610465565b835186529481019492810192600101612c9d565b60209192612d385f6001600160a01b03809460405197889687958693635211fa7760e01b8552604060048601526044850190612c60565b911660248301520393165af190811561020a575f91612d69575b5015612d5a57565b63e91e17e760e01b5f5260045ffd5b612d82915060203d60201161203c5761202e81836102cd565b5f612d52565b9190918051612d9681610ef4565b612d9f81610ef4565b612de45790612ddb670de0b6b3a764000093611ed36080612de09501519360a0612dcf60c0850151835190611e54565b51930151905190611e54565b61498e565b0490565b61042f92612e20612e1a6080611eda9401519460a0612e0e602060c0870151930192835190611e54565b51940151905190611e54565b5161529a565b9261498e565b91908260409103126100ed576020612e3d83611efa565b92015190565b6040805163283a3d6b60e21b8152606060048201529490938593919284926001600160a01b039284928490612e7c906064860190612c60565b9216602484015260448301520392165afa90811561020a575f905f92612ed3575b5015612ec457670de0b5cad2bef0008111612eb55790565b6301d1b96560e61b5f5260045ffd5b6314fe5db560e21b5f5260045ffd5b9050612ef7915060403d604011612efe575b612eef81836102cd565b810190612e26565b905f612e9d565b503d612ee5565b5f9491939293612f1361147a565b612f1b612105565b918051612f2781610ef4565b612f3081610ef4565b1561328a575b602091828601612f4681516152be565b83612f8281850198612f65610d25610d258c516001600160a01b031690565b906040519c8d80948193633964c0c360e11b8352600483016132b2565b03925af198891561020a575f9961326b575b5088612f9f816152be565b8351612faa81610ef4565b612fb381610ef4565b6131f3575060408201519052612ff260c0880151612feb612e1a612fdc87860193845190611e54565b519260a08c0151905190611e54565b908a614f66565b9360808301519685979860a08501518088106131dc57505b60408501948a8651613022906001600160a01b031690565b9061302c916145b9565b60600195898751613043906001600160a01b031690565b9061304d91611513565b835183516001600160a01b031687516001600160a01b03168751916130729386614f95565b9190818601956040019283528552855160608401928d8285519061309591611e54565b51906130a091612284565b90516130ab91610b28565b6130b59185614a40565b85019182518b818451906130c891611e54565b51906130d391610b28565b6130dd9183614a40565b83516001600160a01b03165f908152600560205260409020918051875161310391611e54565b5191608001918251885161311691611e54565b5161312091615369565b87516131349085905f5260205260405f2090565b5551835161314191611e54565b519051835161314f91611e54565b5161315991615369565b915161316c91905f5260205260405f2090565b5551925193516060928301519151604080518b8152602081018b905290810193909352928201929092526001600160a01b039182169382169291909116907f0874b2d545cb271cdbda4e093020c452328b24af12382ed62c4d00f5c26709db90608090a4939291906100fc6114b6565b63e2ea151b60e01b5f52600488905260245260445ffd5b905081985061321a6060613223930151670de0b6b3a7640000818103908210029083615335565b90818652612284565b9661325061323760c0890151835190611e54565b5161324860a08a0151845190611e54565b51908a615355565b93608083015196859860a08501518088116131dc575061300a565b613283919950843d8611610203576101f581836102cd565b975f612f94565b602085016132ab6132a18251606086015190614f33565b8086528251610b28565b9052612f36565b90602061042f928181520190612c60565b6101a061042f92602083526132dc602084018251612c56565b60208101516001600160a01b0316604084015260408101516001600160a01b0316606084015260608101516080840152608081015160a084015260a081015160c084015260c081015160e084015260e08101516101009081850152810151610120908185015281015161335d61014091828601906001600160a01b03169052565b8101519061337961016092838601906001600160a01b03169052565b015191610180808201520190610465565b939590919492865161339b81610ef4565b6133a481610ef4565b6135a95786604085015191845b8251946133bd86610ef4565b6040978897888601516133d6906001600160a01b031690565b9660608701516133ec906001600160a01b031690565b9360800192835181516133fe91611e54565b519351906020015161340f91611e54565b51936020880151613426906001600160a01b031690565b9760c001519861343461031c565b9a61343f908c612bbe565b6001600160a01b031660208b01526001600160a01b0316898b01526060890152608088015260a087015260c086015260e085015261010084018890526001600160a01b03166101208401526001600160a01b031661014083015261016082015281516318b6eb5560e01b8152968791829081906134bf90600483016132c3565b03916001600160a01b03165a905f91f194851561020a575f915f96613585575b5050156135765760091c60011615613570575080516134fd81610ef4565b61350681610ef4565b1580613563575b8015613538575b61351c575090565b60a0015163cc0e4a9960e01b5f5260049190915260245260445ffd5b506001815161354681610ef4565b61354f81610ef4565b148015613514575060a08101518211613514565b5060a0810151821061350d565b91505090565b630568a77b60e21b5f5260045ffd5b6135a093965080919250903d10612efe57612eef81836102cd565b93905f806134df565b866040850151918492946133b1565b6001600160a01b0380911690815f52600e6020528060405f20541692168092036135e0575050565b6336b18d0960e01b5f5260045260245260445ffd5b907f00000000000000000000000000000000000000000000000000000000000000001161361f5750565b6001600160a01b03906318fe738560e01b5f521660045260245ffd5b81810392915f13801582851316918412161761094157565b9190915f838201938412911290801582169115161761094157565b93909161367a85610ef4565b841580156139bd576136af602061369087610b1a565b6040518093819263ef8b30f760e01b8352600483019190602083019252565b03816001600160a01b0387165afa801561020a576136d4915f9161399e575b50610b1a565b94955b6136f2836001600160a01b03165f52600b60205260405f2090565b54916136fc6150fa565b61399657869288929091608083901c91858310613771575050509261376b82613748866137436001600160a01b03966001600160801b03896100fc9b60801c039316612284565b615369565b9788613765856001600160a01b03165f52600b60205260405f2090565b556145b9565b16611513565b90929350613780919450610ef4565b15613879576137a86137a361379585846155a0565b61379e8a614618565b613653565b61544c565b926001600160a01b038116936137bf81868961556a565b604051636e553f6560e01b81526004810182905230602482015294602090869060449082905f905af1801561020a576137488995613854876138496001600160a01b038f96888f896100fc9f859e6138438f61376b9f6138499661384e996001600160801b03965f9161385a575b509a8b935b169061383e8282615468565b615613565b16612284565b610b28565b94612284565b90615369565b613873915060203d602011610203576101f581836102cd565b5f61382d565b90916138996137a361388b83856153ab565b61389489614618565b61363b565b60405163b3d7f6b960e01b8152600481018290526001600160a01b038316936020939290918481602481895afa801561020a576138df915f91613979575b50868a61556a565b6040516394bf804d60e01b815260048101829052306024820152948490869060449082905f905af191821561020a576100fc966138548b613849858f966001600160a01b038f896001600160801b03879f9a849f8f9661376b9f97613849966137489f9961384e9a613843955f9261395c575b5050988992613832565b6139729250803d10610203576101f581836102cd565b5f80613952565b6139909150863d8811610203576101f581836102cd565b5f6138d7565b509093505050565b6139b7915060203d602011610203576101f581836102cd565b5f6136ce565b6139ea60206139cb87612276565b6040518093819263b3d7f6b960e01b8352600483019190602083019252565b03816001600160a01b0387165afa801561020a57613a0f915f91613a15575b50612276565b956136d7565b613a2e915060203d602011610203576101f581836102cd565b5f613a09565b9390613a3f85610ef4565b8415948515613cda57613a756020613a5687610b1a565b6040518093819263266d6a8360e11b8352600483019190602083019252565b03816001600160a01b0389165afa801561020a57613a99915f9161399e5750610b1a565b94955b613ab7856001600160a01b03165f52600b60205260405f2090565b5491613ac16150fa565b6139965787938793909290916001600160801b039182841691868310613b3857505050936001600160a01b03613b0e83866100fc98613b0686613b339860801c612284565b921603615369565b9788613b2b826001600160a01b03165f52600b60205260405f2090565b555b166145b9565b611513565b919650929450613b489150610ef4565b15613c2d57613b5d6137a361379587856153ab565b604051635d043b2960e11b8152600481018290523060248201819052604482015293906020856064815f6001600160a01b038c165af1801561020a57613beb8995613854846138498e613be28b8f6001600160a01b036100fc9f9c613bdd8f9d613b339f94889f859f613849975f91613c0e575b509586925b1690615658565b612284565b9460801c612284565b9788613c08826001600160a01b03165f52600b60205260405f2090565b55613b2d565b613c27915060203d602011610203576101f581836102cd565b5f613bd1565b613c3d6137a361388b87856155a0565b604051632d182be560e21b81526004810182905230602482018190526044820152906020826064815f6001600160a01b038c165af191821561020a57613beb89956138546001600160a01b036138498e613be28b8f8a6100fc9f613bdd8f93613b339f9e889f958b9f96613849975f91613cbb575b509b8c93613bd6565b613cd4915060203d602011610203576101f581836102cd565b5f613cb2565b613d076020613ce887612276565b60405180938192630a28a47760e01b8352600483019190602083019252565b03816001600160a01b0389165afa801561020a57613d2b915f91613a155750612276565b95613a9c565b805c9060018201809211610941575d565b905f5260205260405f20905f52602052600160405f205d565b9190825191613d6e825182519085614952565b613d7783611e22565b935f5b848110613d8957505050505090565b80670de0b6b3a7640000613dbb613da260019486611e54565b51612ddb613db0858a611e54565b51611ed3868a611e54565b04613dc68289611e54565b5201613d7a565b60051115610efe57565b906005821015610efe5752565b959193613e1561042f989694613e2693611f7d976001600160a01b038092168b521660208a01526040890190613dd7565b60e0606088015260e0870190610432565b91608086015284820360a0860152610432565b925f6001600160a01b03602095969396613e9a613e5d87516001600160a01b031690565b94608088015197613e6d89613dcd565b60a060806060830151930151910151916040519b8c9a8b998a976345421ec760e01b895260048901613de4565b0393165af190811561020a575f91613ec4575b5015613eb557565b6305975b2960e11b5f5260045ffd5b613edd915060203d60201161203c5761202e81836102cd565b5f613ead565b916080838303126100ed5782519067ffffffffffffffff918281116100ed5783613f0e918601612123565b9360208101519360408201518481116100ed5781612213918401612123565b93613f57612268936001600160a01b0361042f98969416875260a0602088015260a0870190610432565b9160408601528482036060860152610432565b9190613f7461147a565b6060613f7e612105565b9160208501613f91815151808652611e22565b60808301958651613fa181613dcd565b613faa81613dcd565b6141e957506060830151613fbe8651611e22565b94613fe28260808b0151613fdc61233189516001600160a01b031690565b90615a38565b995b60608601518084106141d25750613ffd83999899614f55565b60208901975f5b8c8b51821015614111578161401891611e54565b5161402281614f55565b61402c8288611e54565b5161410057614051908d61404a8460a061242a8260c0860151611e54565b5191615355565b8061405c8389611e54565b525b61406c61108e838a51611e54565b60408a0161407b848251611e54565b5183116140cd57508d83611b908e6140bf8f968f976140aa866124b6818b60019e9d612493886140c79f6145b9565b526140b9856060880151611e54565b51612284565b905190610b28565b01614004565b916140dc846110c49451611e54565b516323b6a17960e21b5f526001600160a01b03909216600452602452604452606490565b5061410b8187611e54565b5161405e565b50509396945096509650966141319061254885516001600160a01b031690565b7fa26a52d8d53702bba7f137907b8e1f99ff87f6d450144270ca25e72481cca87161416384516001600160a01b031690565b9261418489602087019561417e87516001600160a01b031690565b90615a7f565b6141aa61233161419e6125ee88516001600160a01b031690565b94519661108e88613dcd565b926126306001600160a01b03926141c088613dcd565b88846040519586951698169684612291565b638d261d5d60e01b5f52600484905260245260445ffd5b600387516141f681613dcd565b6141ff81613dcd565b036142215761420e8851615a1c565b6142188151611e22565b945f9199613fe4565b976001875161422f81613dcd565b61423881613dcd565b036142a0576142478851614aec565b614298896142598460408801516157d1565b60808a01519061427361233188516001600160a01b031690565b61427d8c51614b64565b91614292610d258a516001600160a01b031690565b936157ec565b959091613fe4565b9793600287516142af81613dcd565b6142b881613dcd565b03614324579787986142ca8951614aec565b6060850151916142d987614b07565b61431e61431460408b0192808452898b9f8860808201519361430e610d2561277961277261233188516001600160a01b031690565b94615706565b9092519099611e54565b52613fe4565b506004865161433281613dcd565b61433b81613dcd565b036143e35761434a87516156ea565b5f614362610d25610d2586516001600160a01b031690565b60608501519060808a0151918360a0880151986143966040519a8b968795869463e4c4366360e01b86523360048701613f2d565b03925af193841561020a575f905f955f915f916143b8575b5090959199613fe4565b925050506143d99194503d805f833e6143d181836102cd565b810190613ee3565b919592915f6143ae565b636c02b39560e01b5f5260045ffd5b969261042f9896946144489361442c61443a936129b69995610100938d6001600160a01b0380931690521660208d015260408c0190613dd7565b8060608b0152890190610432565b908782036080890152610432565b9160a086015284820360c0860152610432565b949391959296908451614474906001600160a01b031690565b60808601519161448383613dcd565b608086015160a0880151906040968c6040519c8d9788976325da41f360e21b895260048901976144b2986143f2565b03916001600160a01b031691815a5f948591f194851561020a575f905f9661459a575b5015801561458e575b61457f576001809460091c16156144fe57909192809495505f905b614506575b505050505090565b855181101561457a576145198187611e54565b5182850190614529838351611e54565b511061453857508401846144f9565b869061455683612ac081612aba61108e6110c49860208c0151611e54565b5163677d1d7d60e11b5f526001600160a01b03909216600452602452604452606490565b6144fe565b63e124916560e01b5f5260045ffd5b508451865114156144de565b90506145b19195503d805f833e612b2381836102cd565b94905f6144d5565b6145c56100fc92614618565b90614654565b905f5b82518110156145fc576001600160a01b03806145ea8386611e54565b511690831614613570576001016145ce565b6001600160a01b038263ddef98d760e01b5f521660045260245ffd5b7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff81116146425790565b63123baf0360e11b5f5260045260245ffd5b8115614711576001600160a01b037f00000000000000000000000000000000000000000000000000000000000000009116805f528160205261469b60405f205c9384613653565b92836146df57505f197f0000000000000000000000000000000000000000000000000000000000000000805c918201918211610941575d5b5f5260205260405f205d565b6146d35761470c7f0000000000000000000000000000000000000000000000000000000000000000613d31565b6146d3565b5050565b6001600160a01b0392918381168484160361473357505050505f1990565b61475d9361159e92165f52601060205260405f20906001600160a01b03165f5260205260405f2090565b5490565b90604051918281549182825260209260208301915f5260205f20935f905b828210614795575050506100fc925003836102cd565b85546001600160a01b03168452600195860195889550938101939091019061477f565b906147c28261033d565b6147cf60405191826102cd565b82815280926147e0601f199161033d565b01905f5b8281106147f057505050565b6020906147fb612105565b828285010152016147e4565b90604051614814816102b1565b604060ff82945481811661482781610ef4565b84526001600160a01b038160081c16602085015260a81c161515910152565b60608101805151935f5b85811061485f57505050505050565b8061487361108e6001936020880151611e54565b6148956148888389905f5260205260405f2090565b546001600160801b031690565b6148a0838751611e54565b5181116148e7575b50506148ce6148b8828651611e54565b516148c7836080890151611e54565b5190615369565b6148e08288905f5260205260405f2090565b5501614850565b61493261494a9161492c61492361490f868a906001600160a01b03165f5260205260405f2090565b549261491c888c51611e54565b5190610b28565b8260801c612284565b90615cc4565b9185906001600160a01b03165f5260205260405f2090565b555f806148a8565b81148015929190614966575b5050611e1357565b141590505f8061495e565b90670de0b6b3a76400009182810292818404149015171561094157565b8181029291811591840414171561094157565b80516149ac81610ef4565b6149b581610ef4565b806149c8575050670de0b6b3a764000090565b806149d4600192610ef4565b03614a315760206149f3610d258260049401516001600160a01b031690565b6040516333cd77e760e11b815292839182905afa90811561020a575f91614a18575090565b61042f915060203d602011610203576101f581836102cd565b636fa2831960e11b5f5260045ffd5b91906080670de0b6b3a7640000614a84612bc79480614a638660608a0151611e54565b52612ddb614a758660c08a0151611e54565b51611ed38760a08b0151611e54565b04930151611e54565b91906080614ac8612bc79380614aa7856060890151611e54565b52611eda614ab98560c0890151611e54565b51611ed38660a08a0151611e54565b930151611e54565b60061c60011615614add57565b63033c2a5760e61b5f5260045ffd5b60041c600116614af857565b63353d5de760e21b5f5260045ffd5b80519081905f5b828110614b30575050811015614b215790565b631f91af7760e21b5f5260045ffd5b614b3a8183611e54565b51614b48575b600101614b0e565b928203614b555782614b40565b636b8c3be560e01b5f5260045ffd5b62ffffff9060121c1664174876e800908181029181830414901517156109415790565b91906020614b9e5f92604086526040860190610432565b930152565b91906020614b9e600192604086526040860190610432565b9094929192815194614bcc86611e22565b945f5b878110614d9c5750614be5906126de8988611e54565b614bef8887611e54565b5260405194631309bd3d60e31b9283875260208780614c118860048301614b87565b03816001600160a01b0385165afa96871561020a575f97614d7b575b506040519484865260208680614c468660048301614b87565b03816001600160a01b0386165afa93841561020a57613849614ca88c61491c614ca1614cbe96614c9a8f614c8a614cf49f9160209e88935f91614d5c575b506152f5565b92614c95848d615cd7565b611e54565b5190614f33565b9188611e54565b91670de0b6b3a7640000818103911002826152f5565b93614ccd856126de8c86611e54565b614cd78b85611e54565b526001600160a01b03604051809781958294835260048301614ba3565b0392165afa90811561020a57614d3095614d2a935f93614d33575b50614d1c614d2391611e22565b9788611e54565b5283610b28565b90615335565b91565b614d23919350614d54614d1c9160203d602011610203576101f581836102cd565b939150614d0f565b6020614d7592503d602011610203576101f581836102cd565b5f614c84565b614d9591975060203d602011610203576101f581836102cd565b955f614c2d565b80614db2614dac60019388611e54565b51610b1a565b614dbc828a611e54565b5201614bcf565b614ddb60409295949395606083526060830190610432565b9460208201520152565b909491830391838311610941576020614e316001600160a01b0392614e0a87876152f5565b614e148183615cd7565b60405194858094819362b5059f60e51b83528d8a60048501614dc3565b0392165afa801561020a57614d3095611eda88614e7c93614e8598614e8c965f92614e92575b50614e6a826126de61384994958b611e54565b98614e758d8a611e54565b5190615335565b93849251611e22565b9586611e54565b52610b28565b61384992506126de93614eb6614e6a9260203d602011610203576101f581836102cd565b93509350614e57565b634e487b7160e01b5f52601260045260245ffd5b8115614edd570490565b614ebf565b909291614eef8251611e22565b915f5b8151811015614f2c57614f0f83614f098385611e54565b5161498e565b908615614edd578660019204614f258287611e54565b5201614ef2565b5050509150565b90614f3d9161498e565b6001670de0b6b3a76400005f19830104019015150290565b80614f5d5750565b6100fc906152be565b91614f709161498e565b90670de0b6b3a764000090818102918183041490151715610941578115614edd570490565b91949290945f955f9581614faa575050505050565b849750612433614fc38260c0614fcf9697980151611e54565b519160a08a0151611e54565b945160018160031c1615614fe5575b808061154d565b62ffffff91929450602a1c1664174876e800908181029181830414901517156109415761501b670de0b6b3a7640000918661498e565b0492848411615088578061159e61506761504d61507f9461159e876001600160a01b03165f52600660205260405f2090565b54615061886001600160801b038316612284565b90615d5c565b936001600160a01b03165f52600660205260405f2090565b555f8080614fde565b634c69ac5d60e01b5f5260045ffd5b6001600160a01b0390929192165f52602060056020526040805f205f5b606086015180518210156150f157906150e16150d282600194611e54565b516148c78360808b0151611e54565b815f52838652845f2055016150b4565b50505050509050565b3215806151045790565b506001600754161590565b9032615152576001600160a01b0361514392165f52600f60205260405f20906001600160a01b03165f5260205260405f2090565b80549182018092116109415755565b6333fc255960e11b5f5260045ffd5b90916001600160a01b0380841692831561181b576151948561159e836001600160a01b03165f52600f60205260405f2090565b54808411615276578390036151be8661159e846001600160a01b03165f52600f60205260405f2090565b556151e4836151de836001600160a01b03165f52601160205260405f2090565b54610b28565b6151ed81615d6a565b615208826001600160a01b03165f52601160205260405f2090565b551690813b156100ed576040516323de665160e01b81526001600160a01b0390941660048501525f6024850181905260448501829052937fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f916152719186818060648101611619565b0390a4565b63391434e360e21b5f526001600160a01b038616600452602452604483905260645ffd5b670de0b6b3a76400008082040281036152b05790565b600181018091116109415790565b7f0000000000000000000000000000000000000000000000000000000000000000116152e657565b6303da9a2360e31b5f5260045ffd5b90801561532657670de0b6b3a764000091828102928184041490151715610941576001905f19830104019015150290565b630a0c22c760e01b5f5260045ffd5b8215615326576001916153479161498e565b915f19830104019015150290565b9061042f926153639161498e565b906152f5565b906001600160801b038083119081156153a1575b506153925760801b9081018091116109415790565b6389560ca160e01b5f5260045ffd5b905081115f61537d565b906153b88260801c614618565b906001600160801b035f9316806153dc575b50506002916153d89161363b565b0590565b6001600160a01b0393509060246020926040519586938492630a28a47760e01b84526004840152165afa90811561020a576154246153d8926002945f9161542d575b50614618565b928192506153ca565b615446915060203d602011610203576101f581836102cd565b5f61541e565b5f81126154565790565b635467221960e11b5f5260045260245ffd5b60405163095ea7b360e01b602082018181526001600160a01b03851660248401525f6044840152909391929183606481015b03916154ae601f19938481018752866102cd565b5f806001600160a01b0386169287519082855af1906154cb61569d565b82615538575b508161552d575b50156154e5575050505050565b60405160208101959095526001600160a01b031660248501525f604485015260649081018452615523936109179161551d90826102cd565b82615b9b565b5f8080808061154d565b90503b15155f6154d8565b80519192508115918215615550575b5050905f6154d1565b6155639250602080918301019101611f07565b5f80615547565b60405163095ea7b360e01b602082018181526001600160a01b03851660248401526044830195909552939092836064810161549a565b906155b36001600160801b038316614618565b905f9260801c806155cc5750506002916153d89161363b565b6001600160a01b039350906024602092604051958693849263b3d7f6b960e01b84526004840152165afa90811561020a576154246153d8926002945f9161542d5750614618565b9291906001600160a01b038085165f52600860205260405f20549283039283116109415781165f52600860205260405f2054928301809311610941576100fc93615d89565b9291906001600160a01b038085165f52600860205260405f20549283018093116109415781165f52600860205260405f2054928303928311610941576100fc93615d89565b3d156156c7573d906156ae826103c2565b916156bc60405193846102cd565b82523d5f602084013e565b606090565b5f8061042f9360208151910182855af16156e461569d565b91615ec0565b60051c600116156156f757565b63121db02f60e21b5f5260045ffd5b9094916020615735615720866001600160a01b0394612284565b9461572b87876152f5565b614e148183615f1a565b0392165afa801561020a57614d3095613849614ca885614e7c94614e85998c998a615794995f9461579a575b509061578861578161577a61578f946124d69798611e54565b5187610b28565b9c8c611e54565b519061498e565b614ed3565b52612284565b6124d6945061578161577a61578f94936157c56157889460203d602011610203576101f581836102cd565b97509394505050615761565b9060208083516157e2845182611e0c565b60051b930191015e565b9291909383516157fb81611e22565b9161580582611e22565b965f5b8381106159e15750506001600160a01b0381169160405195631309bd3d60e31b9283885260209889898061583f8460048301614b87565b0381895afa98891561020a575f996159c2575b506040518581528a81806158698b60048301614ba3565b03818a5afa90811561020a578a61578f6158a49361589d938f5f926159a5575b9b999d9c9a98979695949392919050614971565b8093615f1a565b5f5b89811061591357505050506158ca9550604051809681948293835260048301614ba3565b03915afa91821561020a578361578f936158f092614d30975f926158f6575b5050610b28565b9061498e565b61590c9250803d10610203576101f581836102cd565b5f806158e9565b869899959750838d83949596988361593761593082600198611e54565b5189615d49565b806159428385611e54565b511161595e575b505050505001908a96949897959392916158a6565b818361597f61599097615989946159788561491c99611e54565b5103614f33565b611af98388611e54565b5192611e54565b61599a828b611e54565b52848d8a835f615949565b6159bb9250803d10610203576101f581836102cd565b5f8f615889565b6159da9199508a3d8c11610203576101f581836102cd565b975f615852565b80615a0b615a066159f46001948c611e54565b516159ff8487611e54565b5190612284565b610b1a565b615a158288611e54565b5201615808565b60071c60011615615a2957565b63efe0265d60e01b5f5260045ffd5b9291615a448451611e22565b935f5b8151811015615a795780615a688585615a6260019587611e54565b51615335565b615a728289611e54565b5201615a47565b50505050565b916001600160a01b03808316938415615b7f57615ab783615ab1836001600160a01b03165f52601160205260405f2090565b54612284565b615ad68561159e846001600160a01b03165f52600f60205260405f2090565b848154019055615ae581615d6a565b615b00826001600160a01b03165f52601160205260405f2090565b5516925f847fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f60405180615b3987829190602083019252565b0390a4823b156100ed576040516323de665160e01b81525f600482018190526001600160a01b0390931660248201526044810191909152918290818381606481016117bd565b63ec442f0560e01b5f526001600160a01b03841660045260245ffd5b6001600160a01b03615baf911691826156cc565b8051908115159182615bd7575b5050615bc55750565b635274afe760e01b5f5260045260245ffd5b615bea9250602080918301019101611f07565b155f80615bbc565b9064ffffffffff615c0282611e22565b92605a1c165f5b828110615c165750505090565b60058082029082820414821517156109415782601f911c1690604d821161094157600191600a0a615c478287611e54565b5201615c09565b62ffffff9060421c1664174876e800908181029181830414901517156109415790565b9093925f94615c84846080850151611e54565b51818111615c93575050505050565b615cb995965091615ca8916124339303614f33565b9260a061242a8260c0860151611e54565b905f8080808061154d565b906001600160801b0361042f9216615369565b9060206001600160a01b0392600460405180958193635b3bfd2b60e11b8352165afa91821561020a575f92615d28575b50818110615d13575050565b63718e4adf60e11b5f5260045260245260445ffd5b615d4291925060203d602011610203576101f581836102cd565b905f615d07565b670de0b6b3a764000091612de09161498e565b9061042f9160801c90615369565b620f42408110615d775750565b6334e3483f60e21b5f5260045260245ffd5b6040516370a0823160e01b808252306004830152602095939490926001600160a01b03929187836024818786165afa92831561020a575f93615ea1575b50808310615e7a5750615dea906001600160a01b03165f52600860205260405f2090565b556040519182523060048301528316908481602481855afa94851561020a575f95615e5b575b5050818410615e39575050615e36906001600160a01b03165f52600860205260405f2090565b55565b631149424d60e01b5f526001600160a01b03166004526024525060445260645ffd5b615e72929550803d10610203576101f581836102cd565b925f80615e10565b631c6a537560e01b5f9081529387166001600160a01b031660045260245250604452606490fd5b615eb9919350883d8a11610203576101f581836102cd565b915f615dc6565b90615ee45750805115615ed557805190602001fd5b630a12f52160e11b5f5260045ffd5b81511580615f11575b615ef5575090565b6001600160a01b0390639996b31560e01b5f521660045260245ffd5b50803b15615eed565b9060206001600160a01b039260046040518095819363273c1adf60e01b8352165afa91821561020a575f92615f6b575b50818111615f56575050565b630fa2583760e21b5f5260045260245260445ffd5b615f8591925060203d602011610203576101f581836102cd565b905f615f4a565b91909163ffffffff808094169116019182116109415756fea26469706673582212206683429dd8621233bf9dfafe00f40360d4204093d879bd8a2517bc175dc511eb64736f6c634300081a0033",
+  "deployedBytecode": "0x60806040526004361015610018575b3661143057611421565b5f3560e01c806315afd409146100d757806315dacbea146100d257806321457897146100cd5780632bfb780c146100c857806343583be5146100c357806348c89491146100be5780634af29ec4146100b9578063ae639329146100b4578063b9a8effa146100af578063beabacc8146100aa578063c9c1661b146100a55763d2c725e00361000e57610aae565b6109c9565b610993565b610950565b610866565b610796565b6106fd565b610671565b610599565b6104b4565b61020f565b6100fe565b6001600160a01b038116036100ed57565b5f80fd5b35906100fc826100dc565b565b346100ed5760403660031901126100ed5760043561011b816100dc565b60243561012661147a565b61012e6114db565b6001600160a01b0382165f818152600860209081526040918290205491516370a0823160e01b8152306004820152919492829060249082905afa93841561020a576101cd946101a1925f916101db575b508061019b856001600160a01b03165f52600860205260405f2090565b55610b28565b918083116101d1575b50816101b591611513565b6101bd6114b6565b6040519081529081906020820190565b0390f35b91506101b56101aa565b6101fd915060203d602011610203575b6101f581836102cd565b810190610aec565b5f61017e565b503d6101eb565b610afb565b346100ed5760803660031901126100ed5761025d60043561022f816100dc565b60243561023b816100dc565b60443590610248826100dc565b61025760643580948333611535565b336116b5565b602060405160018152f35b634e487b7160e01b5f52604160045260245ffd5b67ffffffffffffffff811161029057604052565b610268565b60e0810190811067ffffffffffffffff82111761029057604052565b6060810190811067ffffffffffffffff82111761029057604052565b90601f8019910116810190811067ffffffffffffffff82111761029057604052565b6040519060c0820182811067ffffffffffffffff82111761029057604052565b604051906100fc82610295565b60405190610180820182811067ffffffffffffffff82111761029057604052565b67ffffffffffffffff81116102905760051b60200190565b9080601f830112156100ed57602090823561036f8161033d565b9361037d60405195866102cd565b81855260208086019260051b8201019283116100ed57602001905b8282106103a6575050505090565b81358152908301908301610398565b359060048210156100ed57565b67ffffffffffffffff811161029057601f01601f191660200190565b9291926103ea826103c2565b916103f860405193846102cd565b8294818452818301116100ed578281602093845f960137010152565b9080601f830112156100ed5781602061042f933591016103de565b90565b9081518082526020808093019301915f5b828110610451575050505090565b835185529381019392810192600101610443565b805180835260209291819084018484015e5f828201840152601f01601f1916010190565b916104a69061042f94928452606060208501526060840190610432565b916040818403910152610465565b346100ed576003196020368201126100ed5760043567ffffffffffffffff918282116100ed5760c09082360301126100ed576104ee6102ef565b6104fa826004016100f1565b8152610508602483016100f1565b60208201526044820135604082015260648201358381116100ed576105339060043691850101610355565b6060820152610544608483016103b5565b608082015260a48201359283116100ed5761056b6105759260046101cd9536920101610414565b60a0820152610b35565b60409391935193849384610489565b600211156100ed57565b35906100fc82610584565b346100ed576003196020368201126100ed5760043567ffffffffffffffff918282116100ed5760e09082360301126100ed576105d361030f565b6105df8260040161058e565b81526105ed602483016100f1565b60208201526105fe604483016100f1565b604082015261060f606483016100f1565b60608201526084820135608082015260a482013560a082015260c48201359283116100ed5761064a6106549260046101cd9536920101610414565b60c0820152610cbf565b604080519384526020840192909252908201529081906060820190565b346100ed5760a03660031901126100ed5760405160a0810181811067ffffffffffffffff821117610290576101cd91610654916040526004356106b381610584565b81526024356106c181610584565b60208201526044356106d2816100dc565b604082015260643560608201526084356080820152610f03565b90602061042f928181520190610465565b346100ed5760203660031901126100ed5767ffffffffffffffff6004358181116100ed57366023820112156100ed5780600401359182116100ed5736602483830101116100ed576101cd91602461075492016111c9565b604051918291826106ec565b359060058210156100ed57565b61078361042f9492606083526060830190610432565b9260208201526040818403910152610465565b346100ed576003196020368201126100ed5760043567ffffffffffffffff918282116100ed5760c09082360301126100ed576107d06102ef565b6107dc826004016100f1565b81526107ea602483016100f1565b602082015260448201358381116100ed5761080b9060043691850101610355565b60408201526064820135606082015261082660848301610760565b608082015260a48201359283116100ed5761084d6108579260046101cd9536920101610414565b60a082015261127d565b6040939193519384938461076d565b346100ed5760603660031901126100ed57600435610883816100dc565b60243590610890826100dc565b6044359061089c61147a565b6108a46114db565b6108b66108b083614618565b82614654565b6001600160a01b0381165f52600860205260405f208054938385039485116109415793905560405163a9059cbb60e01b60208201526001600160a01b03909316602484015260448084019290925290825261091c91906109176064836102cd565b615b9b565b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d005b610b06565b5f9103126100ed57565b346100ed575f3660031901126100ed5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b346100ed5760603660031901126100ed5761025d6004356109b3816100dc565b6024356109bf816100dc565b60443591336116b5565b346100ed5760403660031901126100ed576004356109e6816100dc565b602435906109f3826100dc565b6001600160a01b0380911691825f525f602052600192600160405f20541615610a9c575f93929352600360205260405f20926040519283602086549182815201955f5260205f20925f905b828210610a6f5786610a5c87610a56838c03846102cd565b826145cb565b9051604080519182526020820192909252f35b90919280610a9086998483985416906001600160a01b036020921681520190565b98019493920190610a3e565b6327946f5760e21b5f5260045260245ffd5b346100ed575f3660031901126100ed5760207f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6040519015158152f35b908160209103126100ed575190565b6040513d5f823e3d90fd5b634e487b7160e01b5f52601160045260245ffd5b5f1981019190821161094157565b9190820391821161094157565b90610b3e6114db565b610b516001600160a01b03835116611837565b610b6a610b6583516001600160a01b031690565b61186b565b610b83610b7e83516001600160a01b031690565b611961565b90610bd7602083015151610b9e606086019182515190611e0c565b805160c0850190610bb882519160a0880192835191611e7c565b92610bc8875160019060101c1690565b610c50575b50505084846122bc565b9490919586610beb835160019060111c1690565b610bf9575b50505050929190565b84975093610c4694610c3c610c2f610c1885516001600160a01b031690565b6001600160a01b03165f52600260205260405f2090565b546001600160a01b031690565b94845133906129c4565b925f808080610bf0565b610c78610cb794888a610c70610c2f610c1883516001600160a01b031690565b923390611f8b565b610cac610ca6610c8f8a516001600160a01b031690565b6001600160a01b03165f52600560205260405f2090565b88612043565b519151905191611e7c565b5f8080610bcd565b90610cc86114db565b60208201906001600160a01b03610ce181845116611837565b610cf5610b6584516001600160a01b031690565b608084015115610ed15760408401516001600160a01b031690610d31610d2560608701516001600160a01b031690565b6001600160a01b031690565b911614610ec257610d4c610b7e83516001600160a01b031690565b92610d578482612b33565b90610d63858383612bca565b8551600c1c600116610e47575b8551610d8a9190600b1c600116610e06575b868484612f05565b9791979490978397610da18451600190600d1c1690565b610dd1575b505050505051610db581610ef4565b610dbe81610ef4565b610dc9575081929190565b918093509190565b85985090610df0610c2f610c18610dfb9894516001600160a01b031690565b94845191339261338a565b925f80808080610da6565b85516001600160a01b0316610e4060608601918251610e39610c2f836001600160a01b03165f52600260205260405f2090565b9185612e43565b9052610d82565b610e8090610e5c86516001600160a01b031690565b610e7a610c2f826001600160a01b03165f52600260205260405f2090565b91612d01565b610e9d610e97610c8f86516001600160a01b031690565b86612043565b610ea8828683612d88565b6040830152610d8a610ebb868484612bca565b9050610d70565b63a54b181d60e01b5f5260045ffd5b6357a456b760e01b5f5260045ffd5b634e487b7160e01b5f52602160045260245ffd5b60021115610efe57565b610ee0565b610f0b6114db565b600160075460021c166111a55760408101916001600160a01b03928381511693845f52600e6020528060405f205416156111925760049450610f4b61147a565b6020610f61610d2584516001600160a01b031690565b6040516338d52e0f60e01b815296879182905afa801561020a576080955f91611163575b5016610fa181610f9c84516001600160a01b031690565b6135b8565b81516001600160a01b031690610fbd60608601928351906135f5565b60016020860151610fcd81610ef4565b610fd681610ef4565b036110f857610ffe91855191610feb83610ef4565b84516001600160a01b0316915192613a34565b7feeb740c90bf2b18c9532eb7d473137767036d893dff3e009f32718f821b2a4c0829692979397968861105c61103e610d2589516001600160a01b031690565b94604051938493846040919493926060820195825260208201520152565b0390a25b805161106b81610ef4565b61107481610ef4565b6110c75701518084106110ad57506110a061109b91849283915b516001600160a01b031690565b6135f5565b6110a86114b6565b929190565b63e2ea151b60e01b5f52600484905260245260445ffd5b5ffd5b01518085116110e157506110a061109b918592839161108e565b63e2ea151b60e01b5f52600485905260245260445ffd5b61111b9185519161110883610ef4565b84516001600160a01b031691519261366e565b7f3771d13c67011e31e12031c54bb59b0bf544a80b81d280a3711e172aa8b7f47b829692979397968861115b61103e610d2589516001600160a01b031690565b0390a2611060565b611185915060203d60201161118b575b61117d81836102cd565b8101906111b4565b5f610f85565b503d611173565b846385f4129960e01b5f5260045260245ffd5b630f27df0960e01b5f5260045ffd5b908160209103126100ed575161042f816100dc565b91909161120b6112057f000000000000000000000000000000000000000000000000000000000000000092835c159586611274575b36916103de565b336156cc565b926112135750565b7f00000000000000000000000000000000000000000000000000000000000000005c611265575f905d6100fc7f0000000000000000000000000000000000000000000000000000000000000000613d31565b6320f1d86d60e01b5f5260045ffd5b6001855d6111fe565b906112866114db565b6112996001600160a01b03835116611837565b6112ad610b6583516001600160a01b031690565b61130a7f00000000000000000000000000000000000000000000000000000000000000005c6112e384516001600160a01b031690565b907f0000000000000000000000000000000000000000000000000000000000000000613d42565b61132361131e83516001600160a01b031690565b611bf0565b9061137760208301515161133e604086019182515190611e0c565b805160c085019061135882519160a0880192835191613d5b565b926113688751600190600e1c1690565b6113ca575b5050508484613f6a565b949095868461138b8451600190600f1c1690565b61139a575b5050505050929190565b6113c095506113b6610c2f610c1885516001600160a01b031690565b948451339061445b565b5f80808681611390565b6113f161141994888a6113ea610c2f610c1883516001600160a01b031690565b9233613e39565b61140e611408610c8f8a516001600160a01b031690565b886120a7565b519151905191613d5b565b5f808061136d565b637911c44b60e11b5f5260045ffd5b3461142157365f80375f8036816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af43d5f803e15611476573d5ff35b3d5ffd5b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c6114a7576001905d565b633ee5aeb560e01b5f5260045ffd5b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d565b7f00000000000000000000000000000000000000000000000000000000000000005c1561150457565b63604dd39b60e11b5f5260045ffd5b9061151d90614618565b90600160ff1b8214610941576100fc915f0390614654565b92919091611544828486614715565b60018101611554575b5050505050565b8082116116935703906001600160a01b03928381169384156116775780831695861561165b57846115b48561159e8661159e866001600160a01b03165f52601060205260405f2090565b906001600160a01b03165f5260205260405f2090565b551692833b156100ed57604051630ad0fe5760e31b81526001600160a01b039283166004820152919092166024820152604481018290527fa0175360a15bca328baf7ea85c7b784d58b222a50d0ce760b10dba336d226a6191611635915f8180606481015b038183895af1611642575b506040519081529081906020820190565b0390a45f8080808061154d565b8061164f6116559261027c565b80610946565b5f611624565b634a1406b160e11b5f526001600160a01b03841660045260245ffd5b63e602df0560e01b5f526001600160a01b03821660045260245ffd5b6001600160a01b0383637dc7a0d960e11b5f521660045260245260445260645ffd5b929091926001600160a01b039081841691821561181b578086169182156117ff576116f58661159e836001600160a01b03165f52600f60205260405f2090565b548086116117db5785900361171f8761159e846001600160a01b03165f52600f60205260405f2090565b5561173f8761159e836001600160a01b03165f52600f60205260405f2090565b8581540190551691827fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f6040518061177c88829190602083019252565b0390a4803b156100ed576040516323de665160e01b81526001600160a01b03938416600482015293909216602484015260448301525f908290818381606481015b03925af1801561020a576117ce5750565b8061164f6100fc9261027c565b63391434e360e21b5f526001600160a01b038716600452602452604485905260645ffd5b63ec442f0560e01b5f526001600160a01b03871660045260245ffd5b634b637e8f60e11b5f526001600160a01b03851660045260245ffd5b6001600160a01b0316805f525f602052600160405f2054811c16156118595750565b634bdace1360e01b5f5260045260245ffd5b63ffffffff807f00000000000000000000000000000000000000000000000000000000000000001642111580611953575b611944576001600160a01b0382165f525f60205260405f20549060018260021c16906118c6605a90565b906028820180921161094157826118fe575b505090506118e35750565b63d971f59760e01b5f526001600160a01b031660045260245ffd5b6119309250611939937f0000000000000000000000000000000000000000000000000000000000000000921c16615f8c565b63ffffffff1690565b421115805f806118d8565b6336a7e2cd60e21b5f5260045ffd5b506001600754811c1661189c565b60409081519161197083610295565b5f8352826020810191606080845281830190808252808401908082526080936080860182815260a0870183815260c088019384526119ac61147a565b6001600160a01b038a165f526005602052825f20935f602052835f20549260046020526119e8855f20946003602052865f209081549c52614761565b8b526119f38a6147b8565b88526119fe8a611e22565b8752611a098a611e22565b9052611a16898d51615bf2565b9052611a2188611e22565b81528a5191600199600184811c169384611bdc575b5083611bca575b5f5b8d8b8210611a9d575050505050505050505050505080611a8e611a76611a95936001600160a01b03165f52600560205260405f2090565b916001600160a01b03165f52600660205260405f2090565b9083614846565b61042f6114b6565b908a8d92828c8c8c611aff84611aeb81611add611ad88f8f61108e85611ac39251611e54565b6001600160a01b03165f5260205260405f2090565b614807565b94905f5260205260405f2090565b54945183611af98383611e54565b52611e54565b50611b09816149a1565b611b14858d51611e54565b52611b296001600160801b0384168587614a40565b878d8d15611bbd5782015115159182611b9f575b5050611b50575b50505050505b01611a3f565b82611b7392611b6a82611b638851615c4e565b9451611e54565b51961c85615c71565b9283611b83575b8e93508c611b44565b611b9693611b9091610b28565b91614a40565b5f8f8282611b7a565b90915051611bac81610ef4565b611bb581610ef4565b14875f611b3d565b5050505050505050611b4a565b8c5190935060031c6001161592611a3d565b611be7919450615c4e565b1515925f611a36565b604090815191611bff83610295565b5f8352826020810191606080845281830190808252808401908082526080936080860182815260a0870183815260c08801938452611c3b61147a565b6001600160a01b038a165f526005602052825f20935f602052835f2054926004602052611c77855f20946003602052865f209081549c52614761565b8b52611c828a6147b8565b8852611c8d8a611e22565b8752611c988a611e22565b9052611ca5898d51615bf2565b9052611cb088611e22565b81528a5191600199600184811c169384611df8575b5083611de6575b5f5b8d8b8210611d05575050505050505050505050505080611a8e611a76611a95936001600160a01b03165f52600560205260405f2090565b908a8d92828c8c8c611d2b84611aeb81611add611ad88f8f61108e85611ac39251611e54565b50611d35816149a1565b611d40858d51611e54565b52611d556001600160801b0384168587614a8d565b878d8d15611dd95782015115159182611dbb575b5050611d7c575b50505050505b01611cce565b82611d8f92611b6a82611b638851615c4e565b9283611d9f575b8e93508c611d70565b611db293611dac91610b28565b91614a8d565b5f8f8282611d96565b90915051611dc881610ef4565b611dd181610ef4565b14875f611d69565b5050505050505050611d76565b8c5190935060031c6001161592611ccc565b611e03919450615c4e565b1515925f611cc5565b03611e1357565b63aaad13f760e01b5f5260045ffd5b90611e2c8261033d565b611e3960405191826102cd565b8281528092611e4a601f199161033d565b0190602036910137565b8051821015611e685760209160051b010190565b634e487b7160e01b5f52603260045260245ffd5b9190825191611e8f825182519085614952565b611e9883611e22565b935f5b848110611eaa57505050505090565b80611edf611eba60019385611e54565b51611eda611ec88489611e54565b51611ed38589611e54565b519261498e565b614f33565b611ee98289611e54565b5201611e9b565b60041115610efe57565b519081151582036100ed57565b908160209103126100ed5761042f90611efa565b906004821015610efe5752565b959293611f59611f7d9561042f999793611f6f956001600160a01b038092168b521660208a01526040890190611f1b565b606087015260e0608087015260e0860190610432565b9084820360a0860152610432565b9160c0818403910152610465565b5f6001600160a01b036020959693611fea611fad87516001600160a01b031690565b94608088015197611fbd89611ef0565b60a0608060408301519c0151910151916040519b8c9a8b998a976302e97e7d60e61b895260048901611f28565b0393165af190811561020a575f91612014575b501561200557565b631557c43360e11b5f5260045ffd5b612036915060203d60201161203c575b61202e81836102cd565b810190611f07565b5f611ffd565b503d612024565b60208082015151925f5b84811061205b575050505050565b6001906120a16001600160801b03604061208161207b85838b0151611e54565b516149a1565b61208f8560a08b0151611e54565b52835f528587525f2054168287614a40565b0161204d565b60208082015151925f5b8481106120bf575050505050565b6001906120ff6001600160801b0360406120df61207b85838b0151611e54565b6120ed8560a08b0151611e54565b52835f528587525f2054168287614a8d565b016120b1565b60405190612112826102b1565b5f6040838281528260208201520152565b9080601f830112156100ed5781519060209161213e8161033d565b9361214c60405195866102cd565b81855260208086019260051b8201019283116100ed57602001905b828210612175575050505090565b81518152908301908301612167565b81601f820112156100ed5780519061219b826103c2565b926121a960405194856102cd565b828452602083830101116100ed57815f9260208093018386015e8301015290565b6080818303126100ed5780519260208201519167ffffffffffffffff928381116100ed57846121fa918301612123565b9360408201518481116100ed5781612213918401612123565b9360608301519081116100ed5761042f9201612184565b939061042f9593612268936001600160a01b0361225a93168752602087015260a0604087015260a0860190610432565b908482036060860152610432565b916080818403910152610465565b906001820180921161094157565b9190820180921161094157565b916122ae9061042f94928452606060208501526060840190610432565b916040818403910152610432565b926122c561147a565b6060916122d0612105565b9260208601906122e4825151808752611e22565b90608084019687516122f581611ef0565b6122fe81611ef0565b61270157506040840151906123138751611e22565b9561234f8360808c01516123496123318a516001600160a01b031690565b6001600160a01b03165f52601160205260405f205490565b90614ee2565b926123c07f00000000000000000000000000000000000000000000000000000000000000005c61238689516001600160a01b031690565b907f0000000000000000000000000000000000000000000000000000000000000000905f5260205260405f20905f5260205260405f205c90565b612684575b604087015180821161266c57506123de819a999a614f55565b60208a01985f5b8b51811015612527578c6123f98288611e54565b5161240381614f55565b61240d838a611e54565b5161251557816124338460a061242a8260c061243a980151611e54565b51930151611e54565b5191614f66565b80612445838a611e54565b525b61245561108e838b51611e54565b60608b01612464848251611e54565b5183106124e257508e83611b908f8f8f966124d6916124be866124b6818b60019e9d612493886124dc9f611513565b6124af6124a08489611e54565b5191516001600160a01b031690565b908d614f95565b875292611e54565b526124cd856060880151611e54565b51925190612284565b90610b28565b016123e5565b916124f1846110c49451611e54565b516317bc2f2360e11b5f526001600160a01b03909216600452602452604452606490565b50506125218188611e54565b51612447565b5093995095945095929861254d91975061254885516001600160a01b031690565b615097565b7ffbe5b0d79fb94f1e81c0a92bf86ae9d3a19e9d1bf6202c0d3e75120f65d5d8a561257f84516001600160a01b031690565b926125a186602087019561259a87516001600160a01b031690565b3391611535565b6125a96150fa565b612641575b6125d4866125c387516001600160a01b031690565b86516001600160a01b031690615161565b6126086123316125fc6125ee88516001600160a01b031690565b96516001600160a01b031690565b94519661108e88611ef0565b926126306001600160a01b039261261e88611ef0565b8c846040519586951698169684612291565b0390a461263b6114b6565b93929190565b6126678661265687516001600160a01b031690565b86516001600160a01b03169061510f565b6125ae565b6331d38e0b60e01b5f5260049190915260245260445ffd5b9894916126978b97949995929b51614b64565b9a5f5b86518110156126f157808b6126ea8f936126e46126d38f83906126c96001996126c3848a611e54565b51614f33565b611af98383611e54565b516126de8386611e54565b51610b28565b92611e54565b520161269a565b5091949893969a509194986123c5565b94906001885161271081611ef0565b61271981611ef0565b0361279d576127288951614aec565b60408501519186928a61279761278d8b8a60406127486060830151614b07565b92019482865286608082015193612787610d2561277961277261233188516001600160a01b031690565b9551614b64565b95516001600160a01b031690565b94614de5565b909251909a611e54565b526123c5565b600288969296516127ad81611ef0565b6127b681611ef0565b03612849576127c58951614aec565b6128428260608701906127e96127db8351614b07565b60408c019381855251611e54565b516127f5835188611e54565b528b612808608082015193518093611e54565b516128276128206123318c516001600160a01b031690565b9251614b64565b9261283c610d258c516001600160a01b031690565b94614bbb565b96906123c5565b50936003875161285881611ef0565b61286181611ef0565b03612909576128708851614ad0565b5f612888610d25610d2587516001600160a01b031690565b60408681015160808c015160a08901519251632ada38a360e21b8152998a94938593879385936128bd9392336004870161222a565b03925af194851561020a575f915f965f925f916128de575b509196926123c5565b92505095506128ff91503d805f833e6128f781836102cd565b8101906121ca565b919690915f6128d5565b63137a9a3960e01b5f5260045ffd5b9190916040818403126100ed5761292e81611efa565b92602082015167ffffffffffffffff81116100ed5761042f9201612123565b96939461042f9896926129b6966129876129a89661299a95610100948d6001600160a01b0380931690521660208d015260408c0190611f1b565b60608a01528060808a0152880190610432565b9086820360a0880152610432565b9084820360c0860152610432565b9160e0818403910152610465565b9493959296919084516129dd906001600160a01b031690565b906080860151926129ed84611ef0565b60808601518a60a0890151926040519b8c978897632754888d60e01b89526004890197612a199861294d565b03916001600160a01b031691815a5f948591f193841561020a575f905f95612b0c575b50158015612b00575b612af1576001809360091c1615612a635792935090915f835b612a6a575b5050505090565b8451811015612aec57612a7d8186611e54565b516060840190612a8e838351611e54565b5111612a9d5750830183612a5e565b612ac882612ac081612aba61108e8b9760206110c49a0151611e54565b95611e54565b519251611e54565b51633ef629c960e21b5f526001600160a01b03909216600452602452604452606490565b612a63565b6303a6723b60e31b5f5260045ffd5b50835185511415612a45565b9050612b2b9194503d805f833e612b2381836102cd565b810190612918565b93905f612a3c565b6040519291608084019067ffffffffffffffff82118583101761029057612bba916040525f855260208501945f8652612bb260408201915f83528360608201965f88528299612bab60208401805190612b9b6001600160a01b039283604088015116906145cb565b87525190606085015116906145cb565b9052612d88565b905251614b64565b9052565b612bc782610ef4565b52565b919091606060c0604051612bdd81610295565b5f81525f60208201528260408201525f838201525f60808201525f60a08201520152805192612c0b84610ef4565b6080604082015193015160c06020835193015193015193612c34612c2d61030f565b9687612bbe565b60208601526040850152606084015260808301523360a083015260c082015290565b90612bc782610ef4565b919060e08101908351612c7281610ef4565b8152602080850151602083015260408501519260e060408401528351809152602061010084019401915f5b828110612ced575050505060c084606061042f95960151606084015260808101516080840152612cdd60a082015160a08501906001600160a01b03169052565b01519060c0818403910152610465565b835186529481019492810192600101612c9d565b60209192612d385f6001600160a01b03809460405197889687958693635211fa7760e01b8552604060048601526044850190612c60565b911660248301520393165af190811561020a575f91612d69575b5015612d5a57565b63e91e17e760e01b5f5260045ffd5b612d82915060203d60201161203c5761202e81836102cd565b5f612d52565b9190918051612d9681610ef4565b612d9f81610ef4565b612de45790612ddb670de0b6b3a764000093611ed36080612de09501519360a0612dcf60c0850151835190611e54565b51930151905190611e54565b61498e565b0490565b61042f92612e20612e1a6080611eda9401519460a0612e0e602060c0870151930192835190611e54565b51940151905190611e54565b5161529a565b9261498e565b91908260409103126100ed576020612e3d83611efa565b92015190565b6040805163283a3d6b60e21b8152606060048201529490938593919284926001600160a01b039284928490612e7c906064860190612c60565b9216602484015260448301520392165afa90811561020a575f905f92612ed3575b5015612ec457670de0b5cad2bef0008111612eb55790565b6301d1b96560e61b5f5260045ffd5b6314fe5db560e21b5f5260045ffd5b9050612ef7915060403d604011612efe575b612eef81836102cd565b810190612e26565b905f612e9d565b503d612ee5565b5f9491939293612f1361147a565b612f1b612105565b918051612f2781610ef4565b612f3081610ef4565b1561328a575b602091828601612f4681516152be565b83612f8281850198612f65610d25610d258c516001600160a01b031690565b906040519c8d80948193633964c0c360e11b8352600483016132b2565b03925af198891561020a575f9961326b575b5088612f9f816152be565b8351612faa81610ef4565b612fb381610ef4565b6131f3575060408201519052612ff260c0880151612feb612e1a612fdc87860193845190611e54565b519260a08c0151905190611e54565b908a614f66565b9360808301519685979860a08501518088106131dc57505b60408501948a8651613022906001600160a01b031690565b9061302c916145b9565b60600195898751613043906001600160a01b031690565b9061304d91611513565b835183516001600160a01b031687516001600160a01b03168751916130729386614f95565b9190818601956040019283528552855160608401928d8285519061309591611e54565b51906130a091612284565b90516130ab91610b28565b6130b59185614a40565b85019182518b818451906130c891611e54565b51906130d391610b28565b6130dd9183614a40565b83516001600160a01b03165f908152600560205260409020918051875161310391611e54565b5191608001918251885161311691611e54565b5161312091615369565b87516131349085905f5260205260405f2090565b5551835161314191611e54565b519051835161314f91611e54565b5161315991615369565b915161316c91905f5260205260405f2090565b5551925193516060928301519151604080518b8152602081018b905290810193909352928201929092526001600160a01b039182169382169291909116907f0874b2d545cb271cdbda4e093020c452328b24af12382ed62c4d00f5c26709db90608090a4939291906100fc6114b6565b63e2ea151b60e01b5f52600488905260245260445ffd5b905081985061321a6060613223930151670de0b6b3a7640000818103908210029083615335565b90818652612284565b9661325061323760c0890151835190611e54565b5161324860a08a0151845190611e54565b51908a615355565b93608083015196859860a08501518088116131dc575061300a565b613283919950843d8611610203576101f581836102cd565b975f612f94565b602085016132ab6132a18251606086015190614f33565b8086528251610b28565b9052612f36565b90602061042f928181520190612c60565b6101a061042f92602083526132dc602084018251612c56565b60208101516001600160a01b0316604084015260408101516001600160a01b0316606084015260608101516080840152608081015160a084015260a081015160c084015260c081015160e084015260e08101516101009081850152810151610120908185015281015161335d61014091828601906001600160a01b03169052565b8101519061337961016092838601906001600160a01b03169052565b015191610180808201520190610465565b939590919492865161339b81610ef4565b6133a481610ef4565b6135a95786604085015191845b8251946133bd86610ef4565b6040978897888601516133d6906001600160a01b031690565b9660608701516133ec906001600160a01b031690565b9360800192835181516133fe91611e54565b519351906020015161340f91611e54565b51936020880151613426906001600160a01b031690565b9760c001519861343461031c565b9a61343f908c612bbe565b6001600160a01b031660208b01526001600160a01b0316898b01526060890152608088015260a087015260c086015260e085015261010084018890526001600160a01b03166101208401526001600160a01b031661014083015261016082015281516318b6eb5560e01b8152968791829081906134bf90600483016132c3565b03916001600160a01b03165a905f91f194851561020a575f915f96613585575b5050156135765760091c60011615613570575080516134fd81610ef4565b61350681610ef4565b1580613563575b8015613538575b61351c575090565b60a0015163cc0e4a9960e01b5f5260049190915260245260445ffd5b506001815161354681610ef4565b61354f81610ef4565b148015613514575060a08101518211613514565b5060a0810151821061350d565b91505090565b630568a77b60e21b5f5260045ffd5b6135a093965080919250903d10612efe57612eef81836102cd565b93905f806134df565b866040850151918492946133b1565b6001600160a01b0380911690815f52600e6020528060405f20541692168092036135e0575050565b6336b18d0960e01b5f5260045260245260445ffd5b907f00000000000000000000000000000000000000000000000000000000000000001161361f5750565b6001600160a01b03906318fe738560e01b5f521660045260245ffd5b81810392915f13801582851316918412161761094157565b9190915f838201938412911290801582169115161761094157565b93909161367a85610ef4565b841580156139bd576136af602061369087610b1a565b6040518093819263ef8b30f760e01b8352600483019190602083019252565b03816001600160a01b0387165afa801561020a576136d4915f9161399e575b50610b1a565b94955b6136f2836001600160a01b03165f52600b60205260405f2090565b54916136fc6150fa565b61399657869288929091608083901c91858310613771575050509261376b82613748866137436001600160a01b03966001600160801b03896100fc9b60801c039316612284565b615369565b9788613765856001600160a01b03165f52600b60205260405f2090565b556145b9565b16611513565b90929350613780919450610ef4565b15613879576137a86137a361379585846155a0565b61379e8a614618565b613653565b61544c565b926001600160a01b038116936137bf81868961556a565b604051636e553f6560e01b81526004810182905230602482015294602090869060449082905f905af1801561020a576137488995613854876138496001600160a01b038f96888f896100fc9f859e6138438f61376b9f6138499661384e996001600160801b03965f9161385a575b509a8b935b169061383e8282615468565b615613565b16612284565b610b28565b94612284565b90615369565b613873915060203d602011610203576101f581836102cd565b5f61382d565b90916138996137a361388b83856153ab565b61389489614618565b61363b565b60405163b3d7f6b960e01b8152600481018290526001600160a01b038316936020939290918481602481895afa801561020a576138df915f91613979575b50868a61556a565b6040516394bf804d60e01b815260048101829052306024820152948490869060449082905f905af191821561020a576100fc966138548b613849858f966001600160a01b038f896001600160801b03879f9a849f8f9661376b9f97613849966137489f9961384e9a613843955f9261395c575b5050988992613832565b6139729250803d10610203576101f581836102cd565b5f80613952565b6139909150863d8811610203576101f581836102cd565b5f6138d7565b509093505050565b6139b7915060203d602011610203576101f581836102cd565b5f6136ce565b6139ea60206139cb87612276565b6040518093819263b3d7f6b960e01b8352600483019190602083019252565b03816001600160a01b0387165afa801561020a57613a0f915f91613a15575b50612276565b956136d7565b613a2e915060203d602011610203576101f581836102cd565b5f613a09565b9390613a3f85610ef4565b8415948515613cda57613a756020613a5687610b1a565b6040518093819263266d6a8360e11b8352600483019190602083019252565b03816001600160a01b0389165afa801561020a57613a99915f9161399e5750610b1a565b94955b613ab7856001600160a01b03165f52600b60205260405f2090565b5491613ac16150fa565b6139965787938793909290916001600160801b039182841691868310613b3857505050936001600160a01b03613b0e83866100fc98613b0686613b339860801c612284565b921603615369565b9788613b2b826001600160a01b03165f52600b60205260405f2090565b555b166145b9565b611513565b919650929450613b489150610ef4565b15613c2d57613b5d6137a361379587856153ab565b604051635d043b2960e11b8152600481018290523060248201819052604482015293906020856064815f6001600160a01b038c165af1801561020a57613beb8995613854846138498e613be28b8f6001600160a01b036100fc9f9c613bdd8f9d613b339f94889f859f613849975f91613c0e575b509586925b1690615658565b612284565b9460801c612284565b9788613c08826001600160a01b03165f52600b60205260405f2090565b55613b2d565b613c27915060203d602011610203576101f581836102cd565b5f613bd1565b613c3d6137a361388b87856155a0565b604051632d182be560e21b81526004810182905230602482018190526044820152906020826064815f6001600160a01b038c165af191821561020a57613beb89956138546001600160a01b036138498e613be28b8f8a6100fc9f613bdd8f93613b339f9e889f958b9f96613849975f91613cbb575b509b8c93613bd6565b613cd4915060203d602011610203576101f581836102cd565b5f613cb2565b613d076020613ce887612276565b60405180938192630a28a47760e01b8352600483019190602083019252565b03816001600160a01b0389165afa801561020a57613d2b915f91613a155750612276565b95613a9c565b805c9060018201809211610941575d565b905f5260205260405f20905f52602052600160405f205d565b9190825191613d6e825182519085614952565b613d7783611e22565b935f5b848110613d8957505050505090565b80670de0b6b3a7640000613dbb613da260019486611e54565b51612ddb613db0858a611e54565b51611ed3868a611e54565b04613dc68289611e54565b5201613d7a565b60051115610efe57565b906005821015610efe5752565b959193613e1561042f989694613e2693611f7d976001600160a01b038092168b521660208a01526040890190613dd7565b60e0606088015260e0870190610432565b91608086015284820360a0860152610432565b925f6001600160a01b03602095969396613e9a613e5d87516001600160a01b031690565b94608088015197613e6d89613dcd565b60a060806060830151930151910151916040519b8c9a8b998a976345421ec760e01b895260048901613de4565b0393165af190811561020a575f91613ec4575b5015613eb557565b6305975b2960e11b5f5260045ffd5b613edd915060203d60201161203c5761202e81836102cd565b5f613ead565b916080838303126100ed5782519067ffffffffffffffff918281116100ed5783613f0e918601612123565b9360208101519360408201518481116100ed5781612213918401612123565b93613f57612268936001600160a01b0361042f98969416875260a0602088015260a0870190610432565b9160408601528482036060860152610432565b9190613f7461147a565b6060613f7e612105565b9160208501613f91815151808652611e22565b60808301958651613fa181613dcd565b613faa81613dcd565b6141e957506060830151613fbe8651611e22565b94613fe28260808b0151613fdc61233189516001600160a01b031690565b90615a38565b995b60608601518084106141d25750613ffd83999899614f55565b60208901975f5b8c8b51821015614111578161401891611e54565b5161402281614f55565b61402c8288611e54565b5161410057614051908d61404a8460a061242a8260c0860151611e54565b5191615355565b8061405c8389611e54565b525b61406c61108e838a51611e54565b60408a0161407b848251611e54565b5183116140cd57508d83611b908e6140bf8f968f976140aa866124b6818b60019e9d612493886140c79f6145b9565b526140b9856060880151611e54565b51612284565b905190610b28565b01614004565b916140dc846110c49451611e54565b516323b6a17960e21b5f526001600160a01b03909216600452602452604452606490565b5061410b8187611e54565b5161405e565b50509396945096509650966141319061254885516001600160a01b031690565b7fa26a52d8d53702bba7f137907b8e1f99ff87f6d450144270ca25e72481cca87161416384516001600160a01b031690565b9261418489602087019561417e87516001600160a01b031690565b90615a7f565b6141aa61233161419e6125ee88516001600160a01b031690565b94519661108e88613dcd565b926126306001600160a01b03926141c088613dcd565b88846040519586951698169684612291565b638d261d5d60e01b5f52600484905260245260445ffd5b600387516141f681613dcd565b6141ff81613dcd565b036142215761420e8851615a1c565b6142188151611e22565b945f9199613fe4565b976001875161422f81613dcd565b61423881613dcd565b036142a0576142478851614aec565b614298896142598460408801516157d1565b60808a01519061427361233188516001600160a01b031690565b61427d8c51614b64565b91614292610d258a516001600160a01b031690565b936157ec565b959091613fe4565b9793600287516142af81613dcd565b6142b881613dcd565b03614324579787986142ca8951614aec565b6060850151916142d987614b07565b61431e61431460408b0192808452898b9f8860808201519361430e610d2561277961277261233188516001600160a01b031690565b94615706565b9092519099611e54565b52613fe4565b506004865161433281613dcd565b61433b81613dcd565b036143e35761434a87516156ea565b5f614362610d25610d2586516001600160a01b031690565b60608501519060808a0151918360a0880151986143966040519a8b968795869463e4c4366360e01b86523360048701613f2d565b03925af193841561020a575f905f955f915f916143b8575b5090959199613fe4565b925050506143d99194503d805f833e6143d181836102cd565b810190613ee3565b919592915f6143ae565b636c02b39560e01b5f5260045ffd5b969261042f9896946144489361442c61443a936129b69995610100938d6001600160a01b0380931690521660208d015260408c0190613dd7565b8060608b0152890190610432565b908782036080890152610432565b9160a086015284820360c0860152610432565b949391959296908451614474906001600160a01b031690565b60808601519161448383613dcd565b608086015160a0880151906040968c6040519c8d9788976325da41f360e21b895260048901976144b2986143f2565b03916001600160a01b031691815a5f948591f194851561020a575f905f9661459a575b5015801561458e575b61457f576001809460091c16156144fe57909192809495505f905b614506575b505050505090565b855181101561457a576145198187611e54565b5182850190614529838351611e54565b511061453857508401846144f9565b869061455683612ac081612aba61108e6110c49860208c0151611e54565b5163677d1d7d60e11b5f526001600160a01b03909216600452602452604452606490565b6144fe565b63e124916560e01b5f5260045ffd5b508451865114156144de565b90506145b19195503d805f833e612b2381836102cd565b94905f6144d5565b6145c56100fc92614618565b90614654565b905f5b82518110156145fc576001600160a01b03806145ea8386611e54565b511690831614613570576001016145ce565b6001600160a01b038263ddef98d760e01b5f521660045260245ffd5b7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff81116146425790565b63123baf0360e11b5f5260045260245ffd5b8115614711576001600160a01b037f00000000000000000000000000000000000000000000000000000000000000009116805f528160205261469b60405f205c9384613653565b92836146df57505f197f0000000000000000000000000000000000000000000000000000000000000000805c918201918211610941575d5b5f5260205260405f205d565b6146d35761470c7f0000000000000000000000000000000000000000000000000000000000000000613d31565b6146d3565b5050565b6001600160a01b0392918381168484160361473357505050505f1990565b61475d9361159e92165f52601060205260405f20906001600160a01b03165f5260205260405f2090565b5490565b90604051918281549182825260209260208301915f5260205f20935f905b828210614795575050506100fc925003836102cd565b85546001600160a01b03168452600195860195889550938101939091019061477f565b906147c28261033d565b6147cf60405191826102cd565b82815280926147e0601f199161033d565b01905f5b8281106147f057505050565b6020906147fb612105565b828285010152016147e4565b90604051614814816102b1565b604060ff82945481811661482781610ef4565b84526001600160a01b038160081c16602085015260a81c161515910152565b60608101805151935f5b85811061485f57505050505050565b8061487361108e6001936020880151611e54565b6148956148888389905f5260205260405f2090565b546001600160801b031690565b6148a0838751611e54565b5181116148e7575b50506148ce6148b8828651611e54565b516148c7836080890151611e54565b5190615369565b6148e08288905f5260205260405f2090565b5501614850565b61493261494a9161492c61492361490f868a906001600160a01b03165f5260205260405f2090565b549261491c888c51611e54565b5190610b28565b8260801c612284565b90615cc4565b9185906001600160a01b03165f5260205260405f2090565b555f806148a8565b81148015929190614966575b5050611e1357565b141590505f8061495e565b90670de0b6b3a76400009182810292818404149015171561094157565b8181029291811591840414171561094157565b80516149ac81610ef4565b6149b581610ef4565b806149c8575050670de0b6b3a764000090565b806149d4600192610ef4565b03614a315760206149f3610d258260049401516001600160a01b031690565b6040516333cd77e760e11b815292839182905afa90811561020a575f91614a18575090565b61042f915060203d602011610203576101f581836102cd565b636fa2831960e11b5f5260045ffd5b91906080670de0b6b3a7640000614a84612bc79480614a638660608a0151611e54565b52612ddb614a758660c08a0151611e54565b51611ed38760a08b0151611e54565b04930151611e54565b91906080614ac8612bc79380614aa7856060890151611e54565b52611eda614ab98560c0890151611e54565b51611ed38660a08a0151611e54565b930151611e54565b60061c60011615614add57565b63033c2a5760e61b5f5260045ffd5b60041c600116614af857565b63353d5de760e21b5f5260045ffd5b80519081905f5b828110614b30575050811015614b215790565b631f91af7760e21b5f5260045ffd5b614b3a8183611e54565b51614b48575b600101614b0e565b928203614b555782614b40565b636b8c3be560e01b5f5260045ffd5b62ffffff9060121c1664174876e800908181029181830414901517156109415790565b91906020614b9e5f92604086526040860190610432565b930152565b91906020614b9e600192604086526040860190610432565b9094929192815194614bcc86611e22565b945f5b878110614d9c5750614be5906126de8988611e54565b614bef8887611e54565b5260405194631309bd3d60e31b9283875260208780614c118860048301614b87565b03816001600160a01b0385165afa96871561020a575f97614d7b575b506040519484865260208680614c468660048301614b87565b03816001600160a01b0386165afa93841561020a57613849614ca88c61491c614ca1614cbe96614c9a8f614c8a614cf49f9160209e88935f91614d5c575b506152f5565b92614c95848d615cd7565b611e54565b5190614f33565b9188611e54565b91670de0b6b3a7640000818103911002826152f5565b93614ccd856126de8c86611e54565b614cd78b85611e54565b526001600160a01b03604051809781958294835260048301614ba3565b0392165afa90811561020a57614d3095614d2a935f93614d33575b50614d1c614d2391611e22565b9788611e54565b5283610b28565b90615335565b91565b614d23919350614d54614d1c9160203d602011610203576101f581836102cd565b939150614d0f565b6020614d7592503d602011610203576101f581836102cd565b5f614c84565b614d9591975060203d602011610203576101f581836102cd565b955f614c2d565b80614db2614dac60019388611e54565b51610b1a565b614dbc828a611e54565b5201614bcf565b614ddb60409295949395606083526060830190610432565b9460208201520152565b909491830391838311610941576020614e316001600160a01b0392614e0a87876152f5565b614e148183615cd7565b60405194858094819362b5059f60e51b83528d8a60048501614dc3565b0392165afa801561020a57614d3095611eda88614e7c93614e8598614e8c965f92614e92575b50614e6a826126de61384994958b611e54565b98614e758d8a611e54565b5190615335565b93849251611e22565b9586611e54565b52610b28565b61384992506126de93614eb6614e6a9260203d602011610203576101f581836102cd565b93509350614e57565b634e487b7160e01b5f52601260045260245ffd5b8115614edd570490565b614ebf565b909291614eef8251611e22565b915f5b8151811015614f2c57614f0f83614f098385611e54565b5161498e565b908615614edd578660019204614f258287611e54565b5201614ef2565b5050509150565b90614f3d9161498e565b6001670de0b6b3a76400005f19830104019015150290565b80614f5d5750565b6100fc906152be565b91614f709161498e565b90670de0b6b3a764000090818102918183041490151715610941578115614edd570490565b91949290945f955f9581614faa575050505050565b849750612433614fc38260c0614fcf9697980151611e54565b519160a08a0151611e54565b945160018160031c1615614fe5575b808061154d565b62ffffff91929450602a1c1664174876e800908181029181830414901517156109415761501b670de0b6b3a7640000918661498e565b0492848411615088578061159e61506761504d61507f9461159e876001600160a01b03165f52600660205260405f2090565b54615061886001600160801b038316612284565b90615d5c565b936001600160a01b03165f52600660205260405f2090565b555f8080614fde565b634c69ac5d60e01b5f5260045ffd5b6001600160a01b0390929192165f52602060056020526040805f205f5b606086015180518210156150f157906150e16150d282600194611e54565b516148c78360808b0151611e54565b815f52838652845f2055016150b4565b50505050509050565b3215806151045790565b506001600754161590565b9032615152576001600160a01b0361514392165f52600f60205260405f20906001600160a01b03165f5260205260405f2090565b80549182018092116109415755565b6333fc255960e11b5f5260045ffd5b90916001600160a01b0380841692831561181b576151948561159e836001600160a01b03165f52600f60205260405f2090565b54808411615276578390036151be8661159e846001600160a01b03165f52600f60205260405f2090565b556151e4836151de836001600160a01b03165f52601160205260405f2090565b54610b28565b6151ed81615d6a565b615208826001600160a01b03165f52601160205260405f2090565b551690813b156100ed576040516323de665160e01b81526001600160a01b0390941660048501525f6024850181905260448501829052937fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f916152719186818060648101611619565b0390a4565b63391434e360e21b5f526001600160a01b038616600452602452604483905260645ffd5b670de0b6b3a76400008082040281036152b05790565b600181018091116109415790565b7f0000000000000000000000000000000000000000000000000000000000000000116152e657565b6303da9a2360e31b5f5260045ffd5b90801561532657670de0b6b3a764000091828102928184041490151715610941576001905f19830104019015150290565b630a0c22c760e01b5f5260045ffd5b8215615326576001916153479161498e565b915f19830104019015150290565b9061042f926153639161498e565b906152f5565b906001600160801b038083119081156153a1575b506153925760801b9081018091116109415790565b6389560ca160e01b5f5260045ffd5b905081115f61537d565b906153b88260801c614618565b906001600160801b035f9316806153dc575b50506002916153d89161363b565b0590565b6001600160a01b0393509060246020926040519586938492630a28a47760e01b84526004840152165afa90811561020a576154246153d8926002945f9161542d575b50614618565b928192506153ca565b615446915060203d602011610203576101f581836102cd565b5f61541e565b5f81126154565790565b635467221960e11b5f5260045260245ffd5b60405163095ea7b360e01b602082018181526001600160a01b03851660248401525f6044840152909391929183606481015b03916154ae601f19938481018752866102cd565b5f806001600160a01b0386169287519082855af1906154cb61569d565b82615538575b508161552d575b50156154e5575050505050565b60405160208101959095526001600160a01b031660248501525f604485015260649081018452615523936109179161551d90826102cd565b82615b9b565b5f8080808061154d565b90503b15155f6154d8565b80519192508115918215615550575b5050905f6154d1565b6155639250602080918301019101611f07565b5f80615547565b60405163095ea7b360e01b602082018181526001600160a01b03851660248401526044830195909552939092836064810161549a565b906155b36001600160801b038316614618565b905f9260801c806155cc5750506002916153d89161363b565b6001600160a01b039350906024602092604051958693849263b3d7f6b960e01b84526004840152165afa90811561020a576154246153d8926002945f9161542d5750614618565b9291906001600160a01b038085165f52600860205260405f20549283039283116109415781165f52600860205260405f2054928301809311610941576100fc93615d89565b9291906001600160a01b038085165f52600860205260405f20549283018093116109415781165f52600860205260405f2054928303928311610941576100fc93615d89565b3d156156c7573d906156ae826103c2565b916156bc60405193846102cd565b82523d5f602084013e565b606090565b5f8061042f9360208151910182855af16156e461569d565b91615ec0565b60051c600116156156f757565b63121db02f60e21b5f5260045ffd5b9094916020615735615720866001600160a01b0394612284565b9461572b87876152f5565b614e148183615f1a565b0392165afa801561020a57614d3095613849614ca885614e7c94614e85998c998a615794995f9461579a575b509061578861578161577a61578f946124d69798611e54565b5187610b28565b9c8c611e54565b519061498e565b614ed3565b52612284565b6124d6945061578161577a61578f94936157c56157889460203d602011610203576101f581836102cd565b97509394505050615761565b9060208083516157e2845182611e0c565b60051b930191015e565b9291909383516157fb81611e22565b9161580582611e22565b965f5b8381106159e15750506001600160a01b0381169160405195631309bd3d60e31b9283885260209889898061583f8460048301614b87565b0381895afa98891561020a575f996159c2575b506040518581528a81806158698b60048301614ba3565b03818a5afa90811561020a578a61578f6158a49361589d938f5f926159a5575b9b999d9c9a98979695949392919050614971565b8093615f1a565b5f5b89811061591357505050506158ca9550604051809681948293835260048301614ba3565b03915afa91821561020a578361578f936158f092614d30975f926158f6575b5050610b28565b9061498e565b61590c9250803d10610203576101f581836102cd565b5f806158e9565b869899959750838d83949596988361593761593082600198611e54565b5189615d49565b806159428385611e54565b511161595e575b505050505001908a96949897959392916158a6565b818361597f61599097615989946159788561491c99611e54565b5103614f33565b611af98388611e54565b5192611e54565b61599a828b611e54565b52848d8a835f615949565b6159bb9250803d10610203576101f581836102cd565b5f8f615889565b6159da9199508a3d8c11610203576101f581836102cd565b975f615852565b80615a0b615a066159f46001948c611e54565b516159ff8487611e54565b5190612284565b610b1a565b615a158288611e54565b5201615808565b60071c60011615615a2957565b63efe0265d60e01b5f5260045ffd5b9291615a448451611e22565b935f5b8151811015615a795780615a688585615a6260019587611e54565b51615335565b615a728289611e54565b5201615a47565b50505050565b916001600160a01b03808316938415615b7f57615ab783615ab1836001600160a01b03165f52601160205260405f2090565b54612284565b615ad68561159e846001600160a01b03165f52600f60205260405f2090565b848154019055615ae581615d6a565b615b00826001600160a01b03165f52601160205260405f2090565b5516925f847fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f60405180615b3987829190602083019252565b0390a4823b156100ed576040516323de665160e01b81525f600482018190526001600160a01b0390931660248201526044810191909152918290818381606481016117bd565b63ec442f0560e01b5f526001600160a01b03841660045260245ffd5b6001600160a01b03615baf911691826156cc565b8051908115159182615bd7575b5050615bc55750565b635274afe760e01b5f5260045260245ffd5b615bea9250602080918301019101611f07565b155f80615bbc565b9064ffffffffff615c0282611e22565b92605a1c165f5b828110615c165750505090565b60058082029082820414821517156109415782601f911c1690604d821161094157600191600a0a615c478287611e54565b5201615c09565b62ffffff9060421c1664174876e800908181029181830414901517156109415790565b9093925f94615c84846080850151611e54565b51818111615c93575050505050565b615cb995965091615ca8916124339303614f33565b9260a061242a8260c0860151611e54565b905f8080808061154d565b906001600160801b0361042f9216615369565b9060206001600160a01b0392600460405180958193635b3bfd2b60e11b8352165afa91821561020a575f92615d28575b50818110615d13575050565b63718e4adf60e11b5f5260045260245260445ffd5b615d4291925060203d602011610203576101f581836102cd565b905f615d07565b670de0b6b3a764000091612de09161498e565b9061042f9160801c90615369565b620f42408110615d775750565b6334e3483f60e21b5f5260045260245ffd5b6040516370a0823160e01b808252306004830152602095939490926001600160a01b03929187836024818786165afa92831561020a575f93615ea1575b50808310615e7a5750615dea906001600160a01b03165f52600860205260405f2090565b556040519182523060048301528316908481602481855afa94851561020a575f95615e5b575b5050818410615e39575050615e36906001600160a01b03165f52600860205260405f2090565b55565b631149424d60e01b5f526001600160a01b03166004526024525060445260645ffd5b615e72929550803d10610203576101f581836102cd565b925f80615e10565b631c6a537560e01b5f9081529387166001600160a01b031660045260245250604452606490fd5b615eb9919350883d8a11610203576101f581836102cd565b915f615dc6565b90615ee45750805115615ed557805190602001fd5b630a12f52160e11b5f5260045ffd5b81511580615f11575b615ef5575090565b6001600160a01b0390639996b31560e01b5f521660045260245ffd5b50803b15615eed565b9060206001600160a01b039260046040518095819363273c1adf60e01b8352165afa91821561020a575f92615f6b575b50818111615f56575050565b630fa2583760e21b5f5260045260245260445ffd5b615f8591925060203d602011610203576101f581836102cd565b905f615f4a565b91909163ffffffff808094169116019182116109415756fea26469706673582212206683429dd8621233bf9dfafe00f40360d4204093d879bd8a2517bc175dc511eb64736f6c634300081a0033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/packages/protocols/beets/abis-src/VaultExplorer.json
+++ b/packages/protocols/beets/abis-src/VaultExplorer.json
@@ -1,0 +1,1285 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "VaultExplorer",
+  "sourceName": "contracts/VaultExplorer.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IVault",
+          "name": "vault",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenAllowance",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "areBuffersPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "buffersPaused",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenBalance",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "collectAggregateFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "enum SwapKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountGivenScaled18",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "balancesScaled18",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "indexIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "indexOut",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "router",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct PoolSwapParams",
+          "name": "swapParams",
+          "type": "tuple"
+        }
+      ],
+      "name": "computeDynamicSwapFeePercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "dynamicSwapFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "enableRecoveryMode",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getAddLiquidityCalledFlag",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "liquidityAdded",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getAggregateFeePercentages",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "aggregateSwapFeePercentage",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "aggregateYieldFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getAggregateSwapFeeAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "swapFeeAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getAggregateYieldFeeAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "yieldFeeAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getAuthorizer",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "authorizer",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getBptRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "rate",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "getBufferAsset",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "underlyingToken",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "getBufferBalance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "underlyingBalanceRaw",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "wrappedBalanceRaw",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getBufferMinimumTotalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bufferMinimumTotalSupply",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "liquidityOwner",
+          "type": "address"
+        }
+      ],
+      "name": "getBufferOwnerShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "ownerShares",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getBufferPeriodDuration",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "bufferPeriodDuration",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getBufferPeriodEndTime",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "bufferPeriodEndTime",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "getBufferTotalShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bufferShares",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getCurrentLiveBalances",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "balancesLiveScaled18",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "getERC4626BufferAsset",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "underlyingToken",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getHooksConfig",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "enableHookAdjustedAmounts",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallComputeDynamicSwapFee",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "address",
+              "name": "hooksContract",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct HooksConfig",
+          "name": "hooksConfig",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getMaximumPoolTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "maxTokens",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getMinimumPoolTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "minTokens",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getMinimumTradeAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "minimumTradeAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getMinimumWrapAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "minimumWrapAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getNonzeroDeltaCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "nonzeroDeltaCount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getPauseWindowEndTime",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "pauseWindowEndTime",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolConfig",
+      "outputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "bool",
+                  "name": "disableUnbalancedLiquidity",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "enableAddLiquidityCustom",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "enableRemoveLiquidityCustom",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "enableDonation",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct LiquidityManagement",
+              "name": "liquidityManagement",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint256",
+              "name": "staticSwapFeePercentage",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "aggregateSwapFeePercentage",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "aggregateYieldFeePercentage",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint40",
+              "name": "tokenDecimalDiffs",
+              "type": "uint40"
+            },
+            {
+              "internalType": "uint32",
+              "name": "pauseWindowEndTime",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolRegistered",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolInitialized",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolPaused",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolInRecoveryMode",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct PoolConfig",
+          "name": "poolConfig",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolData",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "PoolConfigBits",
+              "name": "poolConfigBits",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "contract IERC20[]",
+              "name": "tokens",
+              "type": "address[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum TokenType",
+                  "name": "tokenType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "contract IRateProvider",
+                  "name": "rateProvider",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "paysYieldFees",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct TokenInfo[]",
+              "name": "tokenInfo",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "balancesRaw",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "balancesLiveScaled18",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "tokenRates",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "decimalScalingFactors",
+              "type": "uint256[]"
+            }
+          ],
+          "internalType": "struct PoolData",
+          "name": "poolData",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getPoolMinimumTotalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "poolMinimumTotalSupply",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolPausedState",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "poolPaused",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint32",
+          "name": "poolPauseWindowEndTime",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "poolBufferPeriodEndTime",
+          "type": "uint32"
+        },
+        {
+          "internalType": "address",
+          "name": "pauseManager",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolRoleAccounts",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "pauseManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "swapFeeManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "poolCreator",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct PoolRoleAccounts",
+          "name": "roleAccounts",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokenCountAndIndexOfToken",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenCount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokenInfo",
+      "outputs": [
+        {
+          "internalType": "contract IERC20[]",
+          "name": "tokens",
+          "type": "address[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "enum TokenType",
+              "name": "tokenType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "contract IRateProvider",
+              "name": "rateProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "paysYieldFees",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct TokenInfo[]",
+          "name": "tokenInfo",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "balancesRaw",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "lastBalancesLiveScaled18",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokenRates",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "decimalScalingFactors",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "tokenRates",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokens",
+      "outputs": [
+        {
+          "internalType": "contract IERC20[]",
+          "name": "tokens",
+          "type": "address[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getProtocolFeeController",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "protocolFeeController",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getReservesOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "reserveAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getStaticSwapFeePercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getTokenDelta",
+      "outputs": [
+        {
+          "internalType": "int256",
+          "name": "tokenDelta",
+          "type": "int256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getVault",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "vault",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getVaultAdmin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAdmin",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getVaultExtension",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "vaultExtension",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getVaultPausedState",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "vaultPaused",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint32",
+          "name": "vaultPauseWindowEndTime",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "vaultBufferPeriodEndTime",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "isERC4626BufferInitialized",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isBufferInitialized",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolInRecoveryMode",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "inRecoveryMode",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolInitialized",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "initialized",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "poolPaused",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolRegistered",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "registered",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isQueryDisabled",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "queryDisabled",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isQueryDisabledPermanently",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "queryDisabledPermanently",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isUnlocked",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "unlocked",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isVaultPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "vaultPaused",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenTotalSupply",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x60a0346101d657601f6137ce38819003918201601f19168301916001600160401b038311848410176101da578084926020946040528339810103126101d657516001600160a01b03811681036101d6576080526040516135df90816101ef82396080518181816102e50152818161042d015281816105840152818161065c01528181610778015281816107f7015281816108570152818161092c015281816109ad01528181610a9701528181610c8001528181610d5901528181610e6501528181610f3c0152818161100c0152818161108f015281816111540152818161122a015281816112bd0152818161133f01528181611414015281816114a90152818161156f01528181611612015281816116cb015281816117560152818161183c015281816118a60152818161196601528181611a3e01528181611abd01528181611baf01528181611c7e01528181611d9801528181611e6201528181611ef501528181612062015281816120e30152818161217501528181612258015281816122ec015281816125f2015281816126c60152818161276c01528181612802015281816128af0152818161292e015281816129b701528181612af101528181612bfc01528181612cc401528181612f28015261304e0152f35b5f80fd5b634e487b7160e01b5f52604160045260245ffdfe6080806040526004361015610012575f80fd5b5f905f3560e01c908162fdfa1314612f63575080630387587d14612668578063098401f514612ee257806313d21cdf14612c3757806313ef8a5d14612bb657806315e3204614612a995780631ba0ae451461296d57806320c1fb7a146128e857806326a8a99114612869578063295f0540146127a55780632e42f4d5146127265780634021fe0f1461266d5780634afbaf5a146126685780634d472bdd146123515780634f037ee714612292578063532cec7c146121fe578063535cfd8a1461211c57806353956aa21461209d57806355cba7fe1461201c57806367e0e07614611e9c5780636844846b14611e085780636c9bc73214611d3e5780637e361bde14611c255780638380edb714611b6957806385c8c01514611a7757806385e0b999146119c357806385f2dbd4146119205780638a8d123a146118605780638d928af81461181d5780638f4ab9ca14611704578063927da1051461164b5780639385e39a146115a657806396787092146115135780639e825ff51461144d578063a8175b27146113cc578063aaabadc5146112f8578063ace9b89b14611261578063b45090f9146111ce578063b4aef0ab1461110c578063b9a8effa14611047578063be7d628a14610fb0578063c673bdaf14610ee0578063c9c1661b14610de9578063ca4f280314610cfe578063cd51c12f14610c38578063ce8630d4146109e6578063d0965a6b14610965578063db817187146108e4578063dc3f574e14610830578063e2cb0ba0146107af578063e4dc2aa41461071c578063e9ddeb26146105e9578063f2784e0714610528578063f29486a1146103655763f7888aec1461027a575f80fd5b3461036257604060031936011261036257610293612fca565b90602061029e612fe0565b9260446001600160a01b0391828060405197889586947ff7888aec0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f575b602090604051908152f35b506020813d60201161034e575b816103396020938361322b565b8101031261034a5760209051610314565b5f80fd5b3d915061032c565b604051903d90823e3d90fd5b80fd5b50346103625760208060031936011261052457610380612fca565b916040519061038e826131f2565b60405161039a8161320f565b8181528184820152816040820152816060820152825280838301528060408301528060608301528060808301528060a08301528060c08301528060e0830152610100818184015281610120809401526001600160a01b0394856040519687927ff29486a10000000000000000000000000000000000000000000000000000000084521660048301528160246101a09889937f0000000000000000000000000000000000000000000000000000000000000000165afa92831561035657926104f5575b506040519360608351805115158752828101511515838801526040810151151560408801520151151560608601528201516080850152604082015160a0850152606082015160c085015264ffffffffff60808301511660e085015263ffffffff60a0830151168185015260c082015115158385015260e08201511515610140850152810151151561016084015201511515610180820152f35b610516919250853d871161051d575b61050e818361322b565b810190613473565b905f61045c565b503d610504565b5080fd5b5034610362576020908160031936011261036257602482610547612fca565b6040517ff2784e070000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc575b50604051908152f35b90508181813d83116105e2575b6105d3818361322b565b8101031261034a57515f6105b3565b503d6105c9565b50346103625760208060031936011261052457610604612fca565b8260408051610612816131d6565b828152828582015201526001600160a01b039081604051917fe9ddeb26000000000000000000000000000000000000000000000000000000008352166004820152606081602481857f0000000000000000000000000000000000000000000000000000000000000000165afa9384156103565780946106b0575b50506040606093815193838251168552838183015116908501520151166040820152f35b9093506060843d606011610714575b816106cc6060938361322b565b810103126103625750604060609361070a828051926106ea846131d6565b6106f3816132c0565b84526107008782016132c0565b87850152016132c0565b828201529361068c565b3d91506106bf565b503461036257602090816003193601126103625760248261073b612fca565b6040517fe4dc2aa40000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc5750604051908152f35b5034610362578060031936011261036257604051907fe2cb0ba00000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b5034610362576020600319360112610362578061084b612fca565b6001600160a01b0390817f00000000000000000000000000000000000000000000000000000000000000001691823b156108df57602484928360405195869485937fdc3f574e0000000000000000000000000000000000000000000000000000000085521660048401525af180156108d4576108c45750f35b6108cd906131a5565b6103625780f35b6040513d84823e3d90fd5b505050fd5b5034610362578060031936011261036257604051907fdb8171870000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b5034610362578060031936011261036257604051907fd0965a6b0000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b50346103625760208060031936011261052457610a01612fca565b9160405190610a0f826131b9565b80825280838301528060408301528060608301528060808301528060a08301528060c08301528060e0830152610100908082840152610120818185015281610140809501526001600160a01b039283604051977fce8630d4000000000000000000000000000000000000000000000000000000008952166004880152610160968781602481887f0000000000000000000000000000000000000000000000000000000000000000165afa938415610356579081879594939294610b48575b5050604051968351151588528084015115159088015260408301511515604088015260608301511515606088015260808301511515608088015260a0830151151560a088015260c0830151151560c088015260e0830151151560e0880152808301511515908701528082015115159086015201511690820152f35b9194509192508782813d8311610c31575b610b63818361322b565b81010312610362575090849291610c258460405192610b81846131b9565b610b8a816132d4565b8452610b978a82016132d4565b8a850152610ba7604082016132d4565b6040850152610bb8606082016132d4565b6060850152610bc9608082016132d4565b6080850152610bda60a082016132d4565b60a0850152610beb60c082016132d4565b60c0850152610bfc60e082016132d4565b60e0850152610c0c8682016132d4565b86850152610c1b8582016132d4565b85850152016132c0565b84820152915f80610acd565b503d610b59565b5034610362578060031936011261036257604051907fcd51c12f0000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356578091610cc1575b60208263ffffffff60405191168152f35b90506020823d602011610cf6575b81610cdc6020938361322b565b810103126103625750610cf0602091613462565b5f610cb0565b3d9150610ccf565b50346103625760206003193601126103625780602491610d1c612fca565b6040517fca4f28030000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015293849182907f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356578091610da3575b60405160208082528190610d9f90820185613284565b0390f35b90503d8082843e610db4818461322b565b8201916020818403126105245780519167ffffffffffffffff8311610362575091610de391610d9f93016132e1565b5f610d89565b503461036257604060031936011261036257610e59906040610e09612fca565b610e11612fe0565b82517fc9c1661b0000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201529116602482015292839081906044820190565b03816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa8015610ed3576040928291610ea4575b5082519182526020820152f35b9050610ec69150823d8411610ecc575b610ebe818361322b565b810190613574565b5f610e97565b503d610eb4565b50604051903d90823e3d90fd5b5034610362576020908160031936011261036257602482610eff612fca565b6040517fc673bdaf0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa918215610356578092610f78575b50506040519015158152f35b9091508282813d8311610fa9575b610f90818361322b565b810103126103625750610fa2906132d4565b5f80610f6c565b503d610f86565b5034610362576020908160031936011261036257602482610fcf612fca565b6040517fbe7d628a0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa918215610356578092610f785750506040519015158152f35b50346103625780600319360112610362576040517fb9a8effa000000000000000000000000000000000000000000000000000000008152906001600160a01b036020836004817f000000000000000000000000000000000000000000000000000000000000000085165afa9182156103565780926110cd575b6020838360405191168152f35b9091506020833d602011611104575b816110e96020938361322b565b8101031261036257506110fd6020926132c0565b905f6110c0565b3d91506110dc565b5034610362578060031936011261036257604051907fb4aef0ab0000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356578091611191575b6020826040519015158152f35b90506020823d6020116111c6575b816111ac6020938361322b565b8101031261036257506111c06020916132d4565b5f611184565b3d915061119f565b50346103625760209081600319360112610362576024826111ed612fca565b6040517fb45090f90000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc5750604051908152f35b5034610362576020908160031936011261036257602482611280612fca565b6040517face9b89b0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa918215610356578092610f785750506040519015158152f35b50346103625780600319360112610362576040517faaabadc50000000000000000000000000000000000000000000000000000000081526001600160a01b036020826004817f000000000000000000000000000000000000000000000000000000000000000085165afa9182156113c157839261137c576020838360405191168152f35b9091506020813d6020116113b9575b816113986020938361322b565b810103126113b5575181811681036113b55760209250905f6110c0565b8280fd5b3d915061138b565b6040513d85823e3d90fd5b5034610362578060031936011261036257604051907fa8175b270000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b503461036257602090816003193601126103625760248261146c612fca565b6040517f9e825ff50000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9182156103565780926114e3575b5050604051908152f35b9091508282813d831161150c575b6114fb818361322b565b810103126103625750515f806114d9565b503d6114f1565b5034610362576020908160031936011261036257602482611532612fca565b6040517f967870920000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc5750604051908152f35b5034610362576040600319360112610362576115c0612fca565b9060206115cb612fe0565b9260446001600160a01b0391828060405197889586947f9385e39a0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b503461036257606060031936011261036257611665612fca565b9061166e612fe0565b916044356001600160a01b039081811680910361034a57602092826064928160405198899687957f927da10500000000000000000000000000000000000000000000000000000000875216600486015216602484015260448301527f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b503461034a57602060031936011261034a5761171e612fca565b6001600160a01b03906040517f85f2dbd4000000000000000000000000000000000000000000000000000000008152602081600481867f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e35783915f916117ee575b501691823b1561034a5760245f928360405195869485937f8f4ab9ca0000000000000000000000000000000000000000000000000000000085521660048401525af180156117e3576117d7575080f35b6117e191506131a5565b005b6040513d5f823e3d90fd5b611810915060203d602011611816575b611808818361322b565b81019061358a565b5f611787565b503d6117fe565b3461034a575f60031936011261034a5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b3461034a575f60031936011261034a576040517f8a8d123a0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f906118e6575b60209063ffffffff60405191168152f35b506020813d602011611918575b816119006020938361322b565b8101031261034a57611913602091613462565b6118d5565b3d91506118f3565b3461034a575f60031936011261034a576040517f85f2dbd40000000000000000000000000000000000000000000000000000000081526001600160a01b036020826004817f000000000000000000000000000000000000000000000000000000000000000085165afa9081156117e3576020925f926119a4575b5060405191168152f35b6119bc919250833d851161181657611808818361322b565b908361199a565b3461034a57604060031936011261034a57611a3260206119e1612fca565b6119e9612fe0565b6040517f85e0b9990000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201529116602482015291829081906044820190565b03816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a575f60031936011261034a576040517f85c8c0150000000000000000000000000000000000000000000000000000000081526060816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f905f905f90611b11575b60609350604051921515835263ffffffff8092166020840152166040820152f35b5050506060813d606011611b61575b81611b2d6060938361322b565b8101031261034a5780611b416060926132d4565b611b596040611b5260208501613462565b9301613462565b909190611af0565b3d9150611b20565b3461034a575f60031936011261034a576040517f8380edb70000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb575b6020906040519015158152f35b506020813d602011611c1d575b81611c056020938361322b565b8101031261034a57611c186020916132d4565b611bde565b3d9150611bf8565b3461034a57602060031936011261034a5760245f611c41612fca565b6040517f7e361bde0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f905f92611cda575b50610d9f611ccc92604051938493604085526040850190613156565b908382036020850152613156565b9150503d805f833e611cec818361322b565b81019060408183031261034a57805167ffffffffffffffff9081811161034a5783611d18918401613401565b91602081015191821161034a57611ccc93610d9f92611d379201613401565b9250611cb0565b3461034a5760208060031936011261034a57602481611d5b612fca565b6040517f6c9bc7320000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f91611dd3575b506040519015158152f35b90508181813d8311611e01575b611dea818361322b565b8101031261034a57611dfb906132d4565b82611dc8565b503d611de0565b3461034a5760208060031936011261034a57602481611e25612fca565b6040517f6844846b0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f91611dd357506040519015158152f35b3461034a57602060031936011261034a5760245f611eb8612fca565b6040517f67e0e0760000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f905f5f915f94611f78575b5092611f6a610d9f92611f5c611f4e96604051978897608089526080890190613284565b9087820360208901526130f5565b908582036040870152613156565b908382036060850152613156565b93505050503d805f833e611f8c818361322b565b810160808282031261034a5781519167ffffffffffffffff9283811161034a5782611fb89183016132e1565b602082015184811161034a5783611fd0918401613352565b92604083015185811161034a5781611fe9918501613401565b91606084015195861161034a57611f5c61200e611f6a93611f4e98610d9f9701613401565b919593919650509250611f2a565b3461034a575f60031936011261034a576040517f55cba7fe0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb576020906040519015158152f35b3461034a575f60031936011261034a576040517f53956aa20000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a57602060031936011261034a5760245f612138612fca565b6040517f535cfd8a0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f906121bc575b610d9f90604051918291602083526020830190613156565b503d805f833e6121cc818361322b565b81019060208183031261034a5780519167ffffffffffffffff831161034a57610d9f926121f99201613401565b6121a4565b3461034a5760208060031936011261034a5760248161221b612fca565b6040517f532cec7c0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f91611dd357506040519015158152f35b3461034a5760208060031936011261034a576024816122af612fca565b6040517f4f037ee70000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f916123245750604051908152f35b90508181813d831161234a575b61233b818361322b565b8101031261034a5751826105b3565b503d612331565b3461034a5760031960408136011261034a5761236b612fca565b60243567ffffffffffffffff9283821161034a5760e090823603011261034a576040519261239884613189565b8160040135600281101561034a57845260248201356020850152604482013581811161034a5782013660238201121561034a576004810135906123da8261326c565b916123e8604051938461322b565b8083526024602084019160051b8301019136831161034a57602401905b828210612658575050506040850152606482013560608501526084820135608085015260a48201356001600160a01b038116810361034a5760a085015260c48201359080821161034a5736602383850101121561034a57600482840101351161262b57604051926124a460207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f600486880101350116018561322b565b82820160048101358086523691016024011161034a576020935f85600485878284986001600160a01b039a010135602483830101858801370101358301015260c086015260405194859384927f4d472bdd00000000000000000000000000000000000000000000000000000000845216600483015260406024830152805161252b816130be565b60448301528281015160648301527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f8460c0612579604086015160e06084890152610124880190613156565b94606081015160a4880152608081015160c48801526001600160a01b0360a08201511660e488015201517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbc868603016101048701528051918291828752018786015e5f8682860101520116010301816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b8135815260209182019101612405565b612ff6565b3461034a57602060031936011261034a576024604061268a612fca565b81517f4021fe0f0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3576040915f915f91612707575082519182526020820152f35b90506127209150823d8411610ecc57610ebe818361322b565b83610e97565b3461034a575f60031936011261034a576040517f2e42f4d50000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a57602060031936011261034a576127be612fca565b6001600160a01b0390816040519283927ff29486a10000000000000000000000000000000000000000000000000000000084521660048301528160246101a09485937f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3576040925f9261284c575b505060608282015191015182519182526020820152f35b6128629250803d1061051d5761050e818361322b565b8280612835565b3461034a575f60031936011261034a576040517f26a8a9910000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a575f60031936011261034a576040517f20c1fb7a0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f906118e65760209063ffffffff60405191168152f35b3461034a575f60031936011261034a576001600160a01b03604051907fb9a8effa0000000000000000000000000000000000000000000000000000000082526020918281600481857f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e357829184915f91612a62575b506004604051809581937f1ba0ae45000000000000000000000000000000000000000000000000000000008352165afa9182156117e3575f92612a32575060405191168152f35b9091508281813d8311612a5b575b612a4a818361322b565b8101031261034a576119bc906132c0565b503d612a40565b92505081813d8311612a92575b612a79818361322b565b8101031261034a5782612a8c83926132c0565b856129eb565b503d612a6f565b3461034a57602060031936011261034a57612ab2612fca565b6001600160a01b0380604051927f15e32046000000000000000000000000000000000000000000000000000000008452166004830152608082602481847f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f915f5f945f92612b4d575b50608094604051941515855263ffffffff8092166020860152166040840152166060820152f35b9350505091506080813d608011612bae575b81612b6c6080938361322b565b8101031261034a57608091612b80826132d4565b612b8c60208401613462565b92612ba56060612b9e60408401613462565b92016132c0565b91939094612b26565b3d9150612b5f565b3461034a575f60031936011261034a576040517f13ef8a5d0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb576020906040519015158152f35b3461034a5760208060031936011261034a57612c51612fca565b60c0604051612c5f81613189565b5f81526060918183868194015282604082015282808201528260808201528260a082015201526001600160a01b039081604051937f13d21cdf0000000000000000000000000000000000000000000000000000000085521660048401525f83602481857f0000000000000000000000000000000000000000000000000000000000000000165afa9283156117e3575f93612de6575b50926040929192519384938285526101008501845184870152838501519360e0604088015284518092528061012088019501925f905b838210612dc9578880610d9f8a8a60c0612db7612da4612d908e612d7d6040880151967fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe097888c830301848d01526130f5565b90870151868a83030160808b0152613156565b6080860151858983030160a08a0152613156565b60a0850151848883030184890152613156565b920151908483030160e0850152613156565b845181168752899850958201959382019360019190910190612d2a565b9092503d805f833e612df8818361322b565b8101848282031261034a57815167ffffffffffffffff9283821161034a57019060e08282031261034a5760405192612e2f84613189565b825184528683015181811161034a5782612e4a9185016132e1565b87850152604083015181811161034a5782612e66918501613352565b60408501528583015181811161034a5782612e82918501613401565b86850152608083015181811161034a5782612e9e918501613401565b608085015260a083015181811161034a5782612ebb918501613401565b60a085015260c083015190811161034a57612ed69201613401565b60c08201529184612cf4565b3461034a575f60031936011261034a576040517f098401f50000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb576020906040519015158152f35b3461034a57604060031936011261034a5760208180611a32612f83612fca565b612f8b612fe0565b7efdfa130000000000000000000000000000000000000000000000000000000084526001600160a01b0391821660048501521660248301526044820190565b600435906001600160a01b038216820361034a57565b602435906001600160a01b038216820361034a57565b3461034a5760208060031936011261034a57613010612fca565b6001600160a01b0380604051927f4afbaf5a0000000000000000000000000000000000000000000000000000000084521660048301528282602481847f0000000000000000000000000000000000000000000000000000000000000000165afa9182156117e3575f92613087575060405191168152f35b9091508281813d83116130b7575b61309f818361322b565b8101031261034a576130b0906132c0565b905f61199a565b503d613095565b600211156130c857565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b9081518082526020808093019301915f5b828110613114575050505090565b909192938260606001928751805161312b816130be565b8252808401516001600160a01b03168483015260409081015115159082015201950193929101613106565b9081518082526020808093019301915f5b828110613175575050505090565b835185529381019392810192600101613167565b60e0810190811067ffffffffffffffff82111761262b57604052565b67ffffffffffffffff811161262b57604052565b610160810190811067ffffffffffffffff82111761262b57604052565b6060810190811067ffffffffffffffff82111761262b57604052565b610140810190811067ffffffffffffffff82111761262b57604052565b6080810190811067ffffffffffffffff82111761262b57604052565b90601f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0910116810190811067ffffffffffffffff82111761262b57604052565b67ffffffffffffffff811161262b5760051b60200190565b9081518082526020808093019301915f5b8281106132a3575050505090565b83516001600160a01b031685529381019392810192600101613295565b51906001600160a01b038216820361034a57565b5190811515820361034a57565b9080601f8301121561034a578151906020916132fc8161326c565b9361330a604051958661322b565b81855260208086019260051b82010192831161034a57602001905b828210613333575050505090565b81516001600160a01b038116810361034a578152908301908301613325565b81601f8201121561034a57805190602061336b8361326c565b93604061337b604051968761322b565b848652828601918360608097028601019481861161034a578401925b8584106133a8575050505050505090565b868483031261034a578251906133bd826131d6565b8451600281101561034a57825285850151906001600160a01b038216820361034a57828792838b9501526133f28688016132d4565b86820152815201930192613397565b9080601f8301121561034a5781519060209161341c8161326c565b9361342a604051958661322b565b81855260208086019260051b82010192831161034a57602001905b828210613453575050505090565b81518152908301908301613445565b519063ffffffff8216820361034a57565b809103906101a0821261034a5760806040519261348f846131f2565b1261034a576040516134a08161320f565b6134a9826132d4565b81526134b7602083016132d4565b60208201526134c8604083016132d4565b60408201526134d9606083016132d4565b606082015282526080810151602083015260a0810151604083015260c0810151606083015260e081015164ffffffffff8116810361034a57608083015261356d6101806101009261352b848201613462565b60a08601526101209361353f8583016132d4565b60c087015261355161014083016132d4565b60e087015261356361016083016132d4565b90860152016132d4565b9082015290565b919082604091031261034a576020825192015190565b9081602091031261034a57516001600160a01b038116810361034a579056fea2646970667358221220a4ef6c33246ed815be6e6e4f48ee6c7f1d4dc2d2994dfd395e937950d089d6fc64736f6c634300081b0033",
+  "deployedBytecode": "0x6080806040526004361015610012575f80fd5b5f905f3560e01c908162fdfa1314612f63575080630387587d14612668578063098401f514612ee257806313d21cdf14612c3757806313ef8a5d14612bb657806315e3204614612a995780631ba0ae451461296d57806320c1fb7a146128e857806326a8a99114612869578063295f0540146127a55780632e42f4d5146127265780634021fe0f1461266d5780634afbaf5a146126685780634d472bdd146123515780634f037ee714612292578063532cec7c146121fe578063535cfd8a1461211c57806353956aa21461209d57806355cba7fe1461201c57806367e0e07614611e9c5780636844846b14611e085780636c9bc73214611d3e5780637e361bde14611c255780638380edb714611b6957806385c8c01514611a7757806385e0b999146119c357806385f2dbd4146119205780638a8d123a146118605780638d928af81461181d5780638f4ab9ca14611704578063927da1051461164b5780639385e39a146115a657806396787092146115135780639e825ff51461144d578063a8175b27146113cc578063aaabadc5146112f8578063ace9b89b14611261578063b45090f9146111ce578063b4aef0ab1461110c578063b9a8effa14611047578063be7d628a14610fb0578063c673bdaf14610ee0578063c9c1661b14610de9578063ca4f280314610cfe578063cd51c12f14610c38578063ce8630d4146109e6578063d0965a6b14610965578063db817187146108e4578063dc3f574e14610830578063e2cb0ba0146107af578063e4dc2aa41461071c578063e9ddeb26146105e9578063f2784e0714610528578063f29486a1146103655763f7888aec1461027a575f80fd5b3461036257604060031936011261036257610293612fca565b90602061029e612fe0565b9260446001600160a01b0391828060405197889586947ff7888aec0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f575b602090604051908152f35b506020813d60201161034e575b816103396020938361322b565b8101031261034a5760209051610314565b5f80fd5b3d915061032c565b604051903d90823e3d90fd5b80fd5b50346103625760208060031936011261052457610380612fca565b916040519061038e826131f2565b60405161039a8161320f565b8181528184820152816040820152816060820152825280838301528060408301528060608301528060808301528060a08301528060c08301528060e0830152610100818184015281610120809401526001600160a01b0394856040519687927ff29486a10000000000000000000000000000000000000000000000000000000084521660048301528160246101a09889937f0000000000000000000000000000000000000000000000000000000000000000165afa92831561035657926104f5575b506040519360608351805115158752828101511515838801526040810151151560408801520151151560608601528201516080850152604082015160a0850152606082015160c085015264ffffffffff60808301511660e085015263ffffffff60a0830151168185015260c082015115158385015260e08201511515610140850152810151151561016084015201511515610180820152f35b610516919250853d871161051d575b61050e818361322b565b810190613473565b905f61045c565b503d610504565b5080fd5b5034610362576020908160031936011261036257602482610547612fca565b6040517ff2784e070000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc575b50604051908152f35b90508181813d83116105e2575b6105d3818361322b565b8101031261034a57515f6105b3565b503d6105c9565b50346103625760208060031936011261052457610604612fca565b8260408051610612816131d6565b828152828582015201526001600160a01b039081604051917fe9ddeb26000000000000000000000000000000000000000000000000000000008352166004820152606081602481857f0000000000000000000000000000000000000000000000000000000000000000165afa9384156103565780946106b0575b50506040606093815193838251168552838183015116908501520151166040820152f35b9093506060843d606011610714575b816106cc6060938361322b565b810103126103625750604060609361070a828051926106ea846131d6565b6106f3816132c0565b84526107008782016132c0565b87850152016132c0565b828201529361068c565b3d91506106bf565b503461036257602090816003193601126103625760248261073b612fca565b6040517fe4dc2aa40000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc5750604051908152f35b5034610362578060031936011261036257604051907fe2cb0ba00000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b5034610362576020600319360112610362578061084b612fca565b6001600160a01b0390817f00000000000000000000000000000000000000000000000000000000000000001691823b156108df57602484928360405195869485937fdc3f574e0000000000000000000000000000000000000000000000000000000085521660048401525af180156108d4576108c45750f35b6108cd906131a5565b6103625780f35b6040513d84823e3d90fd5b505050fd5b5034610362578060031936011261036257604051907fdb8171870000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b5034610362578060031936011261036257604051907fd0965a6b0000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b50346103625760208060031936011261052457610a01612fca565b9160405190610a0f826131b9565b80825280838301528060408301528060608301528060808301528060a08301528060c08301528060e0830152610100908082840152610120818185015281610140809501526001600160a01b039283604051977fce8630d4000000000000000000000000000000000000000000000000000000008952166004880152610160968781602481887f0000000000000000000000000000000000000000000000000000000000000000165afa938415610356579081879594939294610b48575b5050604051968351151588528084015115159088015260408301511515604088015260608301511515606088015260808301511515608088015260a0830151151560a088015260c0830151151560c088015260e0830151151560e0880152808301511515908701528082015115159086015201511690820152f35b9194509192508782813d8311610c31575b610b63818361322b565b81010312610362575090849291610c258460405192610b81846131b9565b610b8a816132d4565b8452610b978a82016132d4565b8a850152610ba7604082016132d4565b6040850152610bb8606082016132d4565b6060850152610bc9608082016132d4565b6080850152610bda60a082016132d4565b60a0850152610beb60c082016132d4565b60c0850152610bfc60e082016132d4565b60e0850152610c0c8682016132d4565b86850152610c1b8582016132d4565b85850152016132c0565b84820152915f80610acd565b503d610b59565b5034610362578060031936011261036257604051907fcd51c12f0000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356578091610cc1575b60208263ffffffff60405191168152f35b90506020823d602011610cf6575b81610cdc6020938361322b565b810103126103625750610cf0602091613462565b5f610cb0565b3d9150610ccf565b50346103625760206003193601126103625780602491610d1c612fca565b6040517fca4f28030000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015293849182907f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356578091610da3575b60405160208082528190610d9f90820185613284565b0390f35b90503d8082843e610db4818461322b565b8201916020818403126105245780519167ffffffffffffffff8311610362575091610de391610d9f93016132e1565b5f610d89565b503461036257604060031936011261036257610e59906040610e09612fca565b610e11612fe0565b82517fc9c1661b0000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201529116602482015292839081906044820190565b03816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa8015610ed3576040928291610ea4575b5082519182526020820152f35b9050610ec69150823d8411610ecc575b610ebe818361322b565b810190613574565b5f610e97565b503d610eb4565b50604051903d90823e3d90fd5b5034610362576020908160031936011261036257602482610eff612fca565b6040517fc673bdaf0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa918215610356578092610f78575b50506040519015158152f35b9091508282813d8311610fa9575b610f90818361322b565b810103126103625750610fa2906132d4565b5f80610f6c565b503d610f86565b5034610362576020908160031936011261036257602482610fcf612fca565b6040517fbe7d628a0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa918215610356578092610f785750506040519015158152f35b50346103625780600319360112610362576040517fb9a8effa000000000000000000000000000000000000000000000000000000008152906001600160a01b036020836004817f000000000000000000000000000000000000000000000000000000000000000085165afa9182156103565780926110cd575b6020838360405191168152f35b9091506020833d602011611104575b816110e96020938361322b565b8101031261036257506110fd6020926132c0565b905f6110c0565b3d91506110dc565b5034610362578060031936011261036257604051907fb4aef0ab0000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356578091611191575b6020826040519015158152f35b90506020823d6020116111c6575b816111ac6020938361322b565b8101031261036257506111c06020916132d4565b5f611184565b3d915061119f565b50346103625760209081600319360112610362576024826111ed612fca565b6040517fb45090f90000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc5750604051908152f35b5034610362576020908160031936011261036257602482611280612fca565b6040517face9b89b0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa918215610356578092610f785750506040519015158152f35b50346103625780600319360112610362576040517faaabadc50000000000000000000000000000000000000000000000000000000081526001600160a01b036020826004817f000000000000000000000000000000000000000000000000000000000000000085165afa9182156113c157839261137c576020838360405191168152f35b9091506020813d6020116113b9575b816113986020938361322b565b810103126113b5575181811681036113b55760209250905f6110c0565b8280fd5b3d915061138b565b6040513d85823e3d90fd5b5034610362578060031936011261036257604051907fa8175b270000000000000000000000000000000000000000000000000000000082526020826004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b503461036257602090816003193601126103625760248261146c612fca565b6040517f9e825ff50000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9182156103565780926114e3575b5050604051908152f35b9091508282813d831161150c575b6114fb818361322b565b810103126103625750515f806114d9565b503d6114f1565b5034610362576020908160031936011261036257602482611532612fca565b6040517f967870920000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa91821561035657916105bc5750604051908152f35b5034610362576040600319360112610362576115c0612fca565b9060206115cb612fe0565b9260446001600160a01b0391828060405197889586947f9385e39a0000000000000000000000000000000000000000000000000000000086521660048501521660248301527f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b503461036257606060031936011261036257611665612fca565b9061166e612fe0565b916044356001600160a01b039081811680910361034a57602092826064928160405198899687957f927da10500000000000000000000000000000000000000000000000000000000875216600486015216602484015260448301527f0000000000000000000000000000000000000000000000000000000000000000165afa908115610356579061031f57602090604051908152f35b503461034a57602060031936011261034a5761171e612fca565b6001600160a01b03906040517f85f2dbd4000000000000000000000000000000000000000000000000000000008152602081600481867f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e35783915f916117ee575b501691823b1561034a5760245f928360405195869485937f8f4ab9ca0000000000000000000000000000000000000000000000000000000085521660048401525af180156117e3576117d7575080f35b6117e191506131a5565b005b6040513d5f823e3d90fd5b611810915060203d602011611816575b611808818361322b565b81019061358a565b5f611787565b503d6117fe565b3461034a575f60031936011261034a5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b3461034a575f60031936011261034a576040517f8a8d123a0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f906118e6575b60209063ffffffff60405191168152f35b506020813d602011611918575b816119006020938361322b565b8101031261034a57611913602091613462565b6118d5565b3d91506118f3565b3461034a575f60031936011261034a576040517f85f2dbd40000000000000000000000000000000000000000000000000000000081526001600160a01b036020826004817f000000000000000000000000000000000000000000000000000000000000000085165afa9081156117e3576020925f926119a4575b5060405191168152f35b6119bc919250833d851161181657611808818361322b565b908361199a565b3461034a57604060031936011261034a57611a3260206119e1612fca565b6119e9612fe0565b6040517f85e0b9990000000000000000000000000000000000000000000000000000000081526001600160a01b0392831660048201529116602482015291829081906044820190565b03816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a575f60031936011261034a576040517f85c8c0150000000000000000000000000000000000000000000000000000000081526060816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f905f905f90611b11575b60609350604051921515835263ffffffff8092166020840152166040820152f35b5050506060813d606011611b61575b81611b2d6060938361322b565b8101031261034a5780611b416060926132d4565b611b596040611b5260208501613462565b9301613462565b909190611af0565b3d9150611b20565b3461034a575f60031936011261034a576040517f8380edb70000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb575b6020906040519015158152f35b506020813d602011611c1d575b81611c056020938361322b565b8101031261034a57611c186020916132d4565b611bde565b3d9150611bf8565b3461034a57602060031936011261034a5760245f611c41612fca565b6040517f7e361bde0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f905f92611cda575b50610d9f611ccc92604051938493604085526040850190613156565b908382036020850152613156565b9150503d805f833e611cec818361322b565b81019060408183031261034a57805167ffffffffffffffff9081811161034a5783611d18918401613401565b91602081015191821161034a57611ccc93610d9f92611d379201613401565b9250611cb0565b3461034a5760208060031936011261034a57602481611d5b612fca565b6040517f6c9bc7320000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f91611dd3575b506040519015158152f35b90508181813d8311611e01575b611dea818361322b565b8101031261034a57611dfb906132d4565b82611dc8565b503d611de0565b3461034a5760208060031936011261034a57602481611e25612fca565b6040517f6844846b0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f91611dd357506040519015158152f35b3461034a57602060031936011261034a5760245f611eb8612fca565b6040517f67e0e0760000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f905f5f915f94611f78575b5092611f6a610d9f92611f5c611f4e96604051978897608089526080890190613284565b9087820360208901526130f5565b908582036040870152613156565b908382036060850152613156565b93505050503d805f833e611f8c818361322b565b810160808282031261034a5781519167ffffffffffffffff9283811161034a5782611fb89183016132e1565b602082015184811161034a5783611fd0918401613352565b92604083015185811161034a5781611fe9918501613401565b91606084015195861161034a57611f5c61200e611f6a93611f4e98610d9f9701613401565b919593919650509250611f2a565b3461034a575f60031936011261034a576040517f55cba7fe0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb576020906040519015158152f35b3461034a575f60031936011261034a576040517f53956aa20000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a57602060031936011261034a5760245f612138612fca565b6040517f535cfd8a0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f906121bc575b610d9f90604051918291602083526020830190613156565b503d805f833e6121cc818361322b565b81019060208183031261034a5780519167ffffffffffffffff831161034a57610d9f926121f99201613401565b6121a4565b3461034a5760208060031936011261034a5760248161221b612fca565b6040517f532cec7c0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f91611dd357506040519015158152f35b3461034a5760208060031936011261034a576024816122af612fca565b6040517f4f037ee70000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f916123245750604051908152f35b90508181813d831161234a575b61233b818361322b565b8101031261034a5751826105b3565b503d612331565b3461034a5760031960408136011261034a5761236b612fca565b60243567ffffffffffffffff9283821161034a5760e090823603011261034a576040519261239884613189565b8160040135600281101561034a57845260248201356020850152604482013581811161034a5782013660238201121561034a576004810135906123da8261326c565b916123e8604051938461322b565b8083526024602084019160051b8301019136831161034a57602401905b828210612658575050506040850152606482013560608501526084820135608085015260a48201356001600160a01b038116810361034a5760a085015260c48201359080821161034a5736602383850101121561034a57600482840101351161262b57604051926124a460207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f600486880101350116018561322b565b82820160048101358086523691016024011161034a576020935f85600485878284986001600160a01b039a010135602483830101858801370101358301015260c086015260405194859384927f4d472bdd00000000000000000000000000000000000000000000000000000000845216600483015260406024830152805161252b816130be565b60448301528281015160648301527fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f8460c0612579604086015160e06084890152610124880190613156565b94606081015160a4880152608081015160c48801526001600160a01b0360a08201511660e488015201517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbc868603016101048701528051918291828752018786015e5f8682860101520116010301816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b8135815260209182019101612405565b612ff6565b3461034a57602060031936011261034a576024604061268a612fca565b81517f4021fe0f0000000000000000000000000000000000000000000000000000000081526001600160a01b03918216600482015292839182907f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3576040915f915f91612707575082519182526020820152f35b90506127209150823d8411610ecc57610ebe818361322b565b83610e97565b3461034a575f60031936011261034a576040517f2e42f4d50000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a57602060031936011261034a576127be612fca565b6001600160a01b0390816040519283927ff29486a10000000000000000000000000000000000000000000000000000000084521660048301528160246101a09485937f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3576040925f9261284c575b505060608282015191015182519182526020820152f35b6128629250803d1061051d5761050e818361322b565b8280612835565b3461034a575f60031936011261034a576040517f26a8a9910000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f9061031f57602090604051908152f35b3461034a575f60031936011261034a576040517f20c1fb7a0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f906118e65760209063ffffffff60405191168152f35b3461034a575f60031936011261034a576001600160a01b03604051907fb9a8effa0000000000000000000000000000000000000000000000000000000082526020918281600481857f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e357829184915f91612a62575b506004604051809581937f1ba0ae45000000000000000000000000000000000000000000000000000000008352165afa9182156117e3575f92612a32575060405191168152f35b9091508281813d8311612a5b575b612a4a818361322b565b8101031261034a576119bc906132c0565b503d612a40565b92505081813d8311612a92575b612a79818361322b565b8101031261034a5782612a8c83926132c0565b856129eb565b503d612a6f565b3461034a57602060031936011261034a57612ab2612fca565b6001600160a01b0380604051927f15e32046000000000000000000000000000000000000000000000000000000008452166004830152608082602481847f0000000000000000000000000000000000000000000000000000000000000000165afa9081156117e3575f915f5f945f92612b4d575b50608094604051941515855263ffffffff8092166020860152166040840152166060820152f35b9350505091506080813d608011612bae575b81612b6c6080938361322b565b8101031261034a57608091612b80826132d4565b612b8c60208401613462565b92612ba56060612b9e60408401613462565b92016132c0565b91939094612b26565b3d9150612b5f565b3461034a575f60031936011261034a576040517f13ef8a5d0000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb576020906040519015158152f35b3461034a5760208060031936011261034a57612c51612fca565b60c0604051612c5f81613189565b5f81526060918183868194015282604082015282808201528260808201528260a082015201526001600160a01b039081604051937f13d21cdf0000000000000000000000000000000000000000000000000000000085521660048401525f83602481857f0000000000000000000000000000000000000000000000000000000000000000165afa9283156117e3575f93612de6575b50926040929192519384938285526101008501845184870152838501519360e0604088015284518092528061012088019501925f905b838210612dc9578880610d9f8a8a60c0612db7612da4612d908e612d7d6040880151967fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe097888c830301848d01526130f5565b90870151868a83030160808b0152613156565b6080860151858983030160a08a0152613156565b60a0850151848883030184890152613156565b920151908483030160e0850152613156565b845181168752899850958201959382019360019190910190612d2a565b9092503d805f833e612df8818361322b565b8101848282031261034a57815167ffffffffffffffff9283821161034a57019060e08282031261034a5760405192612e2f84613189565b825184528683015181811161034a5782612e4a9185016132e1565b87850152604083015181811161034a5782612e66918501613352565b60408501528583015181811161034a5782612e82918501613401565b86850152608083015181811161034a5782612e9e918501613401565b608085015260a083015181811161034a5782612ebb918501613401565b60a085015260c083015190811161034a57612ed69201613401565b60c08201529184612cf4565b3461034a575f60031936011261034a576040517f098401f50000000000000000000000000000000000000000000000000000000081526020816004816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165afa80156117e3575f90611beb576020906040519015158152f35b3461034a57604060031936011261034a5760208180611a32612f83612fca565b612f8b612fe0565b7efdfa130000000000000000000000000000000000000000000000000000000084526001600160a01b0391821660048501521660248301526044820190565b600435906001600160a01b038216820361034a57565b602435906001600160a01b038216820361034a57565b3461034a5760208060031936011261034a57613010612fca565b6001600160a01b0380604051927f4afbaf5a0000000000000000000000000000000000000000000000000000000084521660048301528282602481847f0000000000000000000000000000000000000000000000000000000000000000165afa9182156117e3575f92613087575060405191168152f35b9091508281813d83116130b7575b61309f818361322b565b8101031261034a576130b0906132c0565b905f61199a565b503d613095565b600211156130c857565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b9081518082526020808093019301915f5b828110613114575050505090565b909192938260606001928751805161312b816130be565b8252808401516001600160a01b03168483015260409081015115159082015201950193929101613106565b9081518082526020808093019301915f5b828110613175575050505090565b835185529381019392810192600101613167565b60e0810190811067ffffffffffffffff82111761262b57604052565b67ffffffffffffffff811161262b57604052565b610160810190811067ffffffffffffffff82111761262b57604052565b6060810190811067ffffffffffffffff82111761262b57604052565b610140810190811067ffffffffffffffff82111761262b57604052565b6080810190811067ffffffffffffffff82111761262b57604052565b90601f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0910116810190811067ffffffffffffffff82111761262b57604052565b67ffffffffffffffff811161262b5760051b60200190565b9081518082526020808093019301915f5b8281106132a3575050505090565b83516001600160a01b031685529381019392810192600101613295565b51906001600160a01b038216820361034a57565b5190811515820361034a57565b9080601f8301121561034a578151906020916132fc8161326c565b9361330a604051958661322b565b81855260208086019260051b82010192831161034a57602001905b828210613333575050505090565b81516001600160a01b038116810361034a578152908301908301613325565b81601f8201121561034a57805190602061336b8361326c565b93604061337b604051968761322b565b848652828601918360608097028601019481861161034a578401925b8584106133a8575050505050505090565b868483031261034a578251906133bd826131d6565b8451600281101561034a57825285850151906001600160a01b038216820361034a57828792838b9501526133f28688016132d4565b86820152815201930192613397565b9080601f8301121561034a5781519060209161341c8161326c565b9361342a604051958661322b565b81855260208086019260051b82010192831161034a57602001905b828210613453575050505090565b81518152908301908301613445565b519063ffffffff8216820361034a57565b809103906101a0821261034a5760806040519261348f846131f2565b1261034a576040516134a08161320f565b6134a9826132d4565b81526134b7602083016132d4565b60208201526134c8604083016132d4565b60408201526134d9606083016132d4565b606082015282526080810151602083015260a0810151604083015260c0810151606083015260e081015164ffffffffff8116810361034a57608083015261356d6101806101009261352b848201613462565b60a08601526101209361353f8583016132d4565b60c087015261355161014083016132d4565b60e087015261356361016083016132d4565b90860152016132d4565b9082015290565b919082604091031261034a576020825192015190565b9081602091031261034a57516001600160a01b038116810361034a579056fea2646970667358221220a4ef6c33246ed815be6e6e4f48ee6c7f1d4dc2d2994dfd395e937950d089d6fc64736f6c634300081b0033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/packages/protocols/beets/abis-src/VaultExtension.json
+++ b/packages/protocols/beets/abis-src/VaultExtension.json
@@ -1,0 +1,2856 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "VaultExtension",
+  "sourceName": "contracts/VaultExtension.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IVault",
+          "name": "mainVault",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IVaultAdmin",
+          "name": "vaultAdmin",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        }
+      ],
+      "name": "AddressEmptyCode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "AddressInsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterAddLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterInitializeHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterRemoveLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AfterSwapHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AmountGivenZero",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "AmountInAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "AmountOutBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BalanceNotSettled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BalanceOverflow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeAddLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeInitializeHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeRemoveLiquidityHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BeforeSwapHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "BptAmountInAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "BptAmountOutBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "BufferAlreadyInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "BufferNotInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BufferSharesInvalidOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BufferSharesInvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        }
+      ],
+      "name": "BufferTotalSupplyTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CannotReceiveEth",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CannotSwapSameToken",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CodecOverflow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportAddLiquidityCustom",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportDonation",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportRemoveLiquidityCustom",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DoesNotSupportUnbalancedLiquidity",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "DynamicSwapFeeHookFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allowance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientAllowance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "balance",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "needed",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20InsufficientBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "approver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidApprover",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidReceiver",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSender",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "ERC20InvalidSpender",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ErrorSelectorNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FailedInnerCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FeePrecisionTooHigh",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxAmountIn",
+          "type": "uint256"
+        }
+      ],
+      "name": "HookAdjustedAmountInAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "name": "HookAdjustedAmountOutBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "limit",
+          "type": "uint256"
+        }
+      ],
+      "name": "HookAdjustedSwapLimit",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "poolHooksContract",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "poolFactory",
+          "type": "address"
+        }
+      ],
+      "name": "HookRegistrationFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InputLengthMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidAddLiquidityKind",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRemoveLiquidityKind",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidToken",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTokenConfiguration",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTokenDecimals",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidTokenType",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "InvalidUnderlyingToken",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "issuedShares",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minIssuedShares",
+          "type": "uint256"
+        }
+      ],
+      "name": "IssuedSharesBelowMin",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MaxTokens",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MinTokens",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotEnoughBufferShares",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expectedUnderlyingAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actualUnderlyingAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughUnderlying",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "expectedWrappedAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "actualWrappedAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "NotEnoughWrapped",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotStaticCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotVaultDelegateCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OutOfBounds",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PauseBufferPeriodDurationTooLarge",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PercentageAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolAlreadyInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolAlreadyRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolInRecoveryMode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotInRecoveryMode",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotInitialized",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolNotRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolPauseWindowExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        }
+      ],
+      "name": "PoolTotalSupplyTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ProtocolFeesExceedTotalCollected",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "QueriesDisabled",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "QueriesDisabledPermanently",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "QuoteResultSpoofed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrancyGuardReentrantCall",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "Result",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RouterNotTrusted",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "SafeCastOverflowedUintToInt",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "SenderIsNotVault",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SwapFeePercentageTooHigh",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SwapFeePercentageTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "limit",
+          "type": "uint256"
+        }
+      ],
+      "name": "SwapLimit",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "TokenAlreadyRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "TokenNotRegistered",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "expectedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "actualToken",
+          "type": "address"
+        }
+      ],
+      "name": "TokensMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TokensNotSorted",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TradeAmountTooSmall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultBuffersArePaused",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultIsNotUnlocked",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultNotPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultPauseWindowDurationTooLarge",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultPauseWindowExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "VaultPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "WrapAmountTooSmall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "WrongProtocolFeeControllerDeployment",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "underlyingToken",
+          "type": "address"
+        }
+      ],
+      "name": "WrongUnderlyingToken",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "WrongVaultAdminDeployment",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "WrongVaultExtensionDeployment",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "aggregateSwapFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "AggregateSwapFeePercentageChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "aggregateYieldFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "AggregateYieldFeePercentageChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IAuthorizer",
+          "name": "newAuthorizer",
+          "type": "address"
+        }
+      ],
+      "name": "AuthorizerChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "burnedShares",
+          "type": "uint256"
+        }
+      ],
+      "name": "BufferSharesBurned",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "issuedShares",
+          "type": "uint256"
+        }
+      ],
+      "name": "BufferSharesMinted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "liquidityProvider",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum AddLiquidityKind",
+          "name": "kind",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "amountsAddedRaw",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "swapFeeAmountsRaw",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "LiquidityAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountWrapped",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "LiquidityAddedToBuffer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "liquidityProvider",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "enum RemoveLiquidityKind",
+          "name": "kind",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "totalSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "amountsRemovedRaw",
+          "type": "uint256[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256[]",
+          "name": "swapFeeAmountsRaw",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "LiquidityRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountWrapped",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "LiquidityRemovedFromBuffer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "PoolInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "PoolPausedStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "recoveryMode",
+          "type": "bool"
+        }
+      ],
+      "name": "PoolRecoveryModeStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "factory",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "contract IERC20",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "internalType": "enum TokenType",
+              "name": "tokenType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "contract IRateProvider",
+              "name": "rateProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "paysYieldFees",
+              "type": "bool"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct TokenConfig[]",
+          "name": "tokenConfig",
+          "type": "tuple[]"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "pauseWindowEndTime",
+          "type": "uint32"
+        },
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "pauseManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "swapFeeManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "poolCreator",
+              "type": "address"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct PoolRoleAccounts",
+          "name": "roleAccounts",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "enableHookAdjustedAmounts",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallComputeDynamicSwapFee",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "address",
+              "name": "hooksContract",
+              "type": "address"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct HooksConfig",
+          "name": "hooksConfig",
+          "type": "tuple"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "disableUnbalancedLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableAddLiquidityCustom",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableRemoveLiquidityCustom",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableDonation",
+              "type": "bool"
+            }
+          ],
+          "indexed": false,
+          "internalType": "struct LiquidityManagement",
+          "name": "liquidityManagement",
+          "type": "tuple"
+        }
+      ],
+      "name": "PoolRegistered",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IProtocolFeeController",
+          "name": "newProtocolFeeController",
+          "type": "address"
+        }
+      ],
+      "name": "ProtocolFeeControllerChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "contract IERC20",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "contract IERC20",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeeAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "Swap",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "SwapFeePercentageChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "burnedShares",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "withdrawnUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Unwrap",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "eventKey",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "eventData",
+          "type": "bytes"
+        }
+      ],
+      "name": "VaultAuxiliary",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "VaultBuffersPausedStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "VaultPausedStateChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "VaultQueriesDisabled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "VaultQueriesEnabled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "depositedUnderlying",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "mintedShares",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "bufferBalances",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Wrap",
+      "type": "event"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "fallback"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "enum SwapKind",
+              "name": "kind",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "amountGivenScaled18",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "balancesScaled18",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "indexIn",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "indexOut",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "router",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes",
+              "name": "userData",
+              "type": "bytes"
+            }
+          ],
+          "internalType": "struct PoolSwapParams",
+          "name": "swapParams",
+          "type": "tuple"
+        }
+      ],
+      "name": "computeDynamicSwapFeePercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "dynamicSwapFeePercentage",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "eventKey",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "eventData",
+          "type": "bytes"
+        }
+      ],
+      "name": "emitAuxiliaryEvent",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getAddLiquidityCalledFlag",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getAggregateSwapFeeAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getAggregateYieldFeeAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getAuthorizer",
+      "outputs": [
+        {
+          "internalType": "contract IAuthorizer",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getBptRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "rate",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getCurrentLiveBalances",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "balancesLiveScaled18",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "getERC4626BufferAsset",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "asset",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getHooksConfig",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "enableHookAdjustedAmounts",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterInitialize",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallComputeDynamicSwapFee",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterSwap",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterAddLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallBeforeRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "shouldCallAfterRemoveLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "address",
+              "name": "hooksContract",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct HooksConfig",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getNonzeroDeltaCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolConfig",
+      "outputs": [
+        {
+          "components": [
+            {
+              "components": [
+                {
+                  "internalType": "bool",
+                  "name": "disableUnbalancedLiquidity",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "enableAddLiquidityCustom",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "enableRemoveLiquidityCustom",
+                  "type": "bool"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "enableDonation",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct LiquidityManagement",
+              "name": "liquidityManagement",
+              "type": "tuple"
+            },
+            {
+              "internalType": "uint256",
+              "name": "staticSwapFeePercentage",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "aggregateSwapFeePercentage",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "aggregateYieldFeePercentage",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint40",
+              "name": "tokenDecimalDiffs",
+              "type": "uint40"
+            },
+            {
+              "internalType": "uint32",
+              "name": "pauseWindowEndTime",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolRegistered",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolInitialized",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolPaused",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPoolInRecoveryMode",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct PoolConfig",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolData",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "PoolConfigBits",
+              "name": "poolConfigBits",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "contract IERC20[]",
+              "name": "tokens",
+              "type": "address[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "enum TokenType",
+                  "name": "tokenType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "contract IRateProvider",
+                  "name": "rateProvider",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "paysYieldFees",
+                  "type": "bool"
+                }
+              ],
+              "internalType": "struct TokenInfo[]",
+              "name": "tokenInfo",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "balancesRaw",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "balancesLiveScaled18",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "tokenRates",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "decimalScalingFactors",
+              "type": "uint256[]"
+            }
+          ],
+          "internalType": "struct PoolData",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolPausedState",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolRoleAccounts",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "pauseManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "swapFeeManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "poolCreator",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct PoolRoleAccounts",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokenInfo",
+      "outputs": [
+        {
+          "internalType": "contract IERC20[]",
+          "name": "tokens",
+          "type": "address[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "enum TokenType",
+              "name": "tokenType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "contract IRateProvider",
+              "name": "rateProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "paysYieldFees",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct TokenInfo[]",
+          "name": "tokenInfo",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "balancesRaw",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "lastBalancesLiveScaled18",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokenRates",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "decimalScalingFactors",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "tokenRates",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getPoolTokens",
+      "outputs": [
+        {
+          "internalType": "contract IERC20[]",
+          "name": "tokens",
+          "type": "address[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getProtocolFeeController",
+      "outputs": [
+        {
+          "internalType": "contract IProtocolFeeController",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getReservesOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "getStaticSwapFeePercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "getTokenDelta",
+      "outputs": [
+        {
+          "internalType": "int256",
+          "name": "",
+          "type": "int256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getVaultAdmin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20[]",
+          "name": "tokens",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "exactAmountsIn",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "minBptAmountOut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "userData",
+          "type": "bytes"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bptAmountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC4626",
+          "name": "wrappedToken",
+          "type": "address"
+        }
+      ],
+      "name": "isERC4626BufferInitialized",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolInRecoveryMode",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolInitialized",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "isPoolRegistered",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isQueryDisabled",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isQueryDisabledPermanently",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isUnlocked",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "quote",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "quoteAndRevert",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "reentrancyGuardEntered",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "contract IERC20",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "internalType": "enum TokenType",
+              "name": "tokenType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "contract IRateProvider",
+              "name": "rateProvider",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "paysYieldFees",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct TokenConfig[]",
+          "name": "tokenConfig",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "swapFeePercentage",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint32",
+          "name": "pauseWindowEndTime",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bool",
+          "name": "protocolFeeExempt",
+          "type": "bool"
+        },
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "pauseManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "swapFeeManager",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "poolCreator",
+              "type": "address"
+            }
+          ],
+          "internalType": "struct PoolRoleAccounts",
+          "name": "roleAccounts",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "poolHooksContract",
+          "type": "address"
+        },
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "disableUnbalancedLiquidity",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableAddLiquidityCustom",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableRemoveLiquidityCustom",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "enableDonation",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct LiquidityManagement",
+          "name": "liquidityManagement",
+          "type": "tuple"
+        }
+      ],
+      "name": "registerPool",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "exactBptAmountIn",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "minAmountsOut",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "removeLiquidityRecovery",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "amountsOutRaw",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "vault",
+      "outputs": [
+        {
+          "internalType": "contract IVault",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ],
+  "bytecode": "0x6102006040908082523461036e57818161539a803803809161002182856103b2565b83398101031261036e57610034816103d5565b6020918201516001600160a01b03929091908383169081840361036e5761007a865161005f81610383565b600a8152691a5cd55b9b1bd8dad95960b21b83820152610405565b60c0526100ad865161008b81610383565b60118152701b9bdb96995c9bd1195b1d1850dbdd5b9d607a1b83820152610405565b60e0526100da86516100be81610383565b600b81526a746f6b656e44656c74617360a81b83820152610405565b9561010096875261011281516100ef81610383565b6012815271185919131a5c5d5a591a5d1e50d85b1b195960721b84820152610405565b95610120968752610141825161012781610383565b60098152681cd95cdcda5bdb925960ba1b85820152610405565b610140908152825163fbfa77cf60e01b815290918482600481895afa918215610379575f9261033e575b5080871691160361032f578151634546891d60e11b8152918383600481885afa928315610325575f93610306575b506101609283528051631060fdbd60e11b8152948486600481845afa9586156102d8575f966102e2575b50846004916101a097885283519283809263cd51c12f60e01b82525afa9485156102d8575f956102a9575b50506101809384526101c09586526101e09687525196614ec198896104d98a3960805189505060a05189505060c05189818161105501528181612e370152613041015260e051898181611bee01528181614804015261484c0152518881816111ce01526147aa0152518781816113ab015261170301525186818161138901526116e10152518550505184613aeb0152518381816105c40152612c9901525182818161215201526129af01525181818161064401526129720152f35b6102c9929550803d106102d1575b6102c181836103b2565b8101906103e9565b925f806101ee565b503d6102b7565b82513d5f823e3d90fd5b60049196506102fe8691823d84116102d1576102c181836103b2565b9691506101c3565b61031e919350843d86116102d1576102c181836103b2565b915f610199565b50513d5f823e3d90fd5b634166145b60e11b5f5260045ffd5b9091508481813d8311610372575b61035681836103b2565b8101031261036e57610367906103d5565b905f61016b565b5f80fd5b503d61034c565b84513d5f823e3d90fd5b604081019081106001600160401b0382111761039e57604052565b634e487b7160e01b5f52604160045260245ffd5b601f909101601f19168101906001600160401b0382119082101761039e57604052565b51906001600160a01b038216820361036e57565b9081602091031261036e575163ffffffff8116810361036e5790565b6040519061041282610383565b600c8252610493603a602084016b5661756c7453746f7261676560a01b81526020604051948592828401977f62616c616e6365722d6c6162732e76332e73746f726167652e000000000000008952518091603986015e830190601760f91b60398301528051928391018583015e015f8382015203601a8101845201826103b2565b5190205f1981019081116104c4576040519060208201908152602082526104b982610383565b9051902060ff191690565b634e487b7160e01b5f52601160045260245ffdfe60806040526004361015610018575b3661295b5761294c565b5f3560e01c8062fdfa13146102b657806313d21cdf146102b157806313ef8a5d146102ac57806315e32046146102a75780631ba0ae45146102a25780634afbaf5a1461029d5780634d472bdd146102985780634f037ee714610293578063532cec7c1461028e578063535cfd8a1461028957806367e0e076146102845780636844846b1461027f5780636c9bc7321461027a578063757d64b3146102755780637e361bde146102705780638380edb71461026b57806385e0b9991461026657806385f2dbd414610261578063927da1051461025c57806396787092146102575780639e825ff514610252578063a07d60401461024d578063aaabadc514610248578063ace9b89b14610243578063b45090f91461023e578063b4aef0ab14610239578063ba8a2be014610234578063be7d628a1461022f578063c673bdaf1461022a578063c808824714610225578063ca4f280314610220578063ce8630d41461021b578063d2c725e014610216578063db81718714610211578063e1f21c671461020c578063e4dc2aa414610207578063e9ddeb2614610202578063edfa3568146101fd578063eeec802f146101f8578063f29486a1146101f3578063f7888aec146101ee5763fbfa77cf0361000e57612133565b6120ca565b612030565b611e3c565b611d91565b611cd6565b611c5f565b611c16565b611bd2565b611b94565b611b20565b6119e9565b611941565b6118f9565b6118a5565b6117ba565b611790565b611744565b6116b5565b611684565b611204565b6111a2565b61115e565b61110e565b6110e0565b61107f565b611039565b610f19565b610e27565b610d87565b610d3f565b610bf2565b610aec565b610a88565b61099f565b6108bd565b610668565b610625565b610583565b610559565b61046a565b610313565b6001600160a01b038116036102cc57565b5f80fd5b61010435906102de826102bb565b565b35906102de826102bb565b60409060031901126102cc57600435610303816102bb565b90602435610310816102bb565b90565b346102cc5760206103626001600160a01b0361032e366102eb565b91906103386129a5565b610341816129e6565b165f526006835260405f20906001600160a01b03165f5260205260405f2090565b5460801c604051908152f35b9081518082526020808093019301915f5b82811061038d575050505090565b83516001600160a01b03168552938101939281019260010161037f565b600211156103b457565b634e487b7160e01b5f52602160045260245ffd5b90604060609280516103d9816103aa565b83526001600160a01b0360208201511660208401520151151560408201520190565b9081518082526020808093019301915f5b82811061041a575050505090565b909192938261042c60019287516103c8565b95019392910161040c565b9081518082526020808093019301915f5b828110610456575050505090565b835185529381019392810192600101610448565b346102cc5760203660031901126102cc5761054b6104ac60043561048d816102bb565b610495612176565b5061049e6129a5565b6104a781612a18565b612a4c565b60405191829160208352805160208401526104d7602082015160e0604086015261010085019061036e565b60c06105396105266105126104fe604087015195601f1996878b83030160608c01526103fb565b6060870151868a83030160808b0152610437565b6080860151858983030160a08a0152610437565b60a0850151848883030184890152610437565b920151908483030160e0850152610437565b0390f35b5f9103126102cc57565b346102cc575f3660031901126102cc576105716129a5565b602060ff600954166040519015158152f35b346102cc5760203660031901126102cc5760806004356105a2816102bb565b6105aa6129a5565b6105b3816129e6565b6105bc81612c5a565b6105e99291927f0000000000000000000000000000000000000000000000000000000000000000826121c1565b916001600160a01b038091165f52600160205260405f20541691604051931515845263ffffffff80921660208501521660408301526060820152f35b346102cc575f3660031901126102cc5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b346102cc5760203660031901126102cc576020600435610687816102bb565b61068f6129a5565b6001600160a01b038091165f52600e825260405f205416604051908152f35b634e487b7160e01b5f52604160045260245ffd5b6060810190811067ffffffffffffffff8211176106de57604052565b6106ae565b6080810190811067ffffffffffffffff8211176106de57604052565b610140810190811067ffffffffffffffff8211176106de57604052565b60e0810190811067ffffffffffffffff8211176106de57604052565b67ffffffffffffffff81116106de57604052565b90601f8019910116810190811067ffffffffffffffff8211176106de57604052565b604051906102de8261071c565b604051906102de826106e3565b604051906102de826106ff565b60405190610160820182811067ffffffffffffffff8211176106de57604052565b604051906102de826106c2565b600211156102cc57565b35906102de826107c3565b67ffffffffffffffff81116106de5760051b60200190565b9080601f830112156102cc57602090823561080a816107d8565b93610818604051958661074c565b81855260208086019260051b8201019283116102cc57602001905b828210610841575050505090565b81358152908301908301610833565b67ffffffffffffffff81116106de57601f01601f191660200190565b92919261087882610850565b91610886604051938461074c565b8294818452818301116102cc578281602093845f960137010152565b9080601f830112156102cc578160206103109335910161086c565b346102cc576003196040368201126102cc576004356108db816102bb565b6024359067ffffffffffffffff928383116102cc5760e09083360301126102cc5761090461076e565b90610911836004016107cd565b82526024830135602083015260448301358481116102cc5761093990600436918601016107f0565b6040830152606483013560608301526084830135608083015261095e60a484016102e0565b60a083015260c48301359384116102cc5761098561098f93600461054b96369201016108a2565b60c08301526121de565b6040519081529081906020820190565b346102cc5760203660031901126102cc576004356109bc816102bb565b6109c46129a5565b6109cd81612a18565b610a01602060806109dd84612a4c565b015160405180938192631309bd3d60e31b8352604060048401526044830190610437565b6001602483015203816001600160a01b0386165afa8015610a835761054b9261098f925f92610a4e575b50610a47906001600160a01b03165f52601160205260405f2090565b5490612e00565b610a47919250610a759060203d602011610a7c575b610a6d818361074c565b8101906122bf565b9190610a2b565b503d610a63565b6122eb565b346102cc5760203660031901126102cc576001600160a01b03600435610aad816102bb565b610ab56129a5565b610abe816129e6565b165f525f6020526020600160405f2054811c166040519015158152f35b906020610310928181520190610437565b346102cc5760203660031901126102cc5761054b6080610b22600435610b11816102bb565b610b196129a5565b6104a7816129e6565b0151604051918291602083526020830190610437565b9081518082526020808093019301915f5b828110610b57575050505090565b83516001600160a01b031685529381019392810192600101610b49565b9290610b8c9095949295608085526080850190610b38565b6020908481036020860152602080885192838152019701915f5b828110610bd5575050505084610bc791846103109697036040860152610437565b916060818403910152610437565b9091929782610be76001928b516103c8565b990193929101610ba6565b346102cc5760203660031901126102cc57600435610c0f816102bb565b610c176129a5565b610c20816129e6565b6001600160a01b0381165f52600560205260405f20610c58610c53836001600160a01b03165f52600360205260405f2090565b6122f6565b90815192610c658461236b565b93610c6f816123ba565b91610c79826123ba565b935f5b838110610c94576040518061054b88888c8c85610b74565b80610ca960019284905f5260205260405f2090565b54610d00610cfb8a610ce6610cd986610cd38b6001600160a01b03165f52600460205260405f2090565b93612400565b516001600160a01b031690565b6001600160a01b03165f5260205260405f2090565b612425565b610d0a838c612400565b52610d15828b612400565b506001600160801b038116610d2a8389612400565b5260801c610d388289612400565b5201610c7c565b346102cc5760203660031901126102cc576020600435610d5e816102bb565b610d666129a5565b6001600160a01b038091165f52600e825260405f2054161515604051908152f35b346102cc5760203660031901126102cc576020610dbf600435610da9816102bb565b610db16129a5565b610dba816129e6565b612c5a565b506040519015158152f35b9181601f840112156102cc5782359167ffffffffffffffff83116102cc57602083818601950101116102cc57565b60206003198201126102cc576004359067ffffffffffffffff82116102cc57610e2391600401610dca565b9091565b346102cc575f80610e3736610df8565b90610e40612e24565b610e486129a5565b8160405192839283378101838152039082335af1610e64612464565b908015610e985790610e7a81610e949333612e86565b50604051630b56c9f760e31b815291829160048301611d80565b0390fd5b506004815110610ee55760208101517fffffffff00000000000000000000000000000000000000000000000000000000166314a9360960e31b01612e77576328f9554160e01b5f5260045ffd5b63a728568960e01b5f5260045ffd5b9091610f0b61031093604084526040840190610437565b916020818403910152610437565b346102cc5760203660031901126102cc57600435610f36816102bb565b610f3e6129a5565b610f47816129e6565b6001600160a01b038082165f525f60205260405f2054600360205260405f209160405180938491602082549182815201915f5260205f20935f905b82821061101157505050610f989250038361074c565b610fa482518092612ee0565b91610fae826123ba565b935f5b838110610fc7576040518061054b888883610ef4565b600190611000610ffb610cfb610fee866001600160a01b03165f52600460205260405f2090565b610ce6610cd9868a612400565b612f32565b61100a8289612400565b5201610fb1565b85546001600160a01b0390821616845260019586019588955060209094019390910190610f82565b346102cc575f3660031901126102cc576110516129a5565b60207f00000000000000000000000000000000000000000000000000000000000000005c6040519015158152f35b346102cc5760206001600160801b036110d66001600160a01b036110a2366102eb565b91906110ac6129a5565b6110b5816129e6565b165f526006845260405f20906001600160a01b03165f5260205260405f2090565b5416604051908152f35b346102cc575f3660031901126102cc576110f86129a5565b60206001600160a01b03600a5416604051908152f35b346102cc5760603660031901126102cc576020611156600435611130816102bb565b60243561113c816102bb565b60443591611149836102bb565b6111516129a5565b612fdd565b604051908152f35b346102cc5760203660031901126102cc576001600160a01b03600435611183816102bb565b61118b6129a5565b165f526008602052602060405f2054604051908152f35b346102cc5760203660031901126102cc5760206111566004356111c4816102bb565b6111cc6129a5565b7f0000000000000000000000000000000000000000000000000000000000000000906001600160a01b03165f5260205260405f205c90565b346102cc5760803660031901126102cc57600435611221816102bb565b60243561122d816102bb565b6044359060643567ffffffffffffffff81116102cc576112519036906004016107f0565b6112596129a5565b61126161303f565b611269613077565b61127284612a18565b6001600160a01b039384811691825f526020905f60205261129b60405f205460019060031c1690565b15611671576112bb836001600160a01b03165f52600560205260405f2090565b966112c4612493565b926112e3610c53866001600160a01b03165f52600360205260405f2090565b80855251966112f86040860198808a526123ba565b97608086019889525f5b815181101561134257806113306113236001938f905f5260205260405f2090565b546001600160801b031690565b61133b828d51612400565b5201611302565b5089989697986113708189516113698c6001600160a01b03165f52601160205260405f2090565b54906130d8565b9961137b83516123ba565b95606089019687526113e28b7f00000000000000000000000000000000000000000000000000000000000000005c7f0000000000000000000000000000000000000000000000000000000000000000905f5260205260405f20905f5260205260405f205c90565b151560a08a018181529590611644575b5f5b85518110156115295761141e818f8a8e838e6114108e51151590565b6114d9575b50505050612400565b51611429828c612400565b511161148957808c8f8261147c8f8261148294611463611452610cd960019b6114689651612400565b61145c8484612400565b5190613149565b612400565b519351936114768386612400565b516124e7565b92612400565b52016113f4565b8d8a6114b2836114ab8f956114a5610cd9826114d69951612400565b95612400565b5192612400565b516317bc2f2360e11b5f526001600160a01b03909216600452602452604452606490565b5ffd5b6114f861150a93611515956114ee8589612400565b5191015190613127565b611503838351612400565b5251612400565b516114768484612400565b61151f8383612400565b528a8e838e611415565b508a95509187918d938d61154e816001600160a01b03165f52600560205260405f2090565b965f5b895181101561159f57806115868c61157f836115776001968f905f5260205260405f2090565b549251612400565b519061316b565b611598828c905f5260205260405f2090565b5501611551565b61054b885f89897ffbe5b0d79fb94f1e81c0a92bf86ae9d3a19e9d1bf6202c0d3e75120f65d5d8a58a8a61161d61160b8c6115f48d6115e081338886613179565b6115e86131dc565b611634575b8583613241565b6001600160a01b03165f52601160205260405f2090565b549551886040519485941697846124f4565b0390a46116286130b3565b60405191829182610adb565b61163f8187856131fe565b6115ed565b6116676116618d6001600160a01b03165f525f60205260405f2090565b54612d01565b60208b01526113f2565b8363ef029adf60e01b5f5260045260245ffd5b346102cc575f3660031901126102cc5761169c6129a5565b60206001600160a01b0360095460081c16604051908152f35b346102cc5760203660031901126102cc57602061173a6004356116d7816102bb565b6116df6129a5565b7f00000000000000000000000000000000000000000000000000000000000000005c7f0000000000000000000000000000000000000000000000000000000000000000905f5260205260405f20905f5260205260405f205c90565b6040519015158152f35b346102cc5760203660031901126102cc576001600160a01b03600435611769816102bb565b6117716129a5565b61177a816129e6565b165f525f602052602061115660405f2054612d01565b346102cc575f3660031901126102cc576117a86129a5565b60206001600754166040519015158152f35b346102cc5760c03660031901126102cc576004356117d7816102bb565b602435906117e4826102bb565b6044359167ffffffffffffffff918284116102cc57366023850112156102cc578360040135611812816107d8565b94611820604051968761074c565b8186526020916024602088019160051b830101913683116102cc57602401905b82821061188c57505050506064358381116102cc576118639036906004016107f0565b60a4359384116102cc5761054b9461188261098f9536906004016108a2565b936084359361251f565b838091833561189a816102bb565b815201910190611840565b346102cc5760203660031901126102cc576001600160a01b036004356118ca816102bb565b6118d26129a5565b6118db816129e6565b165f525f6020526020600160405f205460031c166040519015158152f35b346102cc5760203660031901126102cc576001600160a01b0360043561191e816102bb565b6119266129a5565b165f525f6020526020600160405f2054166040519015158152f35b346102cc5760403660031901126102cc5760243567ffffffffffffffff81116102cc57611972903690600401610dca565b61197a6129a5565b611983336129e6565b80604051926020845281602085015260408401375f604082840101527f4bc4412e210115456903c65b5277d299a505e79f2eb852b92b1ca52d85856428600435926040813394601f80199101168101030190a3005b906020610310928181520190610b38565b346102cc5760203660031901126102cc57600435611a06816102bb565b611a0e6129a5565b611a17816129e6565b6001600160a01b038091165f52600360205260405f20906040519081602084549182815201935f5260205f20915f905b828210611a6a5761054b85611a5e8189038261074c565b604051918291826119d8565b909192946001611a8c819284895416906001600160a01b036020921681520190565b960193920190611a47565b80511515825260208082015115159083015260408082015115159083015260608082015115159083015260808082015115159083015260a08082015115159083015260c08082015115159083015260e0808201511515908301526101008082015115159083015261012080820151151590830152610140908101516001600160a01b0316910152565b346102cc5760203660031901126102cc57610160611b85600435611b43816102bb565b611b4b6126ad565b50611b546129a5565b611b5d816129e6565b6001600160a01b038091165f525f60205260405f205490600260205260405f205416906138c1565b611b926040518092611a97565bf35b346102cc575f3660031901126102cc5760207f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6040519015158152f35b346102cc575f3660031901126102cc57611bea6129a5565b60207f00000000000000000000000000000000000000000000000000000000000000005c604051908152f35b346102cc5760603660031901126102cc57611c54600435611c36816102bb565b602435611c42816102bb565b611c4a6129a5565b60443591336139ff565b602060405160018152f35b346102cc5760203660031901126102cc576001600160a01b03600435611c84816102bb565b611c8c6129a5565b165f526011602052602060405f2054604051908152f35b6102de909291926060810193604090816001600160a01b0391828151168552826020820151166020860152015116910152565b346102cc5760203660031901126102cc5761054b600435611cf6816102bb565b611cfe61234d565b50611d076129a5565b611d10816129e6565b6001600160a01b038091165f52600160205260405f2090600260405192611d36846106c2565b828154168452826001820154166020850152015416604082015260405191829182611ca3565b805180835260209291819084018484015e5f828201840152601f01601f1916010190565b906020610310928181520190611d5c565b346102cc5761054b611dda5f80611dc1611daa36610df8565b611db2612e24565b611dba6129a5565b369161086c565b60208151910182335af1611dd3612464565b9033612e86565b604051918291602083526020830190611d5c565b801515036102cc57565b608435906102de82611dee565b6064359063ffffffff821682036102cc57565b60609060a31901126102cc5760a490565b6080906101231901126102cc5761012490565b346102cc576101a03660031901126102cc57600435611e5a816102bb565b60243567ffffffffffffffff81116102cc57366023820112156102cc57806004013591611e86836107d8565b91604093611e97604051948561074c565b8084526020906024602086019160071b840101923684116102cc57602401905b838210611efb57611ef98686611ecb611e05565b611ed3611df8565b611edc36611e18565b91611ee56102d0565b93611eef36611e29565b9560443591612710565b005b6080823603126102cc57826080918851611f14816106e3565b8435611f1f816102bb565b815282850135611f2e816107c3565b8382015289850135611f3f816102bb565b8a82015260608086013590611f5382611dee565b820152815201910190611eb7565b6102de909291926101806101a0820194611fa28382516060809180511515845260208101511515602085015260408101511515604085015201511515910152565b60208101516080840152604081015160a0840152606081015160c0840152611fd8608082015160e085019064ffffffffff169052565b60a081015190611ff3610100928386019063ffffffff169052565b61202760c08201519261200d610120948588019015159052565b60e083015115156101408701528201511515610160860152565b01511515910152565b346102cc5760203660031901126102cc5761054b6120be600435612053816102bb565b5f610120604051612063816106ff565b60405161206f816106e3565b83815283602082015283604082015283606082015281528260208201528260408201528260608201528260808201528260a08201528260c08201528260e0820152826101008201520152612836565b60405191829182611f61565b346102cc5760403660031901126102cc57602061212a6004356120ec816102bb565b6001600160a01b0360243591612101836102bb565b6121096129a5565b165f52600f835260405f20906001600160a01b03165f5260205260405f2090565b54604051908152f35b346102cc575f3660031901126102cc5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b604051906121838261071c565b815f815260c060609182602082015282604082015282808201528260808201528260a08201520152565b634e487b7160e01b5f52601160045260245ffd5b91909163ffffffff808094169116019182116121d957565b6121ad565b612242916121ea6129a5565b6121f382612a18565b6001600160a01b039081831690815f525f6020526040938493612218855f2054612d01565b935f526002602052845f2054169184519687948593849363283a3d6b60e21b855260048501612d4e565b03915afa918215610a83575f915f9361228d575b50501561227e57670de0b5cad2bef000811161226f5790565b6301d1b96560e61b5f5260045ffd5b6314fe5db560e21b5f5260045ffd5b6122b0935080919250903d106122b8575b6122a8818361074c565b810190612d2f565b905f80612256565b503d61229e565b908160209103126102cc575190565b919060206122e6600192604086526040860190610437565b930152565b6040513d5f823e3d90fd5b90604051918281549182825260209260208301915f5260205f20935f905b82821061232a575050506102de9250038361074c565b85546001600160a01b031684526001958601958895509381019390910190612314565b6040519061235a826106c2565b5f6040838281528260208201520152565b90612375826107d8565b612382604051918261074c565b8281528092612393601f19916107d8565b01905f5b8281106123a357505050565b6020906123ae61234d565b82828501015201612397565b906123c4826107d8565b6123d1604051918261074c565b82815280926123e2601f19916107d8565b0190602036910137565b634e487b7160e01b5f52603260045260245ffd5b80518210156124145760209160051b010190565b6123ec565b612422826103aa565b52565b90604051612432816106c2565b604060ff829454818116612445816103aa565b84526001600160a01b038160081c16602085015260a81c161515910152565b3d1561248e573d9061247582610850565b91612483604051938461074c565b82523d5f602084013e565b606090565b6040519060c0820182811067ffffffffffffffff8211176106de576040525f60a08360608152826020820152826040820152606080820152606060808201520152565b620f423f198101919082116121d957565b919082039182116121d957565b916125119061031094928452606060208501526060840190610437565b916040818403910152610437565b939594919592909261252f6129a5565b61253761303f565b612540856129e6565b612548613077565b612551856133c7565b61255a85612a4c565b916125698351600190811c1690565b612691576125d296976125836020850151518351906133fc565b60c0840195865161259b60a087019182519086613412565b97896125ac885160019060081c1690565b612620575b89949250879150926125c49695936135c0565b94859151600190600a1c1690565b6125e3575b505050506103106130b3565b612611612604612617956001600160a01b03165f52600260205260405f2090565b546001600160a01b031690565b92613827565b5f8080836125d7565b9161268491612656899b8b6126506126046125c49c9b999a986001600160a01b03165f52600260205260405f2090565b916134b8565b61267a6126748d6001600160a01b03165f52600560205260405f2090565b8a61355c565b5190519084613412565b97819392949550896125b1565b63218e374760e01b5f526001600160a01b03861660045260245ffd5b60405190610160820182811067ffffffffffffffff8211176106de576040525f610140838281528260208201528260408201528260608201528260808201528260a08201528260c08201528260e082015282610100820152826101208201520152565b94969263ffffffff919694926127246129a5565b61272c613077565b612734613ae4565b604051976127418961071c565b88526020880152166040860152151560608501526060853603126102cc576127bd6127c4926127ce966040805191612778836106c2565b8035612783816102bb565b83526020810135612793816102bb565b602084015201356127a3816102bb565b604082015260808701526001600160a01b031660a0860152565b36906127d6565b60c0830152613ec4565b6102de6130b3565b91908260809103126102cc576040516127ee816106e3565b606080829480356127fe81611dee565b8452602081013561280e81611dee565b6020850152604081013561282181611dee565b604085015201359161283283611dee565b0152565b612861906128426129a5565b61284b816129e6565b6001600160a01b03165f525f60205260405f2090565b54610310600161287083612d01565b9261291961287d826146c8565b61290c612889846146eb565b64ffffffffff85605a1c169063ffffffff866128a3608290565b1c16936128ae61077b565b600488901c89161515815299600588901c8916151560208c0152600688901c8916151560408c0152600788901c8916151560608c01526128ec610788565b9a8b5260208b015260408a0152606089015264ffffffffff166080880152565b63ffffffff1660a0860152565b808216151560c085015280821c8216151560e0850152600281901c8216151561010085015260031c161515610120830152565b637911c44b60e11b5f5260045ffd5b3461294c57365f80375f8036816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af43d5f803e156129a1573d5ff35b3d5ffd5b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001630036129d757565b634fe92d9b60e11b5f5260045ffd5b6001600160a01b0316805f525f602052600160405f20541615612a065750565b6327946f5760e21b5f5260045260245ffd5b6001600160a01b0316805f525f602052600160405f2054811c1615612a3a5750565b634bdace1360e01b5f5260045260245ffd5b906001600160a01b03612a5d612176565b92165f5260056020526040805f205f602052815f2054906004602052825f20906003602052835f20938454938752612a98602088019561470e565b8552612aa38461236b565b91818801928352612ab3856123ba565b9160608901928352612ac4866123ba565b9460809560808b0152612ad8878b51612ee0565b60c08b0152612ae6876123ba565b60a08b019081528a5191600199600184811c169384612c46575b5083612c34575b8c5f5b8b8110612b205750505050505050505050505050565b8a8d92828c8c8c612b6784612b5381612b45610cfb8f8f610cd985610ce69251612400565b94905f5260205260405f2090565b54945183612b618383612400565b52612400565b50612b7181612f32565b612b7c858d51612400565b52612b916001600160801b03841685876148ea565b878d8d15612c275782015115159182612c09575b5050612bba575b50505050505b018d90612b0a565b82612bdd92612bd482612bcd88516146eb565b9451612400565b51961c85614d75565b9283612bed575b8e93508c612bac565b612c0093612bfa916124e7565b916148ea565b5f8f8282612be4565b90915051612c16816103aa565b612c1f816103aa565b14875f612ba5565b5050505050505050612bb2565b8c5190935060031c6001161592612b07565b612c519194506146eb565b1515925f612b00565b6001600160a01b03165f525f60205260405f20549060018260021c1663ffffffff8093612c85608290565b1c169281612c9257509190565b9050612cbe7f0000000000000000000000000000000000000000000000000000000000000000846121c1565b164211159190565b60ff60019116019060ff82116121d957565b906005820291808304600514901517156121d957565b818102929181159184041417156121d957565b62ffffff9060121c1664174876e800908181029181830414901517156121d95790565b51906102de82611dee565b91908260409103126102cc5760208251612d4881611dee565b92015190565b612832612dd060409396959496606084528051612d6a816103aa565b60608501526020810151608085015260c0612d948683015160e060a0880152610140870190610437565b606083015186830152608083015160e087015260a08301516001600160a01b0316610100870152910151848203605f1901610120860152611d5c565b6001600160a01b039096166020830152565b8115612dec570490565b634e487b7160e01b5f52601260045260245ffd5b90670de0b6b3a7640000918281029281840414901517156121d95761031091612de2565b32612e6857600160075416612e595760017f00000000000000000000000000000000000000000000000000000000000000005d565b633d0cc44360e11b5f5260045ffd5b6333fc255960e11b5f5260045ffd5b805115610ee557805190602001fd5b90612eaa5750805115612e9b57805190602001fd5b630a12f52160e11b5f5260045ffd5b81511580612ed7575b612ebb575090565b6001600160a01b0390639996b31560e01b5f521660045260245ffd5b50803b15612eb3565b9064ffffffffff612ef0826123ba565b92605a1c165f5b828110612f045750505090565b601f82612f1083612cd8565b1c1690604d82116121d957600191600a0a612f2b8287612400565b5201612ef7565b8051612f3d816103aa565b612f46816103aa565b80612f59575050670de0b6b3a764000090565b80612f656001926103aa565b03612fce576020612f90612f848260049401516001600160a01b031690565b6001600160a01b031690565b6040516333cd77e760e11b815292839182905afa908115610a83575f91612fb5575090565b610310915060203d602011610a7c57610a6d818361074c565b636fa2831960e11b5f5260045ffd5b6001600160a01b03929183811684841603612ffb57505050505f1990565b61303b9361302592165f52601060205260405f20906001600160a01b03165f5260205260405f2090565b906001600160a01b03165f5260205260405f2090565b5490565b7f00000000000000000000000000000000000000000000000000000000000000005c1561306857565b63604dd39b60e11b5f5260045ffd5b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c6130a4576001905d565b633ee5aeb560e01b5f5260045ffd5b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d565b92916130e484516123ba565b935f5b815181101561312157806131108561310b8661310560019688612400565b51612cee565b612de2565b61311a8289612400565b52016130e7565b50505050565b9061313191612cee565b6001670de0b6b3a76400005f19830104019015150290565b9061315390614765565b90600160ff1b82146121d9576102de915f03906147a1565b906103109160801c90614889565b9190939293613189828285612fdd565b6001810161319a575b505050509050565b8086116131b857946131ae949503926139ff565b805f808080613192565b85906001600160a01b0384637dc7a0d960e11b5f521660045260245260445260645ffd5b3215806131e65790565b506001600754161590565b919082018092116121d957565b9032612e68576001600160a01b0361323292165f52600f60205260405f20906001600160a01b03165f5260205260405f2090565b80549182018092116121d95755565b90916001600160a01b038084169283156133ab5761327485613025836001600160a01b03165f52600f60205260405f2090565b548084116133875783900361329e86613025846001600160a01b03165f52600f60205260405f2090565b556132c4836132be836001600160a01b03165f52601160205260405f2090565b546124e7565b6132cd816148cb565b6132e8826001600160a01b03165f52601160205260405f2090565b551690813b156102cc576040516323de665160e01b81526001600160a01b0390941660048501525f6024850181905260448501829052937fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f9161336991868180606481015b038183895af161336e575b506040519081529081906020820190565b0390a4565b8061337b61338192610738565b8061054f565b5f613358565b63391434e360e21b5f526001600160a01b038616600452602452604483905260645ffd5b634b637e8f60e11b5f526001600160a01b03851660045260245ffd5b6133cf613ae4565b6133d881612c5a565b506133e05750565b6001600160a01b039063d971f59760e01b5f521660045260245ffd5b0361340357565b63aaad13f760e01b5f5260045ffd5b91908251918151815181851491821592613498575b505061340357613436836123ba565b935f5b84811061344857505050505090565b80670de0b6b3a764000061348661346160019486612400565b5161348161346f858a612400565b5161347a868a612400565b5192612cee565b612cee565b046134918289612400565b5201613439565b141590505f80613427565b908160209103126102cc575161031081611dee565b90613503926134f15f6001600160a01b036020956040519788968795869363038293c560e31b8552604060048601526044850190610437565b83810360031901602485015290611d5c565b0393165af1908115610a83575f9161352d575b501561351e57565b636061292560e01b5f5260045ffd5b61354f915060203d602011613555575b613547818361074c565b8101906134a3565b5f613516565b503d61353d565b60208082015151925f5b848110613574575050505050565b6001906135ba6001600160801b03604061359a61359485838b0151612400565b51612f32565b6135a88560a08b0151612400565b52835f528587525f20541682876148ea565b01613566565b9291959694966135e1846001600160a01b03165f52600560205260405f2090565b955f5b602089015180518210156136bf57610cd9826135ff92612400565b61360f612f84610cd98489612400565b6001600160a01b03821690810361366b575090613639600192613632838b612400565b5190614937565b6136528b61364b836114ab818d612400565b5190614889565b613664828b905f5260205260405f2090565b55016135e4565b6114d69088613680612f84610cd9878c612400565b7fffe261a1000000000000000000000000000000000000000000000000000000005f526001600160a01b03918216600452811660245216604452606490565b505096949192509694506136d884516002908119161790565b8085526136f5846001600160a01b03165f525f60205260405f2090565b556001600160a01b039261372260208583169760405180938192631309bd3d60e31b8352600483016122ce565b03818a5afa8015610a8357613747915f91613808575b50613742816148cb565b6124d6565b9761375182614949565b61375c898584614a40565b8089106137f157509285926137c87fa26a52d8d53702bba7f137907b8e1f99ff87f6d450144270ca25e72481cca871936137b960206137af60019a996001600160a01b03165f52601160205260405f2090565b54980151516123ba565b906040519485941697846124f4565b0390a47fcad8c9d32507393b6508ca4a888b81979919b477510585bde8488f153072d6f35f80a2565b638d261d5d60e01b5f52600489905260245260445ffd5b613821915060203d602011610a7c57610a6d818361074c565b5f613738565b926138615f6001600160a01b036020959496613878604051988997889687946338be241d60e01b8652606060048701526064860190610437565b916024850152600319848303016044850152611d5c565b0393165af1908115610a83575f916138a2575b501561389357565b630791ede360e11b5f5260045ffd5b6138bb915060203d60201161355557613547818361074c565b5f61388b565b906138ca6126ad565b5060ff60018084836138dc600c612cc6565b6138e590612cc6565b161c168185846138f5600c612cc6565b6138fe90612cc6565b61390790612cc6565b161c1690828685613918600c612cc6565b61392190612cc6565b61392a90612cc6565b61393390612cc6565b161c1692808786613944600c612cc6565b61394d90612cc6565b61395690612cc6565b61395f90612cc6565b61396890612cc6565b161c16948188818184600c161c1692600c61398290612cc6565b161c169161398e610795565b60098a901c82161515815298600881901c8216151560208b0152600a81901c8216151560408b0152600b1c161515606089015215156080880152151560a0870152151560c0860152151560e0850152151561010084015215156101208301526001600160a01b031661014082015290565b9290916001600160a01b0392838116938415613ac857808316958615613aac5784613a438561302586613025866001600160a01b03165f52601060205260405f2090565b551692833b156102cc57604051630ad0fe5760e31b81526001600160a01b039283166004820152919092166024820152604481018290527fa0175360a15bca328baf7ea85c7b784d58b222a50d0ce760b10dba336d226a6191613369915f81806064810161334d565b634a1406b160e11b5f526001600160a01b03841660045260245ffd5b63e602df0560e01b5f526001600160a01b03821660045260245ffd5b63ffffffff7f00000000000000000000000000000000000000000000000000000000000000001642111580613b29575b613b1a57565b6336a7e2cd60e21b5f5260045ffd5b506001600754811c16613b14565b90805190613b44826103aa565b613b4d826103aa565b8254602082015160409092015175ffffffffffffffffffffffffffffffffffffffffffff1990911660ff939093169290921760089190911b74ffffffffffffffffffffffffffffffffffffffff00161790151560a81b60ff60a81b16179055565b908160209103126102cc575160ff811681036102cc5790565b8054680100000000000000008110156106de5760018101808355811015612414576001600160a01b03915f5260205f200191166001600160a01b0319825416179055565b8151815473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b039182161782556102de9260029190604090613c688360208301511660018701906001600160a01b03166001600160a01b0319825416179055565b0151169101906001600160a01b03166001600160a01b0319825416179055565b91908260409103126102cc576020825192015190565b9081518082526020808093019301915f5b828110613cbd575050505090565b9091929382608060019287516001600160a01b0380825116835284820151613ce4816103aa565b838601526040828101519091169083015260609081015115159082015201950193929101613caf565b9493916102de93606092613d3f926001600160a01b03809216895216602088015260e0604088015260e0870190613c9e565b9401906060809180511515845260208101511515602085015260408101511515604085015201511515910152565b90816101409103126102cc57613d81610788565b90613d8b81612d24565b8252613d9960208201612d24565b6020830152613daa60408201612d24565b6040830152613dbb60608201612d24565b6060830152613dcc60808201612d24565b6080830152613ddd60a08201612d24565b60a0830152613dee60c08201612d24565b60c0830152613dff60e08201612d24565b60e0830152610100613e12818301612d24565b90830152613e24610120809201612d24565b9082015290565b9196959394613e8d6102de9663ffffffff61022096613e55613e97966102a0808a52890190613c9e565b9b60208801521660408601526060850190604090816001600160a01b0391828151168552826020820151166020860152015116910152565b60c0830190611a97565b01906060809180511515845260208101511515602085015260408101511515604085015201511515910152565b90613ee9613ee2836001600160a01b03165f525f60205260405f2090565b5460011690565b6146ac578051516002811061469d576008811161468e57929190613f0c846123ba565b5f945f5b818110614417575050613fc3929394506080820191613f4a8351613f45876001600160a01b03165f52600160205260405f2090565b613c0b565b613f5f612f84600a546001600160a01b031690565b60408091613f78828751016001600160a01b0390511690565b90613f866060860151151590565b83516377ff76e760e01b81526001600160a01b03808c166004830152909316602484015215156044830152909687919082905f9082906064820190565b03925af18015610a83575f955f916143e4575b5061409260c084019161408d61405c84519761404561403f613ffe8b51151560041b60011790565b9a606061402e61401c60209e8f850151151560051b90602019161790565b8c840151151560061b90604019161790565b910151151560071b90608019161790565b91614b5c565b90605a9164ffffffffff908116831b921b19161790565b986140888688019a6140728c5163ffffffff1690565b9060829163ffffffff908116831b921b19161790565b614bfa565b614c1a565b9360a08401906001600160a01b039589876140b485516001600160a01b031690565b168061419d575b50906140d98193926001600160a01b03165f525f60205260405f2090565b5582516001600160a01b03166001600160a01b03166141098b6001600160a01b03165f52600260205260405f2090565b9061412991906001600160a01b03166001600160a01b0319825416179055565b8501948551614138908b614c3e565b519451975163ffffffff16965191516001600160a01b03166001600160a01b0316614162916138c1565b91519251958695339916976141779587613e2b565b037fbc1561eeab9f40962e2fb827a7ff9c7cdb47a9d7c84caeefa4ed90e043842dad91a3565b6141c691849189515f8951938b51968795869485936305c4f8c160e11b85523360048601613d0d565b03925af1908115610a83575f916143c7575b50156143b2576141f5612f84612f8485516001600160a01b031690565b908551809263d77153a760e01b82528160046101409586935afa928315610a83575f93614383575b50508151151580614369575b61432f579061431a6101206142756143046142f06142dc6142c86142b46142a08e61429361428a8c8f6143289f9061427561427d926142688551151590565b60091b9061020019161790565b920151151590565b60081b9061010019161790565b918c0151151590565b600a1b9061040019161790565b60608a01511515600b1b9061080019161790565b60808901511515600c1b9061100019161790565b60a08801511515600d1b9061200019161790565b60c08701511515600e1b9061400019161790565b60e08601511515600f1b9061800019161790565b610100850151151560101b906201000019161790565b60111b906202000019161790565b895f6140bb565b6114d68b61434486516001600160a01b031690565b633ea4f60560e21b5f526001600160a01b039081166004521660245233604452606490565b5061437d614378865151151590565b151590565b15614229565b6143a3929350803d106143ab575b61439b818361074c565b810190613d6d565b905f8061421d565b503d614391565b6114d68a61434485516001600160a01b031690565b6143de9150833d851161355557613547818361074c565b5f6141d8565b9050816144079296503d8711614410575b6143ff818361074c565b810190613c88565b9490945f613fd6565b503d6143f5565b614422818551612400565b519661443588516001600160a01b031690565b906001600160a01b038083169182158015614683575b614674571680821061466557811461464957604090818a01998a51614476906001600160a01b031690565b6001600160a01b0316159060209b8c8201908d825191614495836103aa565b516001600160a01b0316936060019384516144af90151590565b916144b86107b6565b936144c39085612419565b6001600160a01b0390911690830152151581870152866144f48d6001600160a01b03165f52600460205260405f2090565b9061450f91906001600160a01b03165f5260205260405f2090565b9061451991613b37565b8051614524816103aa565b61452d816103aa565b6146135750811591614608575b50612fce5789915b51998a809263313ce56760e01b825260049c8d915afa918215610a83575f926145db575b505060129060ff9180838316115f14614587578a63686d360760e01b5f525ffd5b60019495969798999a50906145ab929103166145a38588612400565b9060ff169052565b6145cf816145ca896001600160a01b03165f52600360205260405f2090565b613bc7565b96959493929101613f10565b6145fa9250803d10614601575b6145f2818361074c565b810190613bae565b5f80614566565b503d6145e8565b51151590505f61453a565b6001915051614621816103aa565b61462a816103aa565b0361463a57612fce578991614542565b63a1e9dd9d60e01b5f5260045ffd5b6327a5b1a760e11b5f526001600160a01b03821660045260245ffd5b636e8f194760e01b5f5260045ffd5b63c1ab6dc160e01b5f5260045ffd5b50818916831461444b565b630e0f7beb60e31b5f5260045ffd5b635ed4ba8f60e01b5f5260045ffd5b6301b6ee3960e71b5f526001600160a01b03821660045260245ffd5b62ffffff90602a1c1664174876e800908181029181830414901517156121d95790565b62ffffff9060421c1664174876e800908181029181830414901517156121d95790565b90604051918281549182825260209260208301915f5260205f20935f905b828210614742575050506102de9250038361074c565b85546001600160a01b03168452600195860195889550938101939091019061472c565b7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff811161478f5790565b63123baf0360e11b5f5260045260245ffd5b908015614885577f0000000000000000000000000000000000000000000000000000000000000000916147e68184906001600160a01b03165f5260205260405f205c90565b8281019283125f82129080158216911516176121d9578261483b57507f000000000000000000000000000000000000000000000000000000000000000092835c5f1981019081116121d9576102de945d614de3565b1561484a575b6102de92614de3565b7f000000000000000000000000000000000000000000000000000000000000000092835c600181018091116121d9576102de945d9250614841565b5050565b906001600160801b038083119081156148c1575b506148b25760801b9081018091116121d95790565b6389560ca160e01b5f5260045ffd5b905081115f61489d565b620f424081106148d85750565b6334e3483f60e21b5f5260045260245ffd5b91906080670de0b6b3a764000061492e612422948061490d8660608a0151612400565b5261348161491f8660c08a0151612400565b5161347a8760a08b0151612400565b04930151612400565b6149436102de92614765565b906147a1565b614964816001600160a01b03165f52601160205260405f2090565b908154620f4240908181018091116121d9576001600160a01b03935561499b826001600160a01b03165f52600f60205260405f2090565b5f805260205260405f20908154019055165f80827fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f604051806149e58190620f4240602083019252565b0390a4803b156102cc575f60405180926323de665160e01b8252818381614a226004820190620f4240604060608401935f81525f60208201520152565b03925af18015610a8357614a335750565b8061337b6102de92610738565b916001600160a01b03808316938415614b4057614a7883614a72836001600160a01b03165f52601160205260405f2090565b546131f1565b614a9785613025846001600160a01b03165f52600f60205260405f2090565b848154019055614aa6816148cb565b614ac1826001600160a01b03165f52601160205260405f2090565b5516925f847fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f60405180614afa87829190602083019252565b0390a4823b156102cc576040516323de665160e01b81525f600482018190526001600160a01b039093166024820152604481019190915291829081838160648101614a22565b63ec442f0560e01b5f526001600160a01b03841660045260245ffd5b5f9190825b8151841015614bee57614b748483612400565b5160ff91614b8186612cd8565b9161010080841015614bda578381039081116121d95780851015614be95750835b6005908111614bda57816007911c16614bcb57600193601f9116831b921b191617930192614b61565b63e4337c0560e01b5f5260045ffd5b632d0483c560e21b5f5260045ffd5b614ba2565b64ffffffffff16925050565b670de0b5cad2bef000821161226f5764174876e800610310920490614df9565b90670de0b5cad2bef000811161226f576103109164174876e8006042920490614e13565b60405163ce20ece760e01b81526001600160a01b0382169291906020908181600481885afa908115610a83575f91614d58575b508310614d495760405163654cf15d60e01b81528181600481885afa918215610a83575f92614d2c575b50508211614d1d578181614d07614cf07f89d41522342fabac1471ca6073a5623e5caf367b03ca6e9a001478d0cf8be4a195614cea614d18966001600160a01b03165f525f60205260405f2090565b54614e5a565b916001600160a01b03165f525f60205260405f2090565b556040519081529081906020820190565b0390a2565b637f47834b60e01b5f5260045ffd5b614d429250803d10610a7c57610a6d818361074c565b5f80614c9b565b6317f640d160e31b5f5260045ffd5b614d6f9150823d8411610a7c57610a6d818361074c565b5f614c71565b9093925f94614d88846080850151612400565b51818111614d98575b5050505050565b614dd8959650614dd29392614dcb92614db19203613127565b9360a0614dc28260c0860151612400565b51930151612400565b5190612cee565b90612e00565b905f80808080614d91565b906001600160a01b03165f5260205260405f205d565b908060181c614bcb57602a1b9062ffffff602a1b19161790565b9061010080841015614bda578381039081116121d9578060ff105f14614e55575060ff5b601811614bda578060181c614bcb5762ffffff90831b921b19161790565b614e37565b90670de0b5cad2bef000811161226f5764174876e80090048060181c614bcb5760121b906503fffffc00001916179056fea2646970667358221220a6e17b54ff4f02ab7e39ccab30a68ff505d38f245ca4321ba25b9c826b1d672764736f6c634300081a0033",
+  "deployedBytecode": "0x60806040526004361015610018575b3661295b5761294c565b5f3560e01c8062fdfa13146102b657806313d21cdf146102b157806313ef8a5d146102ac57806315e32046146102a75780631ba0ae45146102a25780634afbaf5a1461029d5780634d472bdd146102985780634f037ee714610293578063532cec7c1461028e578063535cfd8a1461028957806367e0e076146102845780636844846b1461027f5780636c9bc7321461027a578063757d64b3146102755780637e361bde146102705780638380edb71461026b57806385e0b9991461026657806385f2dbd414610261578063927da1051461025c57806396787092146102575780639e825ff514610252578063a07d60401461024d578063aaabadc514610248578063ace9b89b14610243578063b45090f91461023e578063b4aef0ab14610239578063ba8a2be014610234578063be7d628a1461022f578063c673bdaf1461022a578063c808824714610225578063ca4f280314610220578063ce8630d41461021b578063d2c725e014610216578063db81718714610211578063e1f21c671461020c578063e4dc2aa414610207578063e9ddeb2614610202578063edfa3568146101fd578063eeec802f146101f8578063f29486a1146101f3578063f7888aec146101ee5763fbfa77cf0361000e57612133565b6120ca565b612030565b611e3c565b611d91565b611cd6565b611c5f565b611c16565b611bd2565b611b94565b611b20565b6119e9565b611941565b6118f9565b6118a5565b6117ba565b611790565b611744565b6116b5565b611684565b611204565b6111a2565b61115e565b61110e565b6110e0565b61107f565b611039565b610f19565b610e27565b610d87565b610d3f565b610bf2565b610aec565b610a88565b61099f565b6108bd565b610668565b610625565b610583565b610559565b61046a565b610313565b6001600160a01b038116036102cc57565b5f80fd5b61010435906102de826102bb565b565b35906102de826102bb565b60409060031901126102cc57600435610303816102bb565b90602435610310816102bb565b90565b346102cc5760206103626001600160a01b0361032e366102eb565b91906103386129a5565b610341816129e6565b165f526006835260405f20906001600160a01b03165f5260205260405f2090565b5460801c604051908152f35b9081518082526020808093019301915f5b82811061038d575050505090565b83516001600160a01b03168552938101939281019260010161037f565b600211156103b457565b634e487b7160e01b5f52602160045260245ffd5b90604060609280516103d9816103aa565b83526001600160a01b0360208201511660208401520151151560408201520190565b9081518082526020808093019301915f5b82811061041a575050505090565b909192938261042c60019287516103c8565b95019392910161040c565b9081518082526020808093019301915f5b828110610456575050505090565b835185529381019392810192600101610448565b346102cc5760203660031901126102cc5761054b6104ac60043561048d816102bb565b610495612176565b5061049e6129a5565b6104a781612a18565b612a4c565b60405191829160208352805160208401526104d7602082015160e0604086015261010085019061036e565b60c06105396105266105126104fe604087015195601f1996878b83030160608c01526103fb565b6060870151868a83030160808b0152610437565b6080860151858983030160a08a0152610437565b60a0850151848883030184890152610437565b920151908483030160e0850152610437565b0390f35b5f9103126102cc57565b346102cc575f3660031901126102cc576105716129a5565b602060ff600954166040519015158152f35b346102cc5760203660031901126102cc5760806004356105a2816102bb565b6105aa6129a5565b6105b3816129e6565b6105bc81612c5a565b6105e99291927f0000000000000000000000000000000000000000000000000000000000000000826121c1565b916001600160a01b038091165f52600160205260405f20541691604051931515845263ffffffff80921660208501521660408301526060820152f35b346102cc575f3660031901126102cc5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b346102cc5760203660031901126102cc576020600435610687816102bb565b61068f6129a5565b6001600160a01b038091165f52600e825260405f205416604051908152f35b634e487b7160e01b5f52604160045260245ffd5b6060810190811067ffffffffffffffff8211176106de57604052565b6106ae565b6080810190811067ffffffffffffffff8211176106de57604052565b610140810190811067ffffffffffffffff8211176106de57604052565b60e0810190811067ffffffffffffffff8211176106de57604052565b67ffffffffffffffff81116106de57604052565b90601f8019910116810190811067ffffffffffffffff8211176106de57604052565b604051906102de8261071c565b604051906102de826106e3565b604051906102de826106ff565b60405190610160820182811067ffffffffffffffff8211176106de57604052565b604051906102de826106c2565b600211156102cc57565b35906102de826107c3565b67ffffffffffffffff81116106de5760051b60200190565b9080601f830112156102cc57602090823561080a816107d8565b93610818604051958661074c565b81855260208086019260051b8201019283116102cc57602001905b828210610841575050505090565b81358152908301908301610833565b67ffffffffffffffff81116106de57601f01601f191660200190565b92919261087882610850565b91610886604051938461074c565b8294818452818301116102cc578281602093845f960137010152565b9080601f830112156102cc578160206103109335910161086c565b346102cc576003196040368201126102cc576004356108db816102bb565b6024359067ffffffffffffffff928383116102cc5760e09083360301126102cc5761090461076e565b90610911836004016107cd565b82526024830135602083015260448301358481116102cc5761093990600436918601016107f0565b6040830152606483013560608301526084830135608083015261095e60a484016102e0565b60a083015260c48301359384116102cc5761098561098f93600461054b96369201016108a2565b60c08301526121de565b6040519081529081906020820190565b346102cc5760203660031901126102cc576004356109bc816102bb565b6109c46129a5565b6109cd81612a18565b610a01602060806109dd84612a4c565b015160405180938192631309bd3d60e31b8352604060048401526044830190610437565b6001602483015203816001600160a01b0386165afa8015610a835761054b9261098f925f92610a4e575b50610a47906001600160a01b03165f52601160205260405f2090565b5490612e00565b610a47919250610a759060203d602011610a7c575b610a6d818361074c565b8101906122bf565b9190610a2b565b503d610a63565b6122eb565b346102cc5760203660031901126102cc576001600160a01b03600435610aad816102bb565b610ab56129a5565b610abe816129e6565b165f525f6020526020600160405f2054811c166040519015158152f35b906020610310928181520190610437565b346102cc5760203660031901126102cc5761054b6080610b22600435610b11816102bb565b610b196129a5565b6104a7816129e6565b0151604051918291602083526020830190610437565b9081518082526020808093019301915f5b828110610b57575050505090565b83516001600160a01b031685529381019392810192600101610b49565b9290610b8c9095949295608085526080850190610b38565b6020908481036020860152602080885192838152019701915f5b828110610bd5575050505084610bc791846103109697036040860152610437565b916060818403910152610437565b9091929782610be76001928b516103c8565b990193929101610ba6565b346102cc5760203660031901126102cc57600435610c0f816102bb565b610c176129a5565b610c20816129e6565b6001600160a01b0381165f52600560205260405f20610c58610c53836001600160a01b03165f52600360205260405f2090565b6122f6565b90815192610c658461236b565b93610c6f816123ba565b91610c79826123ba565b935f5b838110610c94576040518061054b88888c8c85610b74565b80610ca960019284905f5260205260405f2090565b54610d00610cfb8a610ce6610cd986610cd38b6001600160a01b03165f52600460205260405f2090565b93612400565b516001600160a01b031690565b6001600160a01b03165f5260205260405f2090565b612425565b610d0a838c612400565b52610d15828b612400565b506001600160801b038116610d2a8389612400565b5260801c610d388289612400565b5201610c7c565b346102cc5760203660031901126102cc576020600435610d5e816102bb565b610d666129a5565b6001600160a01b038091165f52600e825260405f2054161515604051908152f35b346102cc5760203660031901126102cc576020610dbf600435610da9816102bb565b610db16129a5565b610dba816129e6565b612c5a565b506040519015158152f35b9181601f840112156102cc5782359167ffffffffffffffff83116102cc57602083818601950101116102cc57565b60206003198201126102cc576004359067ffffffffffffffff82116102cc57610e2391600401610dca565b9091565b346102cc575f80610e3736610df8565b90610e40612e24565b610e486129a5565b8160405192839283378101838152039082335af1610e64612464565b908015610e985790610e7a81610e949333612e86565b50604051630b56c9f760e31b815291829160048301611d80565b0390fd5b506004815110610ee55760208101517fffffffff00000000000000000000000000000000000000000000000000000000166314a9360960e31b01612e77576328f9554160e01b5f5260045ffd5b63a728568960e01b5f5260045ffd5b9091610f0b61031093604084526040840190610437565b916020818403910152610437565b346102cc5760203660031901126102cc57600435610f36816102bb565b610f3e6129a5565b610f47816129e6565b6001600160a01b038082165f525f60205260405f2054600360205260405f209160405180938491602082549182815201915f5260205f20935f905b82821061101157505050610f989250038361074c565b610fa482518092612ee0565b91610fae826123ba565b935f5b838110610fc7576040518061054b888883610ef4565b600190611000610ffb610cfb610fee866001600160a01b03165f52600460205260405f2090565b610ce6610cd9868a612400565b612f32565b61100a8289612400565b5201610fb1565b85546001600160a01b0390821616845260019586019588955060209094019390910190610f82565b346102cc575f3660031901126102cc576110516129a5565b60207f00000000000000000000000000000000000000000000000000000000000000005c6040519015158152f35b346102cc5760206001600160801b036110d66001600160a01b036110a2366102eb565b91906110ac6129a5565b6110b5816129e6565b165f526006845260405f20906001600160a01b03165f5260205260405f2090565b5416604051908152f35b346102cc575f3660031901126102cc576110f86129a5565b60206001600160a01b03600a5416604051908152f35b346102cc5760603660031901126102cc576020611156600435611130816102bb565b60243561113c816102bb565b60443591611149836102bb565b6111516129a5565b612fdd565b604051908152f35b346102cc5760203660031901126102cc576001600160a01b03600435611183816102bb565b61118b6129a5565b165f526008602052602060405f2054604051908152f35b346102cc5760203660031901126102cc5760206111566004356111c4816102bb565b6111cc6129a5565b7f0000000000000000000000000000000000000000000000000000000000000000906001600160a01b03165f5260205260405f205c90565b346102cc5760803660031901126102cc57600435611221816102bb565b60243561122d816102bb565b6044359060643567ffffffffffffffff81116102cc576112519036906004016107f0565b6112596129a5565b61126161303f565b611269613077565b61127284612a18565b6001600160a01b039384811691825f526020905f60205261129b60405f205460019060031c1690565b15611671576112bb836001600160a01b03165f52600560205260405f2090565b966112c4612493565b926112e3610c53866001600160a01b03165f52600360205260405f2090565b80855251966112f86040860198808a526123ba565b97608086019889525f5b815181101561134257806113306113236001938f905f5260205260405f2090565b546001600160801b031690565b61133b828d51612400565b5201611302565b5089989697986113708189516113698c6001600160a01b03165f52601160205260405f2090565b54906130d8565b9961137b83516123ba565b95606089019687526113e28b7f00000000000000000000000000000000000000000000000000000000000000005c7f0000000000000000000000000000000000000000000000000000000000000000905f5260205260405f20905f5260205260405f205c90565b151560a08a018181529590611644575b5f5b85518110156115295761141e818f8a8e838e6114108e51151590565b6114d9575b50505050612400565b51611429828c612400565b511161148957808c8f8261147c8f8261148294611463611452610cd960019b6114689651612400565b61145c8484612400565b5190613149565b612400565b519351936114768386612400565b516124e7565b92612400565b52016113f4565b8d8a6114b2836114ab8f956114a5610cd9826114d69951612400565b95612400565b5192612400565b516317bc2f2360e11b5f526001600160a01b03909216600452602452604452606490565b5ffd5b6114f861150a93611515956114ee8589612400565b5191015190613127565b611503838351612400565b5251612400565b516114768484612400565b61151f8383612400565b528a8e838e611415565b508a95509187918d938d61154e816001600160a01b03165f52600560205260405f2090565b965f5b895181101561159f57806115868c61157f836115776001968f905f5260205260405f2090565b549251612400565b519061316b565b611598828c905f5260205260405f2090565b5501611551565b61054b885f89897ffbe5b0d79fb94f1e81c0a92bf86ae9d3a19e9d1bf6202c0d3e75120f65d5d8a58a8a61161d61160b8c6115f48d6115e081338886613179565b6115e86131dc565b611634575b8583613241565b6001600160a01b03165f52601160205260405f2090565b549551886040519485941697846124f4565b0390a46116286130b3565b60405191829182610adb565b61163f8187856131fe565b6115ed565b6116676116618d6001600160a01b03165f525f60205260405f2090565b54612d01565b60208b01526113f2565b8363ef029adf60e01b5f5260045260245ffd5b346102cc575f3660031901126102cc5761169c6129a5565b60206001600160a01b0360095460081c16604051908152f35b346102cc5760203660031901126102cc57602061173a6004356116d7816102bb565b6116df6129a5565b7f00000000000000000000000000000000000000000000000000000000000000005c7f0000000000000000000000000000000000000000000000000000000000000000905f5260205260405f20905f5260205260405f205c90565b6040519015158152f35b346102cc5760203660031901126102cc576001600160a01b03600435611769816102bb565b6117716129a5565b61177a816129e6565b165f525f602052602061115660405f2054612d01565b346102cc575f3660031901126102cc576117a86129a5565b60206001600754166040519015158152f35b346102cc5760c03660031901126102cc576004356117d7816102bb565b602435906117e4826102bb565b6044359167ffffffffffffffff918284116102cc57366023850112156102cc578360040135611812816107d8565b94611820604051968761074c565b8186526020916024602088019160051b830101913683116102cc57602401905b82821061188c57505050506064358381116102cc576118639036906004016107f0565b60a4359384116102cc5761054b9461188261098f9536906004016108a2565b936084359361251f565b838091833561189a816102bb565b815201910190611840565b346102cc5760203660031901126102cc576001600160a01b036004356118ca816102bb565b6118d26129a5565b6118db816129e6565b165f525f6020526020600160405f205460031c166040519015158152f35b346102cc5760203660031901126102cc576001600160a01b0360043561191e816102bb565b6119266129a5565b165f525f6020526020600160405f2054166040519015158152f35b346102cc5760403660031901126102cc5760243567ffffffffffffffff81116102cc57611972903690600401610dca565b61197a6129a5565b611983336129e6565b80604051926020845281602085015260408401375f604082840101527f4bc4412e210115456903c65b5277d299a505e79f2eb852b92b1ca52d85856428600435926040813394601f80199101168101030190a3005b906020610310928181520190610b38565b346102cc5760203660031901126102cc57600435611a06816102bb565b611a0e6129a5565b611a17816129e6565b6001600160a01b038091165f52600360205260405f20906040519081602084549182815201935f5260205f20915f905b828210611a6a5761054b85611a5e8189038261074c565b604051918291826119d8565b909192946001611a8c819284895416906001600160a01b036020921681520190565b960193920190611a47565b80511515825260208082015115159083015260408082015115159083015260608082015115159083015260808082015115159083015260a08082015115159083015260c08082015115159083015260e0808201511515908301526101008082015115159083015261012080820151151590830152610140908101516001600160a01b0316910152565b346102cc5760203660031901126102cc57610160611b85600435611b43816102bb565b611b4b6126ad565b50611b546129a5565b611b5d816129e6565b6001600160a01b038091165f525f60205260405f205490600260205260405f205416906138c1565b611b926040518092611a97565bf35b346102cc575f3660031901126102cc5760207f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c6040519015158152f35b346102cc575f3660031901126102cc57611bea6129a5565b60207f00000000000000000000000000000000000000000000000000000000000000005c604051908152f35b346102cc5760603660031901126102cc57611c54600435611c36816102bb565b602435611c42816102bb565b611c4a6129a5565b60443591336139ff565b602060405160018152f35b346102cc5760203660031901126102cc576001600160a01b03600435611c84816102bb565b611c8c6129a5565b165f526011602052602060405f2054604051908152f35b6102de909291926060810193604090816001600160a01b0391828151168552826020820151166020860152015116910152565b346102cc5760203660031901126102cc5761054b600435611cf6816102bb565b611cfe61234d565b50611d076129a5565b611d10816129e6565b6001600160a01b038091165f52600160205260405f2090600260405192611d36846106c2565b828154168452826001820154166020850152015416604082015260405191829182611ca3565b805180835260209291819084018484015e5f828201840152601f01601f1916010190565b906020610310928181520190611d5c565b346102cc5761054b611dda5f80611dc1611daa36610df8565b611db2612e24565b611dba6129a5565b369161086c565b60208151910182335af1611dd3612464565b9033612e86565b604051918291602083526020830190611d5c565b801515036102cc57565b608435906102de82611dee565b6064359063ffffffff821682036102cc57565b60609060a31901126102cc5760a490565b6080906101231901126102cc5761012490565b346102cc576101a03660031901126102cc57600435611e5a816102bb565b60243567ffffffffffffffff81116102cc57366023820112156102cc57806004013591611e86836107d8565b91604093611e97604051948561074c565b8084526020906024602086019160071b840101923684116102cc57602401905b838210611efb57611ef98686611ecb611e05565b611ed3611df8565b611edc36611e18565b91611ee56102d0565b93611eef36611e29565b9560443591612710565b005b6080823603126102cc57826080918851611f14816106e3565b8435611f1f816102bb565b815282850135611f2e816107c3565b8382015289850135611f3f816102bb565b8a82015260608086013590611f5382611dee565b820152815201910190611eb7565b6102de909291926101806101a0820194611fa28382516060809180511515845260208101511515602085015260408101511515604085015201511515910152565b60208101516080840152604081015160a0840152606081015160c0840152611fd8608082015160e085019064ffffffffff169052565b60a081015190611ff3610100928386019063ffffffff169052565b61202760c08201519261200d610120948588019015159052565b60e083015115156101408701528201511515610160860152565b01511515910152565b346102cc5760203660031901126102cc5761054b6120be600435612053816102bb565b5f610120604051612063816106ff565b60405161206f816106e3565b83815283602082015283604082015283606082015281528260208201528260408201528260608201528260808201528260a08201528260c08201528260e0820152826101008201520152612836565b60405191829182611f61565b346102cc5760403660031901126102cc57602061212a6004356120ec816102bb565b6001600160a01b0360243591612101836102bb565b6121096129a5565b165f52600f835260405f20906001600160a01b03165f5260205260405f2090565b54604051908152f35b346102cc575f3660031901126102cc5760206040516001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000168152f35b604051906121838261071c565b815f815260c060609182602082015282604082015282808201528260808201528260a08201520152565b634e487b7160e01b5f52601160045260245ffd5b91909163ffffffff808094169116019182116121d957565b6121ad565b612242916121ea6129a5565b6121f382612a18565b6001600160a01b039081831690815f525f6020526040938493612218855f2054612d01565b935f526002602052845f2054169184519687948593849363283a3d6b60e21b855260048501612d4e565b03915afa918215610a83575f915f9361228d575b50501561227e57670de0b5cad2bef000811161226f5790565b6301d1b96560e61b5f5260045ffd5b6314fe5db560e21b5f5260045ffd5b6122b0935080919250903d106122b8575b6122a8818361074c565b810190612d2f565b905f80612256565b503d61229e565b908160209103126102cc575190565b919060206122e6600192604086526040860190610437565b930152565b6040513d5f823e3d90fd5b90604051918281549182825260209260208301915f5260205f20935f905b82821061232a575050506102de9250038361074c565b85546001600160a01b031684526001958601958895509381019390910190612314565b6040519061235a826106c2565b5f6040838281528260208201520152565b90612375826107d8565b612382604051918261074c565b8281528092612393601f19916107d8565b01905f5b8281106123a357505050565b6020906123ae61234d565b82828501015201612397565b906123c4826107d8565b6123d1604051918261074c565b82815280926123e2601f19916107d8565b0190602036910137565b634e487b7160e01b5f52603260045260245ffd5b80518210156124145760209160051b010190565b6123ec565b612422826103aa565b52565b90604051612432816106c2565b604060ff829454818116612445816103aa565b84526001600160a01b038160081c16602085015260a81c161515910152565b3d1561248e573d9061247582610850565b91612483604051938461074c565b82523d5f602084013e565b606090565b6040519060c0820182811067ffffffffffffffff8211176106de576040525f60a08360608152826020820152826040820152606080820152606060808201520152565b620f423f198101919082116121d957565b919082039182116121d957565b916125119061031094928452606060208501526060840190610437565b916040818403910152610437565b939594919592909261252f6129a5565b61253761303f565b612540856129e6565b612548613077565b612551856133c7565b61255a85612a4c565b916125698351600190811c1690565b612691576125d296976125836020850151518351906133fc565b60c0840195865161259b60a087019182519086613412565b97896125ac885160019060081c1690565b612620575b89949250879150926125c49695936135c0565b94859151600190600a1c1690565b6125e3575b505050506103106130b3565b612611612604612617956001600160a01b03165f52600260205260405f2090565b546001600160a01b031690565b92613827565b5f8080836125d7565b9161268491612656899b8b6126506126046125c49c9b999a986001600160a01b03165f52600260205260405f2090565b916134b8565b61267a6126748d6001600160a01b03165f52600560205260405f2090565b8a61355c565b5190519084613412565b97819392949550896125b1565b63218e374760e01b5f526001600160a01b03861660045260245ffd5b60405190610160820182811067ffffffffffffffff8211176106de576040525f610140838281528260208201528260408201528260608201528260808201528260a08201528260c08201528260e082015282610100820152826101208201520152565b94969263ffffffff919694926127246129a5565b61272c613077565b612734613ae4565b604051976127418961071c565b88526020880152166040860152151560608501526060853603126102cc576127bd6127c4926127ce966040805191612778836106c2565b8035612783816102bb565b83526020810135612793816102bb565b602084015201356127a3816102bb565b604082015260808701526001600160a01b031660a0860152565b36906127d6565b60c0830152613ec4565b6102de6130b3565b91908260809103126102cc576040516127ee816106e3565b606080829480356127fe81611dee565b8452602081013561280e81611dee565b6020850152604081013561282181611dee565b604085015201359161283283611dee565b0152565b612861906128426129a5565b61284b816129e6565b6001600160a01b03165f525f60205260405f2090565b54610310600161287083612d01565b9261291961287d826146c8565b61290c612889846146eb565b64ffffffffff85605a1c169063ffffffff866128a3608290565b1c16936128ae61077b565b600488901c89161515815299600588901c8916151560208c0152600688901c8916151560408c0152600788901c8916151560608c01526128ec610788565b9a8b5260208b015260408a0152606089015264ffffffffff166080880152565b63ffffffff1660a0860152565b808216151560c085015280821c8216151560e0850152600281901c8216151561010085015260031c161515610120830152565b637911c44b60e11b5f5260045ffd5b3461294c57365f80375f8036816001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000165af43d5f803e156129a1573d5ff35b3d5ffd5b6001600160a01b037f00000000000000000000000000000000000000000000000000000000000000001630036129d757565b634fe92d9b60e11b5f5260045ffd5b6001600160a01b0316805f525f602052600160405f20541615612a065750565b6327946f5760e21b5f5260045260245ffd5b6001600160a01b0316805f525f602052600160405f2054811c1615612a3a5750565b634bdace1360e01b5f5260045260245ffd5b906001600160a01b03612a5d612176565b92165f5260056020526040805f205f602052815f2054906004602052825f20906003602052835f20938454938752612a98602088019561470e565b8552612aa38461236b565b91818801928352612ab3856123ba565b9160608901928352612ac4866123ba565b9460809560808b0152612ad8878b51612ee0565b60c08b0152612ae6876123ba565b60a08b019081528a5191600199600184811c169384612c46575b5083612c34575b8c5f5b8b8110612b205750505050505050505050505050565b8a8d92828c8c8c612b6784612b5381612b45610cfb8f8f610cd985610ce69251612400565b94905f5260205260405f2090565b54945183612b618383612400565b52612400565b50612b7181612f32565b612b7c858d51612400565b52612b916001600160801b03841685876148ea565b878d8d15612c275782015115159182612c09575b5050612bba575b50505050505b018d90612b0a565b82612bdd92612bd482612bcd88516146eb565b9451612400565b51961c85614d75565b9283612bed575b8e93508c612bac565b612c0093612bfa916124e7565b916148ea565b5f8f8282612be4565b90915051612c16816103aa565b612c1f816103aa565b14875f612ba5565b5050505050505050612bb2565b8c5190935060031c6001161592612b07565b612c519194506146eb565b1515925f612b00565b6001600160a01b03165f525f60205260405f20549060018260021c1663ffffffff8093612c85608290565b1c169281612c9257509190565b9050612cbe7f0000000000000000000000000000000000000000000000000000000000000000846121c1565b164211159190565b60ff60019116019060ff82116121d957565b906005820291808304600514901517156121d957565b818102929181159184041417156121d957565b62ffffff9060121c1664174876e800908181029181830414901517156121d95790565b51906102de82611dee565b91908260409103126102cc5760208251612d4881611dee565b92015190565b612832612dd060409396959496606084528051612d6a816103aa565b60608501526020810151608085015260c0612d948683015160e060a0880152610140870190610437565b606083015186830152608083015160e087015260a08301516001600160a01b0316610100870152910151848203605f1901610120860152611d5c565b6001600160a01b039096166020830152565b8115612dec570490565b634e487b7160e01b5f52601260045260245ffd5b90670de0b6b3a7640000918281029281840414901517156121d95761031091612de2565b32612e6857600160075416612e595760017f00000000000000000000000000000000000000000000000000000000000000005d565b633d0cc44360e11b5f5260045ffd5b6333fc255960e11b5f5260045ffd5b805115610ee557805190602001fd5b90612eaa5750805115612e9b57805190602001fd5b630a12f52160e11b5f5260045ffd5b81511580612ed7575b612ebb575090565b6001600160a01b0390639996b31560e01b5f521660045260245ffd5b50803b15612eb3565b9064ffffffffff612ef0826123ba565b92605a1c165f5b828110612f045750505090565b601f82612f1083612cd8565b1c1690604d82116121d957600191600a0a612f2b8287612400565b5201612ef7565b8051612f3d816103aa565b612f46816103aa565b80612f59575050670de0b6b3a764000090565b80612f656001926103aa565b03612fce576020612f90612f848260049401516001600160a01b031690565b6001600160a01b031690565b6040516333cd77e760e11b815292839182905afa908115610a83575f91612fb5575090565b610310915060203d602011610a7c57610a6d818361074c565b636fa2831960e11b5f5260045ffd5b6001600160a01b03929183811684841603612ffb57505050505f1990565b61303b9361302592165f52601060205260405f20906001600160a01b03165f5260205260405f2090565b906001600160a01b03165f5260205260405f2090565b5490565b7f00000000000000000000000000000000000000000000000000000000000000005c1561306857565b63604dd39b60e11b5f5260045ffd5b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805c6130a4576001905d565b633ee5aeb560e01b5f5260045ffd5b5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005d565b92916130e484516123ba565b935f5b815181101561312157806131108561310b8661310560019688612400565b51612cee565b612de2565b61311a8289612400565b52016130e7565b50505050565b9061313191612cee565b6001670de0b6b3a76400005f19830104019015150290565b9061315390614765565b90600160ff1b82146121d9576102de915f03906147a1565b906103109160801c90614889565b9190939293613189828285612fdd565b6001810161319a575b505050509050565b8086116131b857946131ae949503926139ff565b805f808080613192565b85906001600160a01b0384637dc7a0d960e11b5f521660045260245260445260645ffd5b3215806131e65790565b506001600754161590565b919082018092116121d957565b9032612e68576001600160a01b0361323292165f52600f60205260405f20906001600160a01b03165f5260205260405f2090565b80549182018092116121d95755565b90916001600160a01b038084169283156133ab5761327485613025836001600160a01b03165f52600f60205260405f2090565b548084116133875783900361329e86613025846001600160a01b03165f52600f60205260405f2090565b556132c4836132be836001600160a01b03165f52601160205260405f2090565b546124e7565b6132cd816148cb565b6132e8826001600160a01b03165f52601160205260405f2090565b551690813b156102cc576040516323de665160e01b81526001600160a01b0390941660048501525f6024850181905260448501829052937fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f9161336991868180606481015b038183895af161336e575b506040519081529081906020820190565b0390a4565b8061337b61338192610738565b8061054f565b5f613358565b63391434e360e21b5f526001600160a01b038616600452602452604483905260645ffd5b634b637e8f60e11b5f526001600160a01b03851660045260245ffd5b6133cf613ae4565b6133d881612c5a565b506133e05750565b6001600160a01b039063d971f59760e01b5f521660045260245ffd5b0361340357565b63aaad13f760e01b5f5260045ffd5b91908251918151815181851491821592613498575b505061340357613436836123ba565b935f5b84811061344857505050505090565b80670de0b6b3a764000061348661346160019486612400565b5161348161346f858a612400565b5161347a868a612400565b5192612cee565b612cee565b046134918289612400565b5201613439565b141590505f80613427565b908160209103126102cc575161031081611dee565b90613503926134f15f6001600160a01b036020956040519788968795869363038293c560e31b8552604060048601526044850190610437565b83810360031901602485015290611d5c565b0393165af1908115610a83575f9161352d575b501561351e57565b636061292560e01b5f5260045ffd5b61354f915060203d602011613555575b613547818361074c565b8101906134a3565b5f613516565b503d61353d565b60208082015151925f5b848110613574575050505050565b6001906135ba6001600160801b03604061359a61359485838b0151612400565b51612f32565b6135a88560a08b0151612400565b52835f528587525f20541682876148ea565b01613566565b9291959694966135e1846001600160a01b03165f52600560205260405f2090565b955f5b602089015180518210156136bf57610cd9826135ff92612400565b61360f612f84610cd98489612400565b6001600160a01b03821690810361366b575090613639600192613632838b612400565b5190614937565b6136528b61364b836114ab818d612400565b5190614889565b613664828b905f5260205260405f2090565b55016135e4565b6114d69088613680612f84610cd9878c612400565b7fffe261a1000000000000000000000000000000000000000000000000000000005f526001600160a01b03918216600452811660245216604452606490565b505096949192509694506136d884516002908119161790565b8085526136f5846001600160a01b03165f525f60205260405f2090565b556001600160a01b039261372260208583169760405180938192631309bd3d60e31b8352600483016122ce565b03818a5afa8015610a8357613747915f91613808575b50613742816148cb565b6124d6565b9761375182614949565b61375c898584614a40565b8089106137f157509285926137c87fa26a52d8d53702bba7f137907b8e1f99ff87f6d450144270ca25e72481cca871936137b960206137af60019a996001600160a01b03165f52601160205260405f2090565b54980151516123ba565b906040519485941697846124f4565b0390a47fcad8c9d32507393b6508ca4a888b81979919b477510585bde8488f153072d6f35f80a2565b638d261d5d60e01b5f52600489905260245260445ffd5b613821915060203d602011610a7c57610a6d818361074c565b5f613738565b926138615f6001600160a01b036020959496613878604051988997889687946338be241d60e01b8652606060048701526064860190610437565b916024850152600319848303016044850152611d5c565b0393165af1908115610a83575f916138a2575b501561389357565b630791ede360e11b5f5260045ffd5b6138bb915060203d60201161355557613547818361074c565b5f61388b565b906138ca6126ad565b5060ff60018084836138dc600c612cc6565b6138e590612cc6565b161c168185846138f5600c612cc6565b6138fe90612cc6565b61390790612cc6565b161c1690828685613918600c612cc6565b61392190612cc6565b61392a90612cc6565b61393390612cc6565b161c1692808786613944600c612cc6565b61394d90612cc6565b61395690612cc6565b61395f90612cc6565b61396890612cc6565b161c16948188818184600c161c1692600c61398290612cc6565b161c169161398e610795565b60098a901c82161515815298600881901c8216151560208b0152600a81901c8216151560408b0152600b1c161515606089015215156080880152151560a0870152151560c0860152151560e0850152151561010084015215156101208301526001600160a01b031661014082015290565b9290916001600160a01b0392838116938415613ac857808316958615613aac5784613a438561302586613025866001600160a01b03165f52601060205260405f2090565b551692833b156102cc57604051630ad0fe5760e31b81526001600160a01b039283166004820152919092166024820152604481018290527fa0175360a15bca328baf7ea85c7b784d58b222a50d0ce760b10dba336d226a6191613369915f81806064810161334d565b634a1406b160e11b5f526001600160a01b03841660045260245ffd5b63e602df0560e01b5f526001600160a01b03821660045260245ffd5b63ffffffff7f00000000000000000000000000000000000000000000000000000000000000001642111580613b29575b613b1a57565b6336a7e2cd60e21b5f5260045ffd5b506001600754811c16613b14565b90805190613b44826103aa565b613b4d826103aa565b8254602082015160409092015175ffffffffffffffffffffffffffffffffffffffffffff1990911660ff939093169290921760089190911b74ffffffffffffffffffffffffffffffffffffffff00161790151560a81b60ff60a81b16179055565b908160209103126102cc575160ff811681036102cc5790565b8054680100000000000000008110156106de5760018101808355811015612414576001600160a01b03915f5260205f200191166001600160a01b0319825416179055565b8151815473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b039182161782556102de9260029190604090613c688360208301511660018701906001600160a01b03166001600160a01b0319825416179055565b0151169101906001600160a01b03166001600160a01b0319825416179055565b91908260409103126102cc576020825192015190565b9081518082526020808093019301915f5b828110613cbd575050505090565b9091929382608060019287516001600160a01b0380825116835284820151613ce4816103aa565b838601526040828101519091169083015260609081015115159082015201950193929101613caf565b9493916102de93606092613d3f926001600160a01b03809216895216602088015260e0604088015260e0870190613c9e565b9401906060809180511515845260208101511515602085015260408101511515604085015201511515910152565b90816101409103126102cc57613d81610788565b90613d8b81612d24565b8252613d9960208201612d24565b6020830152613daa60408201612d24565b6040830152613dbb60608201612d24565b6060830152613dcc60808201612d24565b6080830152613ddd60a08201612d24565b60a0830152613dee60c08201612d24565b60c0830152613dff60e08201612d24565b60e0830152610100613e12818301612d24565b90830152613e24610120809201612d24565b9082015290565b9196959394613e8d6102de9663ffffffff61022096613e55613e97966102a0808a52890190613c9e565b9b60208801521660408601526060850190604090816001600160a01b0391828151168552826020820151166020860152015116910152565b60c0830190611a97565b01906060809180511515845260208101511515602085015260408101511515604085015201511515910152565b90613ee9613ee2836001600160a01b03165f525f60205260405f2090565b5460011690565b6146ac578051516002811061469d576008811161468e57929190613f0c846123ba565b5f945f5b818110614417575050613fc3929394506080820191613f4a8351613f45876001600160a01b03165f52600160205260405f2090565b613c0b565b613f5f612f84600a546001600160a01b031690565b60408091613f78828751016001600160a01b0390511690565b90613f866060860151151590565b83516377ff76e760e01b81526001600160a01b03808c166004830152909316602484015215156044830152909687919082905f9082906064820190565b03925af18015610a83575f955f916143e4575b5061409260c084019161408d61405c84519761404561403f613ffe8b51151560041b60011790565b9a606061402e61401c60209e8f850151151560051b90602019161790565b8c840151151560061b90604019161790565b910151151560071b90608019161790565b91614b5c565b90605a9164ffffffffff908116831b921b19161790565b986140888688019a6140728c5163ffffffff1690565b9060829163ffffffff908116831b921b19161790565b614bfa565b614c1a565b9360a08401906001600160a01b039589876140b485516001600160a01b031690565b168061419d575b50906140d98193926001600160a01b03165f525f60205260405f2090565b5582516001600160a01b03166001600160a01b03166141098b6001600160a01b03165f52600260205260405f2090565b9061412991906001600160a01b03166001600160a01b0319825416179055565b8501948551614138908b614c3e565b519451975163ffffffff16965191516001600160a01b03166001600160a01b0316614162916138c1565b91519251958695339916976141779587613e2b565b037fbc1561eeab9f40962e2fb827a7ff9c7cdb47a9d7c84caeefa4ed90e043842dad91a3565b6141c691849189515f8951938b51968795869485936305c4f8c160e11b85523360048601613d0d565b03925af1908115610a83575f916143c7575b50156143b2576141f5612f84612f8485516001600160a01b031690565b908551809263d77153a760e01b82528160046101409586935afa928315610a83575f93614383575b50508151151580614369575b61432f579061431a6101206142756143046142f06142dc6142c86142b46142a08e61429361428a8c8f6143289f9061427561427d926142688551151590565b60091b9061020019161790565b920151151590565b60081b9061010019161790565b918c0151151590565b600a1b9061040019161790565b60608a01511515600b1b9061080019161790565b60808901511515600c1b9061100019161790565b60a08801511515600d1b9061200019161790565b60c08701511515600e1b9061400019161790565b60e08601511515600f1b9061800019161790565b610100850151151560101b906201000019161790565b60111b906202000019161790565b895f6140bb565b6114d68b61434486516001600160a01b031690565b633ea4f60560e21b5f526001600160a01b039081166004521660245233604452606490565b5061437d614378865151151590565b151590565b15614229565b6143a3929350803d106143ab575b61439b818361074c565b810190613d6d565b905f8061421d565b503d614391565b6114d68a61434485516001600160a01b031690565b6143de9150833d851161355557613547818361074c565b5f6141d8565b9050816144079296503d8711614410575b6143ff818361074c565b810190613c88565b9490945f613fd6565b503d6143f5565b614422818551612400565b519661443588516001600160a01b031690565b906001600160a01b038083169182158015614683575b614674571680821061466557811461464957604090818a01998a51614476906001600160a01b031690565b6001600160a01b0316159060209b8c8201908d825191614495836103aa565b516001600160a01b0316936060019384516144af90151590565b916144b86107b6565b936144c39085612419565b6001600160a01b0390911690830152151581870152866144f48d6001600160a01b03165f52600460205260405f2090565b9061450f91906001600160a01b03165f5260205260405f2090565b9061451991613b37565b8051614524816103aa565b61452d816103aa565b6146135750811591614608575b50612fce5789915b51998a809263313ce56760e01b825260049c8d915afa918215610a83575f926145db575b505060129060ff9180838316115f14614587578a63686d360760e01b5f525ffd5b60019495969798999a50906145ab929103166145a38588612400565b9060ff169052565b6145cf816145ca896001600160a01b03165f52600360205260405f2090565b613bc7565b96959493929101613f10565b6145fa9250803d10614601575b6145f2818361074c565b810190613bae565b5f80614566565b503d6145e8565b51151590505f61453a565b6001915051614621816103aa565b61462a816103aa565b0361463a57612fce578991614542565b63a1e9dd9d60e01b5f5260045ffd5b6327a5b1a760e11b5f526001600160a01b03821660045260245ffd5b636e8f194760e01b5f5260045ffd5b63c1ab6dc160e01b5f5260045ffd5b50818916831461444b565b630e0f7beb60e31b5f5260045ffd5b635ed4ba8f60e01b5f5260045ffd5b6301b6ee3960e71b5f526001600160a01b03821660045260245ffd5b62ffffff90602a1c1664174876e800908181029181830414901517156121d95790565b62ffffff9060421c1664174876e800908181029181830414901517156121d95790565b90604051918281549182825260209260208301915f5260205f20935f905b828210614742575050506102de9250038361074c565b85546001600160a01b03168452600195860195889550938101939091019061472c565b7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff811161478f5790565b63123baf0360e11b5f5260045260245ffd5b908015614885577f0000000000000000000000000000000000000000000000000000000000000000916147e68184906001600160a01b03165f5260205260405f205c90565b8281019283125f82129080158216911516176121d9578261483b57507f000000000000000000000000000000000000000000000000000000000000000092835c5f1981019081116121d9576102de945d614de3565b1561484a575b6102de92614de3565b7f000000000000000000000000000000000000000000000000000000000000000092835c600181018091116121d9576102de945d9250614841565b5050565b906001600160801b038083119081156148c1575b506148b25760801b9081018091116121d95790565b6389560ca160e01b5f5260045ffd5b905081115f61489d565b620f424081106148d85750565b6334e3483f60e21b5f5260045260245ffd5b91906080670de0b6b3a764000061492e612422948061490d8660608a0151612400565b5261348161491f8660c08a0151612400565b5161347a8760a08b0151612400565b04930151612400565b6149436102de92614765565b906147a1565b614964816001600160a01b03165f52601160205260405f2090565b908154620f4240908181018091116121d9576001600160a01b03935561499b826001600160a01b03165f52600f60205260405f2090565b5f805260205260405f20908154019055165f80827fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f604051806149e58190620f4240602083019252565b0390a4803b156102cc575f60405180926323de665160e01b8252818381614a226004820190620f4240604060608401935f81525f60208201520152565b03925af18015610a8357614a335750565b8061337b6102de92610738565b916001600160a01b03808316938415614b4057614a7883614a72836001600160a01b03165f52601160205260405f2090565b546131f1565b614a9785613025846001600160a01b03165f52600f60205260405f2090565b848154019055614aa6816148cb565b614ac1826001600160a01b03165f52601160205260405f2090565b5516925f847fd1398bee19313d6bf672ccb116e51f4a1a947e91c757907f51fbb5b5e56c698f60405180614afa87829190602083019252565b0390a4823b156102cc576040516323de665160e01b81525f600482018190526001600160a01b039093166024820152604481019190915291829081838160648101614a22565b63ec442f0560e01b5f526001600160a01b03841660045260245ffd5b5f9190825b8151841015614bee57614b748483612400565b5160ff91614b8186612cd8565b9161010080841015614bda578381039081116121d95780851015614be95750835b6005908111614bda57816007911c16614bcb57600193601f9116831b921b191617930192614b61565b63e4337c0560e01b5f5260045ffd5b632d0483c560e21b5f5260045ffd5b614ba2565b64ffffffffff16925050565b670de0b5cad2bef000821161226f5764174876e800610310920490614df9565b90670de0b5cad2bef000811161226f576103109164174876e8006042920490614e13565b60405163ce20ece760e01b81526001600160a01b0382169291906020908181600481885afa908115610a83575f91614d58575b508310614d495760405163654cf15d60e01b81528181600481885afa918215610a83575f92614d2c575b50508211614d1d578181614d07614cf07f89d41522342fabac1471ca6073a5623e5caf367b03ca6e9a001478d0cf8be4a195614cea614d18966001600160a01b03165f525f60205260405f2090565b54614e5a565b916001600160a01b03165f525f60205260405f2090565b556040519081529081906020820190565b0390a2565b637f47834b60e01b5f5260045ffd5b614d429250803d10610a7c57610a6d818361074c565b5f80614c9b565b6317f640d160e31b5f5260045ffd5b614d6f9150823d8411610a7c57610a6d818361074c565b5f614c71565b9093925f94614d88846080850151612400565b51818111614d98575b5050505050565b614dd8959650614dd29392614dcb92614db19203613127565b9360a0614dc28260c0860151612400565b51930151612400565b5190612cee565b90612e00565b905f80808080614d91565b906001600160a01b03165f5260205260405f205d565b908060181c614bcb57602a1b9062ffffff602a1b19161790565b9061010080841015614bda578381039081116121d9578060ff105f14614e55575060ff5b601811614bda578060181c614bcb5762ffffff90831b921b19161790565b614e37565b90670de0b5cad2bef000811161226f5764174876e80090048060181c614bcb5760121b906503fffffc00001916179056fea2646970667358221220a6e17b54ff4f02ab7e39ccab30a68ff505d38f245ca4321ba25b9c826b1d672764736f6c634300081a0033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/packages/protocols/beets/abis.json
+++ b/packages/protocols/beets/abis.json
@@ -1,0 +1,18 @@
+{
+  "router": {
+    "address": "0x9dA18982a33FD0c7051B19F0d7C76F2d5E7e017c",
+    "allowedExplorerOnly": []
+  },
+  "vault": {
+    "address": "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+    "allowedExplorerOnly": []
+  },
+  "vaultExtension": {
+    "address": "0x0E8B07657D719B86e06bF0806D6729e3D528C9A9",
+    "allowedExplorerOnly": []
+  },
+  "vaultExplorer": {
+    "address": "0x043A2daD730d585C44FB79D2614F295D2d625412",
+    "allowedExplorerOnly": []
+  }
+}

--- a/packages/protocols/beets/package.json
+++ b/packages/protocols/beets/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@themoss/protocol-beets",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Moss protocol adapter for Beets — Balancer V3 DEX on Monad mainnet",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:abi:online": "vitest run --config vitest.online.config.ts",
+    "update:abis": "tsx scripts/update-abis.ts",
+    "gen:abis": "tsx scripts/gen-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "@themoss/system": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/abi-tools": "workspace:*",
+    "@themoss/simulator": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/beets/scripts/abis.ts
+++ b/packages/protocols/beets/scripts/abis.ts
@@ -1,0 +1,76 @@
+/**
+ * The DETERMINISTIC half of the ABI pipeline: derive src/abis/beets.ts purely
+ * from the committed abis-src/ files + VENDOR.json metadata. No network, no
+ * clock — same inputs, same bytes. This is what makes the provenance chain
+ * enforceable: test/abis.test.ts asserts generate() === the committed file,
+ * so hand-edits to the generated TS, generator edits without regeneration,
+ * and abis-src edits without regeneration all fail the suite.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface SourceSpec {
+  file: string;
+  exportName: string;
+}
+
+/** Full upstream ABIs are exported (ADR 0007) — the adapter's callable surface
+ * is reviewed where Capabilities and Receipt parsers live, and simulation is
+ * the enforcement layer. */
+export const SOURCES: SourceSpec[] = [
+  { file: "Router.json", exportName: "BeetsRouterAbi" },
+  { file: "Vault.json", exportName: "BeetsVaultAbi" },
+  { file: "VaultExtension.json", exportName: "BeetsVaultExtensionAbi" },
+  { file: "VaultExplorer.json", exportName: "BeetsVaultExplorerAbi" },
+];
+
+export interface VendorInfo {
+  name: string;
+  branch: string;
+  commit: string;
+  fileSha256: Record<string, string>;
+  vendoredAt: string;
+}
+
+interface AbiEntry {
+  type: string;
+  name?: string;
+}
+
+export function generate(packageRoot: string): string {
+  const vendor = JSON.parse(
+    readFileSync(join(packageRoot, "abis-src", "VENDOR.json"), "utf8"),
+  ) as VendorInfo;
+
+  const fileDigests = SOURCES.map(
+    (source) => `//   ${source.file}: sha256 ${vendor.fileSha256[source.file]}`,
+  ).join("\n");
+
+  let generated = `// GENERATED FILE — do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis [commit|latest]
+// ABI origin: vendored (ADR 0007)
+//   source:   ${vendor.name}@${vendor.branch} ${vendor.commit} (GitHub) — hardhat artifacts
+//             copied verbatim into ../../abis-src/, no hand-edits
+${fileDigests}
+//   vendored: ${vendor.vendoredAt}
+//   verification: swap/add/remove surfaces exercised live on Monad mainnet via
+//   rpc.monad.xyz (the adapter's e2e tests pin observable behavior). The Router
+//   and Vault ABIs are additionally cross-checked against explorer-verified
+//   implementations by \`pnpm test:abi:online\` (see abis.json).
+`;
+
+  for (const source of SOURCES) {
+    const raw = readFileSync(join(packageRoot, "abis-src", source.file), "utf8");
+    const artifact = JSON.parse(raw) as AbiEntry[] | { abi: AbiEntry[] };
+    // balancer-deployments ships hardhat artifacts ({ contractName, abi, bytecode, … });
+    // tolerate bare ABI arrays too.
+    const abi = Array.isArray(artifact) ? artifact : artifact.abi;
+    if (!Array.isArray(abi)) {
+      throw new Error(`${source.file}: could not locate an ABI array in the upstream file`);
+    }
+    generated += `\nexport const ${source.exportName} = ${JSON.stringify(abi, null, 2)} as const;\n`;
+  }
+
+  return generated;
+}

--- a/packages/protocols/beets/scripts/gen-abis.ts
+++ b/packages/protocols/beets/scripts/gen-abis.ts
@@ -1,0 +1,13 @@
+/**
+ * Offline regeneration: derive src/abis/beets.ts from the COMMITTED abis-src/
+ * files. Use after changing the deterministic generator in ./abis.ts — no network involved.
+ * test/abis.test.ts enforces that the committed output matches this exactly.
+ */
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate } from "./abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+writeFileSync(join(packageRoot, "src/abis/beets.ts"), generate(packageRoot));
+console.log("regenerated src/abis/beets.ts from abis-src/ (offline)");

--- a/packages/protocols/beets/scripts/update-abis.ts
+++ b/packages/protocols/beets/scripts/update-abis.ts
@@ -1,0 +1,116 @@
+/**
+ * The NETWORK half of the ABI pipeline: re-vendor upstream files into
+ * abis-src/ (verbatim, with SHA-256 provenance in VENDOR.json), then derive
+ * src/abis/beets.ts via the deterministic generator in ./abis.ts.
+ *
+ * Upstream is the balancer/balancer-deployments repository — the canonical
+ * source of deployment artifacts for Balancer v3 — pinned to an exact commit,
+ * never a moving branch. Default runs re-vendor at the currently pinned commit
+ * (byte-identical output); reviewers move the pin deliberately and review the
+ * abis-src diff.
+ *
+ * Usage: pnpm update:abis [commit|latest]
+ *   (no arg)   re-vendor at the currently pinned commit (VENDOR.json)
+ *   <commit>   re-vendor at an explicit 40-hex commit
+ *   latest     resolve the upstream default branch HEAD and vendor at it
+ */
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate, SOURCES, type VendorInfo } from "./abis.js";
+
+const REPO = "balancer/balancer-deployments";
+const BRANCH = "master";
+const TASK_BY_FILE: Record<string, string> = {
+  "Router.json": "20250307-v3-router-v2",
+  "Vault.json": "20241204-v3-vault",
+  "VaultExtension.json": "20241204-v3-vault",
+  "VaultExplorer.json": "20250407-v3-vault-explorer-v2",
+};
+const FETCH_RETRIES = 3;
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function fetchText(url: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= FETCH_RETRIES; attempt += 1) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+      if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      return await response.text();
+    } catch (error) {
+      lastError = error;
+      if (attempt < FETCH_RETRIES)
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+    }
+  }
+  throw new Error(`${url}: failed after ${FETCH_RETRIES} attempts — ${String(lastError)}`);
+}
+
+async function commitSha(requested: string): Promise<string> {
+  if (/^[0-9a-f]{40}$/.test(requested)) return requested;
+  if (requested === "latest") {
+    const payload = JSON.parse(
+      await fetchText(`https://api.github.com/repos/${REPO}/commits/${BRANCH}`),
+    ) as { sha: string };
+    const sha = String(payload.sha);
+    console.log(`resolved upstream ${REPO}@${BRANCH} → ${sha}`);
+    return sha;
+  }
+  throw new Error(`invalid commit argument (expected 40-hex SHA or "latest"): ${requested}`);
+}
+
+async function main(): Promise<void> {
+  const current = JSON.parse(
+    readFileSync(join(packageRoot, "abis-src", "VENDOR.json"), "utf8"),
+  ) as VendorInfo;
+  const prevCommit = current.commit;
+  const commit = await commitSha(process.argv[2] ?? prevCommit);
+
+  const fileSha256: Record<string, string> = {};
+  mkdirSync(join(packageRoot, "abis-src"), { recursive: true });
+  for (const source of SOURCES) {
+    const task = TASK_BY_FILE[source.file];
+    if (!task) throw new Error(`no deploy task known for ${source.file}`);
+    const url = `https://raw.githubusercontent.com/${REPO}/${commit}/v3/tasks/${task}/artifact/${source.file}`;
+    const raw = await fetchText(url);
+
+    // Refuse anything that does not parse as a hardhat artifact with an ABI:
+    // this keeps an accidental 404/HTML fetch from ever reaching abis-src/.
+    const artifact = JSON.parse(raw) as { abi?: unknown };
+    if (!Array.isArray(artifact.abi)) {
+      throw new Error(`${source.file}@${commit}: fetched content has no top-level ABI array`);
+    }
+    fileSha256[source.file] = createHash("sha256").update(raw).digest("hex");
+    writeFileSync(join(packageRoot, "abis-src", source.file), raw);
+  }
+
+  const vendor: VendorInfo = {
+    name: REPO,
+    branch: BRANCH,
+    commit,
+    fileSha256,
+    vendoredAt: new Date().toISOString().slice(0, 10),
+  };
+  writeFileSync(
+    join(packageRoot, "abis-src", "VENDOR.json"),
+    `${JSON.stringify(vendor, null, 2)}\n`,
+  );
+  writeFileSync(join(packageRoot, "src/abis/beets.ts"), generate(packageRoot));
+
+  const digests = SOURCES.map((s) => `${s.file}=${fileSha256[s.file]?.slice(0, 16)}…`).join(" ");
+  console.log(
+    `vendored ${SOURCES.length} files at ${commit} (${digests}) → abis-src/ + VENDOR.json + src/abis/beets.ts`,
+  );
+  if (commit !== prevCommit) {
+    console.log(
+      `pin moved ${prevCommit.slice(0, 8)} → ${commit.slice(0, 8)} — review the abis-src/ diff`,
+    );
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/protocols/beets/src/abis/beets.ts
+++ b/packages/protocols/beets/src/abis/beets.ts
@@ -1,0 +1,8080 @@
+// GENERATED FILE — do not edit by hand.
+//   regenerate offline from abis-src/:  pnpm gen:abis
+//   re-vendor from upstream:            pnpm update:abis [commit|latest]
+// ABI origin: vendored (ADR 0007)
+//   source:   balancer/balancer-deployments@master c1c3038a4fa214231af9099e4438998fccc30d59 (GitHub) — hardhat artifacts
+//             copied verbatim into ../../abis-src/, no hand-edits
+//   Router.json: sha256 cf269cf3a24e3d30182e4ba4ed7ccd5cc9f0bd8306ae3f4daa42e1fe8a466ed8
+//   Vault.json: sha256 c4bdb00e1e3d2372a6a5073aa7cb63ef9b9e6fce093f50bfccfc52002fbf6f32
+//   VaultExtension.json: sha256 be467f1e2aa2c7f775c7170b7851eca4329a3b6e2b03b53f6b78dd0f0fe2857d
+//   VaultExplorer.json: sha256 05a2a259bb1924ec542a2abfae20aaba9159a9028b0679b721fa3a30ce755868
+//   vendored: 2026-07-29
+//   verification: swap/add/remove surfaces exercised live on Monad mainnet via
+//   rpc.monad.xyz (the adapter's e2e tests pin observable behavior). The Router
+//   and Vault ABIs are additionally cross-checked against explorer-verified
+//   implementations by `pnpm test:abi:online` (see abis.json).
+
+export const BeetsRouterAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IWETH",
+        "name": "weth",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IPermit2",
+        "name": "permit2",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "routerVersion",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "AddressInsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorSelectorNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EthTransfer",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedInnerCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InputLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientEth",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "bits",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeCastOverflowedUintDowncast",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "SenderIsNotVault",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapDeadline",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "maxAmountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "addLiquidityCustom",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "maxAmountsIn",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minBptAmountOut",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum AddLiquidityKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "wethIsEth",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRouterCommon.AddLiquidityHookParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "addLiquidityHook",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "maxAmountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "addLiquidityProportional",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "addLiquiditySingleTokenExactOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "exactAmountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "addLiquidityUnbalanced",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "donate",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPermit2",
+    "outputs": [
+      {
+        "internalType": "contract IPermit2",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSender",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWeth",
+    "outputs": [
+      {
+        "internalType": "contract IWETH",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "exactAmountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20[]",
+            "name": "tokens",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "exactAmountsIn",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minBptAmountOut",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "wethIsEth",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRouter.InitializeHookParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "initializeHook",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "nonce",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IRouterCommon.PermitApproval[]",
+        "name": "permitBatch",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "permitSignatures",
+        "type": "bytes[]"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+              },
+              {
+                "internalType": "uint160",
+                "name": "amount",
+                "type": "uint160"
+              },
+              {
+                "internalType": "uint48",
+                "name": "expiration",
+                "type": "uint48"
+              },
+              {
+                "internalType": "uint48",
+                "name": "nonce",
+                "type": "uint48"
+              }
+            ],
+            "internalType": "struct IAllowanceTransfer.PermitDetails[]",
+            "name": "details",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sigDeadline",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IAllowanceTransfer.PermitBatch",
+        "name": "permit2Batch",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "permit2Signature",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "multicallData",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "permitBatchAndCall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "maxAmountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryAddLiquidityCustom",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "maxAmountsIn",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minBptAmountOut",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum AddLiquidityKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "wethIsEth",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRouterCommon.AddLiquidityHookParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "queryAddLiquidityHook",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryAddLiquidityProportional",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryAddLiquiditySingleTokenExactOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "exactAmountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryAddLiquidityUnbalanced",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryRemoveLiquidityCustom",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "minAmountsOut",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxBptAmountIn",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum RemoveLiquidityKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "wethIsEth",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRouterCommon.RemoveLiquidityHookParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "queryRemoveLiquidityHook",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryRemoveLiquidityProportional",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "queryRemoveLiquidityRecovery",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "queryRemoveLiquidityRecoveryHook",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryRemoveLiquiditySingleTokenExactIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryRemoveLiquiditySingleTokenExactOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "enum SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenIn",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenOut",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountGiven",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "limit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "wethIsEth",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRouter.SwapSingleTokenHookParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "querySwapHook",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "querySwapSingleTokenExactIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountCalculated",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "querySwapSingleTokenExactOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountCalculated",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "removeLiquidityCustom",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "minAmountsOut",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxBptAmountIn",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum RemoveLiquidityKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "wethIsEth",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRouterCommon.RemoveLiquidityHookParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "removeLiquidityHook",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "removeLiquidityProportional",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "removeLiquidityRecovery",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "removeLiquidityRecoveryHook",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "removeLiquiditySingleTokenExactIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "removeLiquiditySingleTokenExactOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "swapSingleTokenExactIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "wethIsEth",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "swapSingleTokenExactOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "sender",
+            "type": "address"
+          },
+          {
+            "internalType": "enum SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenIn",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenOut",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountGiven",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "limit",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "wethIsEth",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IRouter.SwapSingleTokenHookParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "swapSingleTokenHook",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+] as const;
+
+export const BeetsVaultAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVaultExtension",
+        "name": "vaultExtension",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IAuthorizer",
+        "name": "authorizer",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IProtocolFeeController",
+        "name": "protocolFeeController",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "AddressInsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterAddLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterInitializeHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterRemoveLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterSwapHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AllZeroInputs",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AmountGivenZero",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "AmountInAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "AmountOutBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BalanceNotSettled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BalanceOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeAddLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeInitializeHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeRemoveLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeSwapHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "BptAmountInAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "BptAmountOutBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "BufferAlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "BufferNotInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BufferSharesInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BufferSharesInvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "BufferTotalSupplyTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotReceiveEth",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotSwapSameToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportAddLiquidityCustom",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportDonation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportRemoveLiquidityCustom",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportUnbalancedLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DynamicSwapFeeHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allowance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientAllowance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSpender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedInnerCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeePrecisionTooHigh",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "HookAdjustedAmountInAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "HookAdjustedAmountOutBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "HookAdjustedSwapLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "poolHooksContract",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "poolFactory",
+        "type": "address"
+      }
+    ],
+    "name": "HookRegistrationFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InputLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddLiquidityKind",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidRemoveLiquidityKind",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenConfiguration",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenDecimals",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenType",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidUnderlyingToken",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "invariantRatio",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxInvariantRatio",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvariantRatioAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "invariantRatio",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minInvariantRatio",
+        "type": "uint256"
+      }
+    ],
+    "name": "InvariantRatioBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "issuedShares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minIssuedShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "IssuedSharesBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MaxTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MinTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MultipleNonZeroInputs",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotEnoughBufferShares",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedUnderlyingAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualUnderlyingAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotEnoughUnderlying",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedWrappedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualWrappedAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotEnoughWrapped",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotStaticCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotVaultDelegateCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PauseBufferPeriodDurationTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PercentageAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolAlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolInRecoveryMode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotInRecoveryMode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolPauseWindowExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolTotalSupplyTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProtocolFeesExceedTotalCollected",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QueriesDisabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QueriesDisabledPermanently",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QuoteResultSpoofed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RouterNotTrusted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "value",
+        "type": "int256"
+      }
+    ],
+    "name": "SafeCastOverflowedIntToUint",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeCastOverflowedUintToInt",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "SenderIsNotVault",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapFeePercentageTooHigh",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapFeePercentageTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "SwapLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "expectedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "actualToken",
+        "type": "address"
+      }
+    ],
+    "name": "TokensMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TradeAmountTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultBuffersArePaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultIsNotUnlocked",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultNotPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultPauseWindowDurationTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultPauseWindowExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "WrapAmountTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongProtocolFeeControllerDeployment",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "underlyingToken",
+        "type": "address"
+      }
+    ],
+    "name": "WrongUnderlyingToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongVaultAdminDeployment",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongVaultExtensionDeployment",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroDivision",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "aggregateSwapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "AggregateSwapFeePercentageChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "aggregateYieldFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "AggregateYieldFeePercentageChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IAuthorizer",
+        "name": "newAuthorizer",
+        "type": "address"
+      }
+    ],
+    "name": "AuthorizerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "burnedShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "BufferSharesBurned",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "issuedShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "BufferSharesMinted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "enum AddLiquidityKind",
+        "name": "kind",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amountsAddedRaw",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "swapFeeAmountsRaw",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "LiquidityAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountWrapped",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LiquidityAddedToBuffer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "enum RemoveLiquidityKind",
+        "name": "kind",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amountsRemovedRaw",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "swapFeeAmountsRaw",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "LiquidityRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountWrapped",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LiquidityRemovedFromBuffer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "PoolPausedStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "recoveryMode",
+        "type": "bool"
+      }
+    ],
+    "name": "PoolRecoveryModeStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "factory",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "enum TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IRateProvider",
+            "name": "rateProvider",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "paysYieldFees",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct TokenConfig[]",
+        "name": "tokenConfig",
+        "type": "tuple[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "pauseWindowEndTime",
+        "type": "uint32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pauseManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "swapFeeManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "poolCreator",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct PoolRoleAccounts",
+        "name": "roleAccounts",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "enableHookAdjustedAmounts",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallComputeDynamicSwapFee",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "hooksContract",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct HooksConfig",
+        "name": "hooksConfig",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "disableUnbalancedLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableAddLiquidityCustom",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableRemoveLiquidityCustom",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableDonation",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct LiquidityManagement",
+        "name": "liquidityManagement",
+        "type": "tuple"
+      }
+    ],
+    "name": "PoolRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IProtocolFeeController",
+        "name": "newProtocolFeeController",
+        "type": "address"
+      }
+    ],
+    "name": "ProtocolFeeControllerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "SwapFeePercentageChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "burnedShares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawnUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "Unwrap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "eventKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "eventData",
+        "type": "bytes"
+      }
+    ],
+    "name": "VaultAuxiliary",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "VaultBuffersPausedStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "VaultPausedStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "VaultQueriesDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "VaultQueriesEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositedUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mintedShares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "Wrap",
+    "type": "event"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "maxAmountsIn",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minBptAmountOut",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum AddLiquidityKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct AddLiquidityParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "addLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "enum SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum WrappingDirection",
+            "name": "direction",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IERC4626",
+            "name": "wrappedToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountGivenRaw",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "limitRaw",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct BufferWrapOrUnwrapParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "erc4626BufferWrapOrUnwrap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountCalculatedRaw",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountInRaw",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutRaw",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokenCountAndIndexOfToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVaultExtension",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reentrancyGuardEntered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxBptAmountIn",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "minAmountsOut",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "enum RemoveLiquidityKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct RemoveLiquidityParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "returnData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "sendTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountHint",
+        "type": "uint256"
+      }
+    ],
+    "name": "settle",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "credit",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "enum SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenIn",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenOut",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountGivenRaw",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "limitRaw",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct VaultSwapParams",
+        "name": "vaultSwapParams",
+        "type": "tuple"
+      }
+    ],
+    "name": "swap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountCalculated",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "unlock",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "result",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+] as const;
+
+export const BeetsVaultExtensionAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "mainVault",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IVaultAdmin",
+        "name": "vaultAdmin",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "AddressInsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterAddLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterInitializeHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterRemoveLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AfterSwapHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AmountGivenZero",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "AmountInAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "AmountOutBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BalanceNotSettled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BalanceOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeAddLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeInitializeHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeRemoveLiquidityHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BeforeSwapHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "BptAmountInAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "BptAmountOutBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "BufferAlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "BufferNotInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BufferSharesInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BufferSharesInvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "BufferTotalSupplyTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotReceiveEth",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotSwapSameToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CodecOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportAddLiquidityCustom",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportDonation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportRemoveLiquidityCustom",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotSupportUnbalancedLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DynamicSwapFeeHookFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allowance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientAllowance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSpender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ErrorSelectorNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedInnerCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeePrecisionTooHigh",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "HookAdjustedAmountInAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "HookAdjustedAmountOutBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "HookAdjustedSwapLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "poolHooksContract",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "poolFactory",
+        "type": "address"
+      }
+    ],
+    "name": "HookRegistrationFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InputLengthMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddLiquidityKind",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidRemoveLiquidityKind",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenConfiguration",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenDecimals",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenType",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "InvalidUnderlyingToken",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "issuedShares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minIssuedShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "IssuedSharesBelowMin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MaxTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MinTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotEnoughBufferShares",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedUnderlyingAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualUnderlyingAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotEnoughUnderlying",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedWrappedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actualWrappedAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "NotEnoughWrapped",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotStaticCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotVaultDelegateCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OutOfBounds",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PauseBufferPeriodDurationTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PercentageAboveMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolAlreadyInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolInRecoveryMode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotInRecoveryMode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotInitialized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolPauseWindowExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolTotalSupplyTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProtocolFeesExceedTotalCollected",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QueriesDisabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QueriesDisabledPermanently",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QuoteResultSpoofed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "result",
+        "type": "bytes"
+      }
+    ],
+    "name": "Result",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RouterNotTrusted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeCastOverflowedUintToInt",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "SenderIsNotVault",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapFeePercentageTooHigh",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SwapFeePercentageTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "SwapLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "expectedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "actualToken",
+        "type": "address"
+      }
+    ],
+    "name": "TokensMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokensNotSorted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TradeAmountTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultBuffersArePaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultIsNotUnlocked",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultNotPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultPauseWindowDurationTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultPauseWindowExpired",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "VaultPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "WrapAmountTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongProtocolFeeControllerDeployment",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "underlyingToken",
+        "type": "address"
+      }
+    ],
+    "name": "WrongUnderlyingToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongVaultAdminDeployment",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongVaultExtensionDeployment",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "aggregateSwapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "AggregateSwapFeePercentageChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "aggregateYieldFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "AggregateYieldFeePercentageChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IAuthorizer",
+        "name": "newAuthorizer",
+        "type": "address"
+      }
+    ],
+    "name": "AuthorizerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "burnedShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "BufferSharesBurned",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "issuedShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "BufferSharesMinted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "enum AddLiquidityKind",
+        "name": "kind",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amountsAddedRaw",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "swapFeeAmountsRaw",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "LiquidityAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountWrapped",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LiquidityAddedToBuffer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "liquidityProvider",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "enum RemoveLiquidityKind",
+        "name": "kind",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "amountsRemovedRaw",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "swapFeeAmountsRaw",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "LiquidityRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountWrapped",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LiquidityRemovedFromBuffer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolInitialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "PoolPausedStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "recoveryMode",
+        "type": "bool"
+      }
+    ],
+    "name": "PoolRecoveryModeStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "factory",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "enum TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IRateProvider",
+            "name": "rateProvider",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "paysYieldFees",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct TokenConfig[]",
+        "name": "tokenConfig",
+        "type": "tuple[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "pauseWindowEndTime",
+        "type": "uint32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pauseManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "swapFeeManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "poolCreator",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct PoolRoleAccounts",
+        "name": "roleAccounts",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "enableHookAdjustedAmounts",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallComputeDynamicSwapFee",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "hooksContract",
+            "type": "address"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct HooksConfig",
+        "name": "hooksConfig",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "disableUnbalancedLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableAddLiquidityCustom",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableRemoveLiquidityCustom",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableDonation",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct LiquidityManagement",
+        "name": "liquidityManagement",
+        "type": "tuple"
+      }
+    ],
+    "name": "PoolRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IProtocolFeeController",
+        "name": "newProtocolFeeController",
+        "type": "address"
+      }
+    ],
+    "name": "ProtocolFeeControllerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IERC20",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IERC20",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "SwapFeePercentageChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "burnedShares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "withdrawnUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "Unwrap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "eventKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "eventData",
+        "type": "bytes"
+      }
+    ],
+    "name": "VaultAuxiliary",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "VaultBuffersPausedStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "VaultPausedStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "VaultQueriesDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "VaultQueriesEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositedUnderlying",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mintedShares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bufferBalances",
+        "type": "bytes32"
+      }
+    ],
+    "name": "Wrap",
+    "type": "event"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountGivenScaled18",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "balancesScaled18",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "indexIn",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "indexOut",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "router",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PoolSwapParams",
+        "name": "swapParams",
+        "type": "tuple"
+      }
+    ],
+    "name": "computeDynamicSwapFeePercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "dynamicSwapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "eventKey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "eventData",
+        "type": "bytes"
+      }
+    ],
+    "name": "emitAuxiliaryEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getAddLiquidityCalledFlag",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getAggregateSwapFeeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getAggregateYieldFeeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizer",
+    "outputs": [
+      {
+        "internalType": "contract IAuthorizer",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getBptRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rate",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getCurrentLiveBalances",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "balancesLiveScaled18",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "getERC4626BufferAsset",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getHooksConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "enableHookAdjustedAmounts",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallComputeDynamicSwapFee",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "hooksContract",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct HooksConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getNonzeroDeltaCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "disableUnbalancedLiquidity",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "enableAddLiquidityCustom",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "enableRemoveLiquidityCustom",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "enableDonation",
+                "type": "bool"
+              }
+            ],
+            "internalType": "struct LiquidityManagement",
+            "name": "liquidityManagement",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "staticSwapFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "aggregateSwapFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "aggregateYieldFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint40",
+            "name": "tokenDecimalDiffs",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint32",
+            "name": "pauseWindowEndTime",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolRegistered",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolInitialized",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolPaused",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolInRecoveryMode",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct PoolConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "PoolConfigBits",
+            "name": "poolConfigBits",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "contract IERC20[]",
+            "name": "tokens",
+            "type": "address[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum TokenType",
+                "name": "tokenType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "contract IRateProvider",
+                "name": "rateProvider",
+                "type": "address"
+              },
+              {
+                "internalType": "bool",
+                "name": "paysYieldFees",
+                "type": "bool"
+              }
+            ],
+            "internalType": "struct TokenInfo[]",
+            "name": "tokenInfo",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "balancesRaw",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "balancesLiveScaled18",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "tokenRates",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "decimalScalingFactors",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct PoolData",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolPausedState",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolRoleAccounts",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pauseManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "swapFeeManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "poolCreator",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct PoolRoleAccounts",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokenInfo",
+    "outputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IRateProvider",
+            "name": "rateProvider",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "paysYieldFees",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct TokenInfo[]",
+        "name": "tokenInfo",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balancesRaw",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "lastBalancesLiveScaled18",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokenRates",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "decimalScalingFactors",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "tokenRates",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokens",
+    "outputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProtocolFeeController",
+    "outputs": [
+      {
+        "internalType": "contract IProtocolFeeController",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getReservesOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getStaticSwapFeePercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getTokenDelta",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVaultAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "exactAmountsIn",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minBptAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "isERC4626BufferInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolInRecoveryMode",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolRegistered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isQueryDisabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isQueryDisabledPermanently",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isUnlocked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "quote",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "result",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "quoteAndRevert",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reentrancyGuardEntered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "enum TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IRateProvider",
+            "name": "rateProvider",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "paysYieldFees",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct TokenConfig[]",
+        "name": "tokenConfig",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint32",
+        "name": "pauseWindowEndTime",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bool",
+        "name": "protocolFeeExempt",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pauseManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "swapFeeManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "poolCreator",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct PoolRoleAccounts",
+        "name": "roleAccounts",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "poolHooksContract",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "disableUnbalancedLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableAddLiquidityCustom",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableRemoveLiquidityCustom",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "enableDonation",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct LiquidityManagement",
+        "name": "liquidityManagement",
+        "type": "tuple"
+      }
+    ],
+    "name": "registerPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactBptAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "minAmountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "removeLiquidityRecovery",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOutRaw",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+] as const;
+
+export const BeetsVaultExplorerAbi = [
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "vault",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenAllowance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "areBuffersPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "buffersPaused",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenBalance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "collectAggregateFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountGivenScaled18",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "balancesScaled18",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "indexIn",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "indexOut",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "router",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct PoolSwapParams",
+        "name": "swapParams",
+        "type": "tuple"
+      }
+    ],
+    "name": "computeDynamicSwapFeePercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "dynamicSwapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "enableRecoveryMode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getAddLiquidityCalledFlag",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "liquidityAdded",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getAggregateFeePercentages",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "aggregateSwapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "aggregateYieldFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getAggregateSwapFeeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swapFeeAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getAggregateYieldFeeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "yieldFeeAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizer",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "authorizer",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getBptRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rate",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "getBufferAsset",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "underlyingToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "getBufferBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "underlyingBalanceRaw",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "wrappedBalanceRaw",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBufferMinimumTotalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bufferMinimumTotalSupply",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "liquidityOwner",
+        "type": "address"
+      }
+    ],
+    "name": "getBufferOwnerShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ownerShares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBufferPeriodDuration",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "bufferPeriodDuration",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBufferPeriodEndTime",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "bufferPeriodEndTime",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "getBufferTotalShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bufferShares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getCurrentLiveBalances",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "balancesLiveScaled18",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "getERC4626BufferAsset",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "underlyingToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getHooksConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "enableHookAdjustedAmounts",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterInitialize",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallComputeDynamicSwapFee",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterSwap",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterAddLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallBeforeRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "shouldCallAfterRemoveLiquidity",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "hooksContract",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct HooksConfig",
+        "name": "hooksConfig",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMaximumPoolTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxTokens",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMinimumPoolTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "minTokens",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMinimumTradeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "minimumTradeAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMinimumWrapAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "minimumWrapAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getNonzeroDeltaCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "nonzeroDeltaCount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPauseWindowEndTime",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "pauseWindowEndTime",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolConfig",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "disableUnbalancedLiquidity",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "enableAddLiquidityCustom",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "enableRemoveLiquidityCustom",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "enableDonation",
+                "type": "bool"
+              }
+            ],
+            "internalType": "struct LiquidityManagement",
+            "name": "liquidityManagement",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "staticSwapFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "aggregateSwapFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "aggregateYieldFeePercentage",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint40",
+            "name": "tokenDecimalDiffs",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint32",
+            "name": "pauseWindowEndTime",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolRegistered",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolInitialized",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolPaused",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "isPoolInRecoveryMode",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct PoolConfig",
+        "name": "poolConfig",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolData",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "PoolConfigBits",
+            "name": "poolConfigBits",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "contract IERC20[]",
+            "name": "tokens",
+            "type": "address[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum TokenType",
+                "name": "tokenType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "contract IRateProvider",
+                "name": "rateProvider",
+                "type": "address"
+              },
+              {
+                "internalType": "bool",
+                "name": "paysYieldFees",
+                "type": "bool"
+              }
+            ],
+            "internalType": "struct TokenInfo[]",
+            "name": "tokenInfo",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "balancesRaw",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "balancesLiveScaled18",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "tokenRates",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "decimalScalingFactors",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct PoolData",
+        "name": "poolData",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolMinimumTotalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "poolMinimumTotalSupply",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolPausedState",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "poolPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "poolPauseWindowEndTime",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "poolBufferPeriodEndTime",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "pauseManager",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolRoleAccounts",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pauseManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "swapFeeManager",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "poolCreator",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct PoolRoleAccounts",
+        "name": "roleAccounts",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokenCountAndIndexOfToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenCount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokenInfo",
+    "outputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IRateProvider",
+            "name": "rateProvider",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "paysYieldFees",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct TokenInfo[]",
+        "name": "tokenInfo",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balancesRaw",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "lastBalancesLiveScaled18",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokenRates",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "decimalScalingFactors",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "tokenRates",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokens",
+    "outputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProtocolFeeController",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "protocolFeeController",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getReservesOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "reserveAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "getStaticSwapFeePercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "getTokenDelta",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "tokenDelta",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVaultAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "vaultAdmin",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVaultExtension",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "vaultExtension",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVaultPausedState",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "vaultPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "vaultPauseWindowEndTime",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "vaultBufferPeriodEndTime",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC4626",
+        "name": "wrappedToken",
+        "type": "address"
+      }
+    ],
+    "name": "isERC4626BufferInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isBufferInitialized",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolInRecoveryMode",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "inRecoveryMode",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "initialized",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "poolPaused",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolRegistered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isQueryDisabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "queryDisabled",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isQueryDisabledPermanently",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "queryDisabledPermanently",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isUnlocked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "unlocked",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isVaultPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "vaultPaused",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenTotalSupply",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+] as const;

--- a/packages/protocols/beets/src/beets.ts
+++ b/packages/protocols/beets/src/beets.ts
@@ -1,0 +1,730 @@
+/**
+ * Beets 鈥?Balancer V3 DEX adapter on Monad mainnet.
+ *
+ * The canonical Balancer v3 Router at `0x9dA18982鈥?e017c` executes
+ * single-pool swaps and liquidity changes; the Vault (`0xbA133333鈥?9bA9`) is
+ * the settlement and event surface, and the VaultExtension
+ * (`0x0E8B0765鈥9A9`) hosts the pool view reads. All three addresses come
+ * from the balancer-deployments repository (see abis-src/VENDOR.json) and are
+ * pinned on-chain by the e2e suite.
+ *
+ * v1 scope (intentionally narrow, mirrors the Balancer v3 Router v2 surface):
+ *   - Single-pool swaps only: `swapSingleTokenExactIn` / `swapSingleTokenExactOut`.
+ *   - Native MON supported on both sides: `wethIsEth` makes the Router wrap
+ *     (input) or unwrap (output) automatically 鈥?no pre-wrap needed.
+ *   - Liquidity: single-token `addLiquidityUnbalanced` and single-token
+ *     `removeLiquiditySingleTokenExactIn`.
+ *   - Quoting uses the Router's `querySwap*` / `queryAddLiquidity*` /
+ *     `queryRemoveLiquidity*` view calls, executed as an eth_call from the
+ *     zero address: the Vault's `quote` path reverts non-static callers
+ *     (`NotStaticCall`), and the simulated rate is independent of the sender.
+ *   - Router deadlines are timestamps: the adapter stamps `now + 10 minutes`
+ *     at plan time (Balancer reverts once `block.timestamp > deadline`).
+ *
+ * Risk model (closed set per ADR 0003):
+ *   - `fundOut`     鈥?input amounts leave the account
+ *   - `approval`    鈥?a Router allowance is granted (explicit transaction)
+ *   - `priceImpact` 鈥?pool depth moves the realised rate vs quoted
+ */
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  BasisPoints,
+  Capability,
+  type CapabilityResult,
+  type Change,
+  createHandle,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type MossRuntime,
+  NATIVE,
+  ParameterError,
+  type ParamsSpec,
+  PositiveDecimalString,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+  type TokenRef,
+  TokenReference,
+} from "@themoss/core";
+import { ERC20, ERC20Abi } from "@themoss/erc";
+import { WMON_ADDRESS } from "@themoss/system";
+import { decodeEventLog, formatUnits, parseUnits } from "viem";
+import {
+  BeetsRouterAbi,
+  BeetsVaultAbi,
+  BeetsVaultExplorerAbi,
+  BeetsVaultExtensionAbi,
+} from "./abis/beets.js";
+import type { BeetsLiquidityOutcome, BeetsSwapOutcome, BeetsSwapQuote } from "./types.js";
+
+// Canonical Balancer v3 deployment on Monad mainnet, from
+// balancer/balancer-deployments (pinned commit c1c3038a 鈥?see VENDOR.json).
+// Verified on-chain 2026-07-29 via rpc.monad.xyz: all three are plain
+// (non-proxy) contracts, and the Router's getVault() returns the Vault below.
+export const BEETS_ROUTER_ADDRESS: AddressValue = "0x9dA18982a33FD0c7051B19F0d7C76F2d5E7e017c";
+export const BEETS_VAULT_ADDRESS: AddressValue = "0xbA1333333333a1BA1108E8412f11850A5C319bA9";
+export const BEETS_VAULT_EXTENSION_ADDRESS: AddressValue =
+  "0x0E8B07657D719B86e06bF0806D6729e3D528C9A9";
+export const BEETS_VAULT_EXPLORER_ADDRESS: AddressValue =
+  "0x043A2daD730d585C44FB79D2614F295D2d625412";
+
+// Balancer v3's Router quote views revert with `NotStaticCall` when executed
+// as an eth_call from a non-zero address (the Vault's quote path inspects the
+// simulation context, not the quote's sender argument).
+const QUERY_ACCOUNT: AddressValue = "0x0000000000000000000000000000000000000000";
+
+const DEFAULT_SLIPPAGE_BPS = 50;
+const DEFAULT_DEADLINE_SECONDS = 600;
+
+const OptionalHumanTokenAmount = PositiveDecimalString.optional().describe(
+  'An optional positive base-10 decimal amount in a token\'s display units, such as "1" or "1.5".',
+);
+const BeetsSlippage = BasisPoints.min(50)
+  .max(5_000)
+  .describe("An integer basis-point count from 50 through 5000; 1 bps equals 0.01%.");
+
+const swapParams = {
+  pool: {
+    type: Address,
+    description: "Address of the Balancer v3 pool that holds both tokens.",
+  },
+  tokenIn: { type: TokenReference, description: 'Asset offered to the swap; "native" for MON.' },
+  tokenOut: {
+    type: TokenReference,
+    description: 'Asset requested from the swap; "native" for MON.',
+  },
+  amountIn: {
+    type: OptionalHumanTokenAmount,
+    description: "Fixed input quantity; omit when amountOut is supplied.",
+  },
+  amountOut: {
+    type: OptionalHumanTokenAmount,
+    description: "Minimum output quantity; omit when amountIn is supplied.",
+  },
+  slippage: {
+    type: BeetsSlippage.default(DEFAULT_SLIPPAGE_BPS),
+    description: "Maximum adverse movement allowed between quoting and execution.",
+  },
+} satisfies ParamsSpec;
+
+const addLiquidityParams = {
+  pool: {
+    type: Address,
+    description: "Address of the Balancer v3 pool receiving liquidity.",
+  },
+  tokenIn: { type: TokenReference, description: 'Asset deposited; "native" for MON.' },
+  amountIn: {
+    type: PositiveDecimalString,
+    description: "Human-readable token amount to deposit, in display units.",
+  },
+  slippage: {
+    type: BeetsSlippage.default(DEFAULT_SLIPPAGE_BPS),
+    description: "Maximum adverse movement allowed between quoting and execution.",
+  },
+} satisfies ParamsSpec;
+
+const removeLiquidityParams = {
+  pool: {
+    type: Address,
+    description: "Address of the Balancer v3 pool withdrawing liquidity.",
+  },
+  tokenOut: { type: TokenReference, description: 'Asset withdrawn; "native" for MON.' },
+  bptAmountIn: {
+    type: PositiveDecimalString,
+    description: "Human-readable BPT amount to redeem, in display units.",
+  },
+  slippage: {
+    type: BeetsSlippage.default(DEFAULT_SLIPPAGE_BPS),
+    description: "Maximum adverse movement allowed between quoting and execution.",
+  },
+} satisfies ParamsSpec;
+
+const poolParams = {
+  pool: { type: Address, description: "Address of the Balancer v3 pool to inspect." },
+} satisfies ParamsSpec;
+
+type InferredSwapParams = InferParams<typeof swapParams>;
+type SwapParams = Omit<InferredSwapParams, "amountIn" | "amountOut" | "slippage"> &
+  Partial<Pick<InferredSwapParams, "amountIn" | "amountOut" | "slippage">>;
+type BeetsSwapParams = Pick<SwapParams, "pool" | "tokenIn" | "tokenOut" | "slippage"> & {
+  slippage?: InferredSwapParams["slippage"];
+} & ({ amountIn: string; amountOut?: never } | { amountIn?: never; amountOut: string });
+
+type InferredAddParams = InferParams<typeof addLiquidityParams>;
+type AddParams = InferredAddParams;
+
+type InferredRemoveParams = InferParams<typeof removeLiquidityParams>;
+type RemoveParams = InferredRemoveParams;
+
+type PreparedSwap = {
+  side: "amountIn" | "amountOut";
+  pool: AddressValue;
+  tokenIn: AddressValue;
+  tokenOut: AddressValue;
+  inputDecimals: number;
+  outputDecimals: number;
+  /** amountIn side: the exact input sent; amountOut side: the slippage-headroom input sent. */
+  executionAmountIn: bigint;
+  /** amountIn side: raw quoted output; amountOut side: the exact requested output. */
+  estimatedAmountOut: bigint;
+  /** amountIn side: slippage-adjusted minimum output; amountOut side: the exact requested output. */
+  minimumAmountOut: bigint;
+  /** amountOut side: raw quoted required input (pre-headroom). */
+  estimatedAmountIn: bigint;
+  wethIsEth: boolean;
+  nativeIn: boolean;
+};
+
+type PreparedAddLiquidity = {
+  pool: AddressValue;
+  tokenIn: AddressValue;
+  amountIn: bigint;
+  exactAmountsIn: readonly bigint[];
+  estimatedBptOut: bigint;
+  minBptAmountOut: bigint;
+  wethIsEth: boolean;
+  nativeIn: boolean;
+};
+
+type PreparedRemoveLiquidity = {
+  pool: AddressValue;
+  tokenOut: AddressValue;
+  bptAmountIn: bigint;
+  estimatedAmountOut: bigint;
+  minimumAmountOut: bigint;
+  wethIsEth: boolean;
+};
+
+@Protocol({
+  name: "beets",
+  category: "dex",
+  description:
+    "Beets Balancer v3 single-pool swaps and liquidity on Monad mainnet, " +
+    "executed through the canonical Router with native MON wrap/unwrap support.",
+  contracts: {
+    router: { abi: BeetsRouterAbi, addr: BEETS_ROUTER_ADDRESS },
+    vault: { abi: BeetsVaultAbi, addr: BEETS_VAULT_ADDRESS },
+    vaultExtension: { abi: BeetsVaultExtensionAbi, addr: BEETS_VAULT_EXTENSION_ADDRESS },
+  },
+  protocols: { erc20: ERC20 },
+  labels: { Router: BEETS_ROUTER_ADDRESS, Vault: BEETS_VAULT_ADDRESS },
+})
+export class Beets {
+  declare runtime: MossRuntime;
+  declare router: Handle<typeof BeetsRouterAbi>;
+  declare vault: Handle<typeof BeetsVaultAbi>;
+  declare vaultExtension: Handle<typeof BeetsVaultExtensionAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  quote(params: BeetsSwapParams, ctx: ActionCtx): Promise<BeetsSwapQuote>;
+  @Query({
+    intent: "Quote a Beets swap of {tokenIn} to {tokenOut} in pool {pool}",
+    params: swapParams,
+    tags: ["amm", "balancer", "quote"],
+  })
+  async quote(params: SwapParams, ctx: ActionCtx): Promise<BeetsSwapQuote> {
+    const prepared = await this.#prepareSwap(params, ctx.account);
+    if (prepared.side === "amountIn") {
+      return {
+        pool: prepared.pool,
+        amountSide: "amountIn",
+        tokenIn: params.tokenIn,
+        tokenOut: params.tokenOut,
+        amountIn: formatUnits(prepared.executionAmountIn, prepared.inputDecimals),
+        estimatedAmountOut: formatUnits(prepared.estimatedAmountOut, prepared.outputDecimals),
+        minimumAmountOut: formatUnits(prepared.minimumAmountOut, prepared.outputDecimals),
+      };
+    }
+    return {
+      pool: prepared.pool,
+      amountSide: "amountOut",
+      tokenIn: params.tokenIn,
+      tokenOut: params.tokenOut,
+      estimatedAmountIn: formatUnits(prepared.estimatedAmountIn, prepared.inputDecimals),
+      maximumAmountIn: formatUnits(prepared.executionAmountIn, prepared.inputDecimals),
+      amountOut: formatUnits(prepared.minimumAmountOut, prepared.outputDecimals),
+    };
+  }
+
+  swap(params: BeetsSwapParams, ctx: ActionCtx): Promise<CapabilityResult>;
+  @Capability<Beets, typeof swapParams>({
+    intent:
+      "Swap {tokenIn} for {tokenOut} in Beets pool {pool}, tolerating {slippage} bps slippage",
+    verb: "swap",
+    params: swapParams,
+    receipt: "swapReceipt",
+    risk: ["fundOut", "approval", "priceImpact"],
+    tags: ["amm", "balancer", "single-pool"],
+  })
+  async swap(params: SwapParams, ctx: ActionCtx): Promise<CapabilityResult> {
+    const prepared = await this.#prepareSwap(params, ctx.account);
+    const deadline = deadlineTimestamp();
+    const children = [];
+    if (params.tokenIn !== NATIVE) {
+      children.push(
+        await this.erc20.approve({
+          token: prepared.tokenIn,
+          spender: this.router.address,
+          amount: prepared.executionAmountIn.toString(),
+        }),
+      );
+    }
+    children.push(
+      prepared.side === "amountIn"
+        ? this.router.swapSingleTokenExactIn(
+            [
+              prepared.pool,
+              prepared.tokenIn,
+              prepared.tokenOut,
+              prepared.executionAmountIn,
+              prepared.minimumAmountOut,
+              deadline,
+              prepared.wethIsEth,
+              "0x",
+            ],
+            { value: prepared.nativeIn ? prepared.executionAmountIn : 0n },
+          )
+        : this.router.swapSingleTokenExactOut(
+            [
+              prepared.pool,
+              prepared.tokenIn,
+              prepared.tokenOut,
+              prepared.minimumAmountOut,
+              prepared.executionAmountIn,
+              deadline,
+              prepared.wethIsEth,
+              "0x",
+            ],
+            { value: prepared.nativeIn ? prepared.executionAmountIn : 0n },
+          ),
+    );
+    return children;
+  }
+
+  @Receipt()
+  swapReceipt(changes: readonly Change[]): ReceiptResult<BeetsSwapOutcome> {
+    let swap: BeetsSwapOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer" || !sameAddress(change.address, BEETS_VAULT_ADDRESS)) {
+        return this.erc20.changesReceipt([change]);
+      }
+      const event = decodeBeetsEvent(BeetsVaultAbi, change);
+      if (event.eventName !== "Swap") {
+        throw new Error(`Unexpected Change: Beets Vault emitted ${event.eventName}`);
+      }
+      if (swap) throw new Error("Beets swap emitted multiple Vault Swap events");
+      const tokenIn = wethNormalize(event.args.tokenIn, event.args.amountIn, changes);
+      const tokenOut = wethNormalize(event.args.tokenOut, event.args.amountOut, changes);
+      swap = {
+        operation: "swap",
+        pool: event.args.pool,
+        tokenIn,
+        tokenOut,
+        amountIn: event.args.amountIn.toString(),
+        amountOut: event.args.amountOut.toString(),
+        swapFeePercentage: event.args.swapFeePercentage.toString(),
+        swapFeeAmount: event.args.swapFeeAmount.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: swap,
+        text: `Beets Swap: ${swap.amountIn} ${swap.tokenIn} to ${swap.amountOut} ${swap.tokenOut} in pool ${swap.pool}`,
+      };
+    });
+    if (!swap) throw new Error("Beets swap Receipt requires a Vault Swap event");
+    return {
+      kind: "receipt",
+      outcome: swap,
+      text: `Beets Swap: ${swap.amountIn} ${swap.tokenIn} to ${swap.amountOut} ${swap.tokenOut} in pool ${swap.pool}`,
+      changes: parsed,
+    };
+  }
+
+  quoteAddLiquidity(params: AddParams, ctx: ActionCtx): Promise<object>;
+  @Query({
+    intent: "Quote a Beets single-token add of {amountIn} {tokenIn} into pool {pool}",
+    params: addLiquidityParams,
+    tags: ["amm", "balancer", "liquidity", "quote"],
+  })
+  async quoteAddLiquidity(params: AddParams, ctx: ActionCtx) {
+    const prepared = await this.#prepareAddLiquidity(params, ctx.account);
+    return {
+      pool: prepared.pool,
+      tokenIn: params.tokenIn,
+      amountIn: params.amountIn,
+      estimatedBptOut: prepared.estimatedBptOut.toString(),
+      minimumBptOut: prepared.minBptAmountOut.toString(),
+    };
+  }
+
+  addLiquidity(params: AddParams, ctx: ActionCtx): Promise<CapabilityResult>;
+  @Capability<Beets, typeof addLiquidityParams>({
+    intent: "Add {amountIn} {tokenIn} to Beets pool {pool}, tolerating {slippage} bps slippage",
+    verb: "supply",
+    params: addLiquidityParams,
+    receipt: "addLiquidityReceipt",
+    risk: ["fundOut", "approval", "priceImpact"],
+    tags: ["amm", "balancer", "liquidity"],
+  })
+  async addLiquidity(params: AddParams, ctx: ActionCtx): Promise<CapabilityResult> {
+    const prepared = await this.#prepareAddLiquidity(params, ctx.account);
+    const children = [];
+    if (params.tokenIn !== NATIVE) {
+      children.push(
+        await this.erc20.approve({
+          token: prepared.tokenIn,
+          spender: this.router.address,
+          amount: prepared.amountIn.toString(),
+        }),
+      );
+    }
+    children.push(
+      this.router.addLiquidityUnbalanced(
+        [
+          prepared.pool,
+          prepared.exactAmountsIn,
+          prepared.minBptAmountOut,
+          prepared.wethIsEth,
+          "0x",
+        ],
+        { value: prepared.nativeIn ? prepared.amountIn : 0n },
+      ),
+    );
+    return children;
+  }
+
+  @Receipt()
+  addLiquidityReceipt(changes: readonly Change[]): ReceiptResult<BeetsLiquidityOutcome> {
+    let added: BeetsLiquidityOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer" || !sameAddress(change.address, BEETS_VAULT_ADDRESS)) {
+        return this.erc20.changesReceipt([change]);
+      }
+      const event = decodeBeetsEvent(BeetsVaultAbi, change);
+      if (event.eventName !== "LiquidityAdded") {
+        throw new Error(`Unexpected Change: Beets Vault emitted ${event.eventName}`);
+      }
+      if (added) throw new Error("Beets add emitted multiple Vault LiquidityAdded events");
+      added = {
+        operation: "addLiquidity",
+        pool: event.args.pool,
+        provider: event.args.liquidityProvider,
+        kind: Number(event.args.kind),
+        amounts: event.args.amountsAddedRaw.map(String),
+        swapFees: event.args.swapFeeAmountsRaw.map(String),
+        totalBptSupply: event.args.totalSupply.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: added,
+        text: `Beets Add Liquidity: ${added.amounts.length} token amounts into pool ${added.pool} by ${added.provider}`,
+      };
+    });
+    if (!added) throw new Error("Beets add Receipt requires a Vault LiquidityAdded event");
+    return {
+      kind: "receipt",
+      outcome: added,
+      text: `Beets Add Liquidity: ${added.amounts.length} token amounts into pool ${added.pool} by ${added.provider}`,
+      changes: parsed,
+    };
+  }
+
+  quoteRemoveLiquidity(params: RemoveParams, ctx: ActionCtx): Promise<object>;
+  @Query({
+    intent: "Quote a Beets single-token removal of {bptAmountIn} BPT from pool {pool}",
+    params: removeLiquidityParams,
+    tags: ["amm", "balancer", "liquidity", "quote"],
+  })
+  async quoteRemoveLiquidity(params: RemoveParams, ctx: ActionCtx) {
+    const prepared = await this.#prepareRemoveLiquidity(params, ctx.account);
+    return {
+      pool: prepared.pool,
+      tokenOut: params.tokenOut,
+      bptAmountIn: params.bptAmountIn,
+      estimatedAmountOut: prepared.estimatedAmountOut.toString(),
+      minimumAmountOut: prepared.minimumAmountOut.toString(),
+    };
+  }
+
+  removeLiquidity(params: RemoveParams, ctx: ActionCtx): Promise<CapabilityResult>;
+  @Capability<Beets, typeof removeLiquidityParams>({
+    intent:
+      "Remove {bptAmountIn} BPT from Beets pool {pool} for {tokenOut}, tolerating {slippage} bps slippage",
+    verb: "withdraw",
+    params: removeLiquidityParams,
+    receipt: "removeLiquidityReceipt",
+    risk: ["fundOut", "priceImpact"],
+    tags: ["amm", "balancer", "liquidity"],
+  })
+  async removeLiquidity(params: RemoveParams, ctx: ActionCtx): Promise<CapabilityResult> {
+    const prepared = await this.#prepareRemoveLiquidity(params, ctx.account);
+    return [
+      this.router.removeLiquiditySingleTokenExactIn(
+        [
+          prepared.pool,
+          prepared.bptAmountIn,
+          prepared.tokenOut,
+          prepared.minimumAmountOut,
+          prepared.wethIsEth,
+          "0x",
+        ],
+        {},
+      ),
+    ];
+  }
+
+  @Receipt()
+  removeLiquidityReceipt(changes: readonly Change[]): ReceiptResult<BeetsLiquidityOutcome> {
+    let removed: BeetsLiquidityOutcome | undefined;
+    const parsed = changes.map((change) => {
+      if (change.kind === "nativeTransfer" || !sameAddress(change.address, BEETS_VAULT_ADDRESS)) {
+        return this.erc20.changesReceipt([change]);
+      }
+      const event = decodeBeetsEvent(BeetsVaultAbi, change);
+      if (event.eventName !== "LiquidityRemoved") {
+        throw new Error(`Unexpected Change: Beets Vault emitted ${event.eventName}`);
+      }
+      if (removed) throw new Error("Beets remove emitted multiple Vault LiquidityRemoved events");
+      removed = {
+        operation: "removeLiquidity",
+        pool: event.args.pool,
+        provider: event.args.liquidityProvider,
+        kind: Number(event.args.kind),
+        amounts: event.args.amountsRemovedRaw.map(String),
+        swapFees: event.args.swapFeeAmountsRaw.map(String),
+        totalBptSupply: event.args.totalSupply.toString(),
+      };
+      return {
+        kind: "change" as const,
+        change,
+        data: removed,
+        text: `Beets Remove Liquidity: ${removed.amounts.length} token amounts from pool ${removed.pool} by ${removed.provider}`,
+      };
+    });
+    if (!removed) throw new Error("Beets remove Receipt requires a Vault LiquidityRemoved event");
+    return {
+      kind: "receipt",
+      outcome: removed,
+      text: `Beets Remove Liquidity: ${removed.amounts.length} token amounts from pool ${removed.pool} by ${removed.provider}`,
+      changes: parsed,
+    };
+  }
+
+  @Query({
+    intent: "Inspect Beets pool {pool}: tokens, raw balances, and static swap fee",
+    params: poolParams,
+    tags: ["amm", "balancer", "pool"],
+  })
+  async pool(params: InferParams<typeof poolParams>, ctx: ActionCtx) {
+    const explorer = this.#vaultExplorer(ctx.account);
+    const [tokens, , balancesRaw] = await explorer.read.getPoolTokenInfo([params.pool]);
+    const staticSwapFeePercentage = await explorer.read.getStaticSwapFeePercentage([params.pool]);
+    return {
+      pool: params.pool,
+      tokens,
+      balancesRaw: balancesRaw.map(String),
+      staticSwapFeePercentage: staticSwapFeePercentage.toString(),
+    };
+  }
+
+  async #prepareSwap(params: SwapParams, account: AddressValue): Promise<PreparedSwap> {
+    const tokenIn = resolvedToken(params.tokenIn);
+    const tokenOut = resolvedToken(params.tokenOut);
+    if (sameAddress(tokenIn, tokenOut)) {
+      throw new ParameterError("tokenIn and tokenOut must differ");
+    }
+    const poolTokens = await this.#poolTokens(params.pool, account);
+    if (!poolTokens.some((token) => sameAddress(token, tokenIn))) {
+      throw new ParameterError(`tokenIn is not a token of pool ${params.pool}`);
+    }
+    if (!poolTokens.some((token) => sameAddress(token, tokenOut))) {
+      throw new ParameterError(`tokenOut is not a token of pool ${params.pool}`);
+    }
+    const inputDecimals = await this.#decimals(tokenIn, account);
+    const outputDecimals = await this.#decimals(tokenOut, account);
+    const side = amountSide(params);
+    const slippage = BigInt(params.slippage ?? DEFAULT_SLIPPAGE_BPS);
+    const wethIsEth = params.tokenIn === NATIVE || params.tokenOut === NATIVE;
+
+    if (side.kind === "amountIn") {
+      const amountIn = parseUnits(side.amount, inputDecimals);
+      const estimated = (await this.router.call.querySwapSingleTokenExactIn(
+        [params.pool, tokenIn, tokenOut, amountIn, account, "0x"],
+        { from: QUERY_ACCOUNT },
+      )) as bigint;
+      const minimumAmountOut = (estimated * (10_000n - slippage)) / 10_000n;
+      return {
+        side: "amountIn",
+        pool: params.pool,
+        tokenIn,
+        tokenOut,
+        inputDecimals,
+        outputDecimals,
+        executionAmountIn: amountIn,
+        estimatedAmountOut: estimated,
+        minimumAmountOut,
+        estimatedAmountIn: amountIn,
+        wethIsEth,
+        nativeIn: params.tokenIn === NATIVE,
+      };
+    }
+
+    const amountOut = parseUnits(side.amount, outputDecimals);
+    const required = (await this.router.call.querySwapSingleTokenExactOut(
+      [params.pool, tokenIn, tokenOut, amountOut, account, "0x"],
+      { from: QUERY_ACCOUNT },
+    )) as bigint;
+    const executionAmountIn = (required * (10_000n + slippage) + 9_999n) / 10_000n;
+    return {
+      side: "amountOut",
+      pool: params.pool,
+      tokenIn,
+      tokenOut,
+      inputDecimals,
+      outputDecimals,
+      executionAmountIn,
+      estimatedAmountOut: amountOut,
+      minimumAmountOut: amountOut,
+      estimatedAmountIn: required,
+      wethIsEth,
+      nativeIn: params.tokenIn === NATIVE,
+    };
+  }
+
+  async #prepareAddLiquidity(
+    params: AddParams,
+    account: AddressValue,
+  ): Promise<PreparedAddLiquidity> {
+    const tokenIn = resolvedToken(params.tokenIn);
+    const poolTokens = await this.#poolTokens(params.pool, account);
+    const index = poolTokens.findIndex((token) => sameAddress(token, tokenIn));
+    if (index < 0) throw new ParameterError(`tokenIn is not a token of pool ${params.pool}`);
+    const decimals = await this.#decimals(tokenIn, account);
+    const amountIn = parseUnits(params.amountIn, decimals);
+    const exactAmountsIn = poolTokens.map((_token, i) => (i === index ? amountIn : 0n));
+    const quoted = (await this.router.call.queryAddLiquidityUnbalanced(
+      [params.pool, exactAmountsIn, account, "0x"],
+      { from: QUERY_ACCOUNT },
+    )) as bigint;
+    const minBptAmountOut = (quoted * (10_000n - BigInt(params.slippage))) / 10_000n;
+    return {
+      pool: params.pool,
+      tokenIn,
+      amountIn,
+      exactAmountsIn,
+      estimatedBptOut: quoted,
+      minBptAmountOut,
+      wethIsEth: params.tokenIn === NATIVE,
+      nativeIn: params.tokenIn === NATIVE,
+    };
+  }
+
+  async #prepareRemoveLiquidity(
+    params: RemoveParams,
+    account: AddressValue,
+  ): Promise<PreparedRemoveLiquidity> {
+    const tokenOut = resolvedToken(params.tokenOut);
+    const poolTokens = await this.#poolTokens(params.pool, account);
+    if (!poolTokens.some((token) => sameAddress(token, tokenOut))) {
+      throw new ParameterError(`tokenOut is not a token of pool ${params.pool}`);
+    }
+    const bptDecimals = await this.#decimals(params.pool, account);
+    const bptAmountIn = parseUnits(params.bptAmountIn, bptDecimals);
+    const quoted = (await this.router.call.queryRemoveLiquiditySingleTokenExactIn(
+      [params.pool, bptAmountIn, tokenOut, account, "0x"],
+      { from: QUERY_ACCOUNT },
+    )) as bigint;
+    const minimumAmountOut = (quoted * (10_000n - BigInt(params.slippage))) / 10_000n;
+    return {
+      pool: params.pool,
+      tokenOut,
+      bptAmountIn,
+      estimatedAmountOut: quoted,
+      minimumAmountOut,
+      wethIsEth: params.tokenOut === NATIVE,
+    };
+  }
+
+  async #poolTokens(pool: AddressValue, account: AddressValue): Promise<readonly AddressValue[]> {
+    return this.#vaultExplorer(account).read.getPoolTokens([pool]);
+  }
+
+  #vaultExplorer(account: AddressValue): Handle<typeof BeetsVaultExplorerAbi> {
+    return createHandle(
+      BeetsVaultExplorerAbi,
+      BEETS_VAULT_EXPLORER_ADDRESS,
+      this.runtime.client,
+      account,
+    );
+  }
+
+  async #decimals(token: AddressValue, account: AddressValue): Promise<number> {
+    const handle = createHandle(ERC20Abi, token, this.runtime.client, account);
+    const decimals = await handle.read.decimals();
+    if (decimals > 255n) throw new Error(`token ${token} reports invalid decimals`);
+    return Number(decimals);
+  }
+}
+
+function deadlineTimestamp(): bigint {
+  return BigInt(Math.floor(Date.now() / 1000) + DEFAULT_DEADLINE_SECONDS);
+}
+
+function resolvedToken(token: TokenRef): AddressValue {
+  return token === NATIVE ? WMON_ADDRESS : token;
+}
+
+function amountSide(params: SwapParams) {
+  if (params.amountIn !== undefined && params.amountOut === undefined) {
+    return { kind: "amountIn", amount: params.amountIn } as const;
+  }
+  if (params.amountOut !== undefined && params.amountIn === undefined) {
+    return { kind: "amountOut", amount: params.amountOut } as const;
+  }
+  throw new ParameterError("provide exactly one of amountIn or amountOut");
+}
+
+function sameAddress(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function wethNormalize(token: AddressValue, amount: bigint, changes: readonly Change[]): TokenRef {
+  if (!sameAddress(token, WMON_ADDRESS)) return token;
+  const nativeMatch = changes.some(
+    (change) => change.kind === "nativeTransfer" && change.value === amount.toString(),
+  );
+  return nativeMatch ? NATIVE : token;
+}
+
+function tryDecodeBeetsEvent<TAbi extends typeof BeetsVaultAbi>(
+  abi: TAbi,
+  change: Extract<Change, { kind: "event" }>,
+) {
+  try {
+    return decodeEventLog({
+      abi,
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeBeetsEvent<TAbi extends typeof BeetsVaultAbi>(
+  abi: TAbi,
+  change: Extract<Change, { kind: "event" }>,
+) {
+  const event = tryDecodeBeetsEvent(abi, change);
+  if (!event)
+    throw new Error(`Unexpected Change: ${change.address} emitted an unsupported Beets event`);
+  return event;
+}

--- a/packages/protocols/beets/src/index.ts
+++ b/packages/protocols/beets/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  BeetsRouterAbi,
+  BeetsVaultAbi,
+  BeetsVaultExplorerAbi,
+  BeetsVaultExtensionAbi,
+} from "./abis/beets.js";
+export {
+  BEETS_ROUTER_ADDRESS,
+  BEETS_VAULT_ADDRESS,
+  BEETS_VAULT_EXPLORER_ADDRESS,
+  BEETS_VAULT_EXTENSION_ADDRESS,
+  Beets,
+} from "./beets.js";
+export type { BeetsLiquidityOutcome, BeetsSwapOutcome, BeetsSwapQuote } from "./types.js";

--- a/packages/protocols/beets/src/types.ts
+++ b/packages/protocols/beets/src/types.ts
@@ -1,0 +1,45 @@
+import type { AddressValue, TokenRef } from "@themoss/core";
+
+export type BeetsSwapOutcome = {
+  operation: "swap";
+  pool: AddressValue;
+  tokenIn: TokenRef;
+  tokenOut: TokenRef;
+  amountIn: string;
+  amountOut: string;
+  swapFeePercentage: string;
+  swapFeeAmount: string;
+};
+
+export type BeetsLiquidityOutcome = {
+  operation: "addLiquidity" | "removeLiquidity";
+  pool: AddressValue;
+  provider: AddressValue;
+  kind: number;
+  /** Raw per-token amounts in the pool's canonical token order (see pool).
+   * The pure Receipt parser cannot resolve token addresses by itself, so
+   * names come from the `pool` Query for the same pool. */
+  amounts: readonly string[];
+  swapFees: readonly string[];
+  totalBptSupply: string;
+};
+
+export type BeetsSwapQuote =
+  | {
+      pool: AddressValue;
+      amountSide: "amountIn";
+      tokenIn: TokenRef;
+      tokenOut: TokenRef;
+      amountIn: string;
+      estimatedAmountOut: string;
+      minimumAmountOut: string;
+    }
+  | {
+      pool: AddressValue;
+      amountSide: "amountOut";
+      tokenIn: TokenRef;
+      tokenOut: TokenRef;
+      estimatedAmountIn: string;
+      maximumAmountIn: string;
+      amountOut: string;
+    };

--- a/packages/protocols/beets/test-online/abi-explorer.test.ts
+++ b/packages/protocols/beets/test-online/abi-explorer.test.ts
@@ -1,0 +1,189 @@
+/**
+ * On-chain derivation checks for the vendored Beets ABIs (ADR 0007).
+ *
+ * The Balancer v3 Router, Vault, VaultExtension, and VaultExplorer on Monad
+ * are plain (non-proxy) contracts, so there are no ERC-1967 slots to pin.
+ * This suite instead enforces the derivation directly against Monad mainnet:
+ *
+ * - every address recorded in abis.json matches the adapter's constant;
+ * - all four contracts have deployed bytecode;
+ * - the VaultExplorer's getVault()/getVaultExtension() still return the
+ *   Vault and VaultExtension recorded in abis.json — a Balancer re-deploy
+ *   turns this suite red so a human re-verifies the vendored ABIs before
+ *   trusting them again (the Router v2 ABI exposes no getVault, so the
+ *   explorer is the pinned surface, exactly as the e2e suite uses it);
+ * - every function selector and event topic hash the adapter actually uses,
+ *   recomputed from the artifact, appears in the deployed bytecode. The
+ *   artifacts declare the full shared Balancer interface (Vault and
+ *   VaultExtension are one implementation split over delegatecall, and the
+ *   VaultExplorer artifact carries the whole view surface), so only the used
+ *   items are pinned;
+ * - the VaultExplorer can still answer getPoolTokens for the live
+ *   WMON/gMON pool the e2e suite quotes against.
+ *
+ * Requires Monad mainnet RPC; runs only via `pnpm test:abi:online`.
+ * If MonadScan verifies the source, replace this with the keyed
+ * fetchAbi + compareDeployedAbi cross-check used by protocol-kuru.
+ */
+
+import { readFileSync } from "node:fs";
+import { createRuntime } from "@themoss/core";
+import { type Address, getAddress, toEventSelector, toFunctionSelector } from "viem";
+import { describe, expect, it } from "vitest";
+import {
+  BeetsRouterAbi,
+  BeetsVaultAbi,
+  BeetsVaultExplorerAbi,
+  BeetsVaultExtensionAbi,
+} from "../src/abis/beets.js";
+import {
+  BEETS_ROUTER_ADDRESS,
+  BEETS_VAULT_ADDRESS,
+  BEETS_VAULT_EXPLORER_ADDRESS,
+  BEETS_VAULT_EXTENSION_ADDRESS,
+} from "../src/index.js";
+
+interface AbiManifest {
+  router: { address: Address };
+  vault: { address: Address };
+  vaultExtension: { address: Address };
+  vaultExplorer: { address: Address };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
+) as AbiManifest;
+
+const CONTRACTS = [
+  { name: "router", address: manifest.router.address, abi: BeetsRouterAbi },
+  { name: "vault", address: manifest.vault.address, abi: BeetsVaultAbi },
+  { name: "vaultExtension", address: manifest.vaultExtension.address, abi: BeetsVaultExtensionAbi },
+  { name: "vaultExplorer", address: manifest.vaultExplorer.address, abi: BeetsVaultExplorerAbi },
+] as const;
+
+describe("Beets ABI on-chain derivation", () => {
+  it("pins the contracts the adapter actually uses", () => {
+    expect(getAddress(manifest.router.address)).toBe(getAddress(BEETS_ROUTER_ADDRESS));
+    expect(getAddress(manifest.vault.address)).toBe(getAddress(BEETS_VAULT_ADDRESS));
+    expect(getAddress(manifest.vaultExtension.address)).toBe(
+      getAddress(BEETS_VAULT_EXTENSION_ADDRESS),
+    );
+    expect(getAddress(manifest.vaultExplorer.address)).toBe(
+      getAddress(BEETS_VAULT_EXPLORER_ADDRESS),
+    );
+  });
+
+  it("has deployed bytecode at all four addresses", { timeout: 60_000 }, async () => {
+    const runtime = await createRuntime();
+    for (const contract of CONTRACTS) {
+      expect(
+        (await runtime.client.getCode({ address: contract.address }))?.length,
+        contract.name,
+      ).toBeGreaterThan(2);
+    }
+  });
+
+  it("Router still points at the Vault recorded in abis.json", { timeout: 60_000 }, async () => {
+    const runtime = await createRuntime();
+    // The Router v2 ABI has no getVault; the VaultExplorer is the pinned
+    // surface for the Vault, exactly as the e2e suite uses it.
+    const vault = (await runtime.client.readContract({
+      address: manifest.vaultExplorer.address,
+      abi: BeetsVaultExplorerAbi,
+      functionName: "getVault",
+    })) as Address;
+    const vaultExtension = (await runtime.client.readContract({
+      address: manifest.vaultExplorer.address,
+      abi: BeetsVaultExplorerAbi,
+      functionName: "getVaultExtension",
+    })) as Address;
+    expect(getAddress(vault)).toBe(getAddress(manifest.vault.address));
+    expect(getAddress(vaultExtension)).toBe(getAddress(manifest.vaultExtension.address));
+  });
+
+  it("every selector and topic hash the adapter uses appears in the deployed bytecode", {
+    timeout: 120_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    // The artifacts declare the full shared Balancer interface (Vault and
+    // VaultExtension are one implementation split over delegatecall, and the
+    // VaultExplorer artifact carries the whole view surface), so only the
+    // items the adapter actually calls or decodes are pinned here — that is
+    // the surface a re-deploy must not break.
+    const used: Record<string, { functions: readonly string[]; events: readonly string[] }> = {
+      router: {
+        functions: [
+          "swapSingleTokenExactIn",
+          "swapSingleTokenExactOut",
+          "addLiquidityUnbalanced",
+          "removeLiquiditySingleTokenExactIn",
+          "querySwapSingleTokenExactIn",
+          "querySwapSingleTokenExactOut",
+          "queryAddLiquidityUnbalanced",
+          "queryRemoveLiquiditySingleTokenExactIn",
+        ],
+        events: [],
+      },
+      vault: { functions: [], events: ["Swap", "LiquidityAdded", "LiquidityRemoved"] },
+      vaultExtension: { functions: [], events: [] },
+      vaultExplorer: {
+        functions: [
+          "getPoolTokenInfo",
+          "getStaticSwapFeePercentage",
+          "getPoolTokens",
+          "getVault",
+          "getVaultExtension",
+        ],
+        events: [],
+      },
+    };
+    for (const contract of CONTRACTS) {
+      const code = await runtime.client.getCode({ address: contract.address });
+      expect(code?.length ?? 0, contract.name).toBeGreaterThan(2);
+      const haystack = (code ?? "0x").toLowerCase();
+      const want = used[contract.name];
+      if (!want) throw new Error(`no adapter-used ABI items declared for ${contract.name}`);
+      for (const name of want.functions) {
+        const item = contract.abi.find(
+          (entry): entry is Extract<(typeof contract.abi)[number], { type: "function" }> =>
+            entry.type === "function" && entry.name === name,
+        );
+        if (!item) throw new Error(`${contract.name} ABI lacks function ${name}`);
+        const needle = toFunctionSelector(item).slice(2);
+        expect(
+          haystack,
+          `${contract.name} function ${name} (${needle}) missing from bytecode`,
+        ).toContain(needle.toLowerCase());
+      }
+      for (const name of want.events) {
+        const item = contract.abi.find(
+          (entry): entry is Extract<(typeof contract.abi)[number], { type: "event" }> =>
+            entry.type === "event" && entry.name === name,
+        );
+        if (!item) throw new Error(`${contract.name} ABI lacks event ${name}`);
+        const needle = toEventSelector(item).slice(2);
+        expect(
+          haystack,
+          `${contract.name} event ${name} (${needle}) missing from bytecode`,
+        ).toContain(needle.toLowerCase());
+      }
+    }
+  });
+
+  it("VaultExplorer answers getPoolTokens for the live WMON/gMON pool", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    const tokens = (await runtime.client.readContract({
+      address: manifest.vaultExplorer.address,
+      abi: BeetsVaultExplorerAbi,
+      functionName: "getPoolTokens",
+      args: [getAddress("0x66b7b2389ccedF5f0F5217b7811741344b34b4fA")],
+    })) as Address[];
+    // Note: `.map(getAddress)` would pass the array index as viem's chainId
+    // argument (EIP-1191 checksumming); wrap in a lambda instead.
+    const normalized = tokens.map((token) => getAddress(token));
+    expect(normalized).toContain(getAddress("0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A"));
+    expect(normalized).toContain(getAddress("0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081"));
+  });
+});

--- a/packages/protocols/beets/test/abis.test.ts
+++ b/packages/protocols/beets/test/abis.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { generate } from "../scripts/abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// The provenance chain, enforced: the committed generated TS must be exactly
+// what the deterministic generator derives from the committed abis-src/.
+// Fails on: hand-edits to src/abis/beets.ts, generator edits without
+// `pnpm gen:abis`, abis-src/ edits without regeneration.
+describe("abi provenance chain", () => {
+  it("src/abis/beets.ts derives byte-for-byte from abis-src/", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "beets.ts"), "utf8");
+    expect(committed).toBe(generate(packageRoot));
+  });
+});

--- a/packages/protocols/beets/test/beets.test.ts
+++ b/packages/protocols/beets/test/beets.test.ts
@@ -1,0 +1,609 @@
+import {
+  type Change,
+  createRuntime,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  NATIVE,
+  type ReceiptResult,
+  Registry,
+} from "@themoss/core";
+import { ERC20Abi } from "@themoss/erc";
+import { AUSD_ADDRESS, USDC_ADDRESS, WMON_ADDRESS } from "@themoss/system";
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  encodeFunctionResult,
+  getAddress,
+} from "viem";
+import { describe, expect, it } from "vitest";
+import { BeetsRouterAbi, BeetsVaultAbi, BeetsVaultExplorerAbi } from "../src/abis/beets.js";
+import {
+  BEETS_ROUTER_ADDRESS,
+  BEETS_VAULT_ADDRESS,
+  BEETS_VAULT_EXPLORER_ADDRESS,
+  BEETS_VAULT_EXTENSION_ADDRESS,
+  Beets,
+} from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const POOL = getAddress("0x1111111111111111111111111111111111111111");
+const POOL_TOKENS = [WMON_ADDRESS, USDC_ADDRESS, AUSD_ADDRESS] as const;
+const BALANCES = [1_000_000_000_000_000_000_000n, 1_000_000_000n, 1_000_000_000n];
+const GMON_ADDRESS = getAddress("0x8498312A6B3CbD158bf0c93AbdCF29E6e4F55081");
+const LIVE_WMON_GMON_POOL = getAddress("0x66b7b2389ccedF5f0F5217b7811741344b34b4fA");
+
+const DECIMALS: Record<string, number> = {
+  [WMON_ADDRESS.toLowerCase()]: 18,
+  [USDC_ADDRESS.toLowerCase()]: 6,
+  [AUSD_ADDRESS.toLowerCase()]: 6,
+  [POOL.toLowerCase()]: 18,
+};
+
+describe("Beets", () => {
+  it("loads the swap surface with human amounts and slippage defaults", async () => {
+    const { registry } = offlineRegistry();
+    const [loaded] = registry.load([{ protocol: "beets", method: "swap" }]);
+    expect(loaded?.params.amountIn).toMatchObject({
+      description: expect.stringContaining("Fixed input"),
+      type: { description: expect.stringContaining("display units") },
+    });
+    expect(loaded?.params.amountOut).toMatchObject({
+      description: expect.stringContaining("Minimum output"),
+    });
+    expect(loaded?.params.slippage).toMatchObject({
+      type: { default: 50, minimum: 50, maximum: 5_000 },
+    });
+    await expect(
+      registry.action("beets", "swap", ACCOUNT, {
+        pool: POOL,
+        tokenIn: USDC_ADDRESS,
+        tokenOut: AUSD_ADDRESS,
+      }),
+    ).rejects.toThrow("provide exactly one of amountIn or amountOut");
+    await expect(
+      registry.action("beets", "swap", ACCOUNT, {
+        pool: POOL,
+        tokenIn: USDC_ADDRESS,
+        tokenOut: AUSD_ADDRESS,
+        amountIn: "1",
+        amountOut: "1",
+      }),
+    ).rejects.toThrow("provide exactly one of amountIn or amountOut");
+    for (const slippage of [49, 5_001]) {
+      await expect(
+        registry.action("beets", "swap", ACCOUNT, {
+          pool: POOL,
+          tokenIn: USDC_ADDRESS,
+          tokenOut: AUSD_ADDRESS,
+          amountIn: "1",
+          slippage,
+        }),
+      ).rejects.toThrow();
+    }
+  });
+
+  it("rejects tokens outside the pool and identical sides", async () => {
+    const { registry } = offlineRegistry();
+    await expect(
+      registry.action("beets", "swap", ACCOUNT, {
+        pool: POOL,
+        tokenIn: USDC_ADDRESS,
+        tokenOut: getAddress("0x9999999999999999999999999999999999999999"),
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("tokenOut is not a token of pool");
+    await expect(
+      registry.action("beets", "swap", ACCOUNT, {
+        pool: POOL,
+        tokenIn: USDC_ADDRESS,
+        tokenOut: USDC_ADDRESS,
+        amountIn: "1",
+      }),
+    ).rejects.toThrow("tokenIn and tokenOut must differ");
+  });
+
+  it("builds approve + swapSingleTokenExactIn for an ERC20 exact-in swap", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("beets", "swap", ACCOUNT, {
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1.5",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const [approval, swap] = flattenCapabilityTree(capability);
+    if (!approval || !swap) throw new Error("missing Beets transactions");
+    expect(decodeFunctionData({ abi: ERC20Abi, data: approval.transaction.data })).toMatchObject({
+      functionName: "approve",
+      args: [BEETS_ROUTER_ADDRESS, 1_500_000n],
+    });
+    const decoded = decodeFunctionData({ abi: BeetsRouterAbi, data: swap.transaction.data });
+    expect(decoded.functionName).toBe("swapSingleTokenExactIn");
+    expect(decoded.args.slice(0, 6)).toEqual([
+      POOL,
+      USDC_ADDRESS,
+      AUSD_ADDRESS,
+      1_500_000n,
+      1_492_500n,
+      expect.any(BigInt),
+    ]);
+    expect(decoded.args.slice(6)).toEqual([false, "0x"]);
+    expect(swap.transaction.value).toBe("0x0");
+  });
+
+  it("forwards native MON and sets wethIsEth for a native-in exact-in swap", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("beets", "swap", ACCOUNT, {
+      pool: POOL,
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "2",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const nodes = flattenCapabilityTree(capability);
+    expect(nodes).toHaveLength(1); // no approval for native input
+    const decoded = decodeFunctionData({
+      abi: BeetsRouterAbi,
+      data: nodes[0]?.transaction.data ?? "0x",
+    });
+    expect(decoded.functionName).toBe("swapSingleTokenExactIn");
+    expect(decoded.args.slice(1, 4)).toEqual([
+      WMON_ADDRESS,
+      USDC_ADDRESS,
+      2_000_000_000_000_000_000n,
+    ]);
+    expect(decoded.args[6]).toBe(true);
+    expect(nodes[0]?.transaction.value).toBe("0x1bc16d674ec80000");
+  });
+
+  it("reverse-quotes an exact-out swap with input headroom", async () => {
+    const { registry } = offlineRegistry();
+    const quote = await registry.action("beets", "quote", ACCOUNT, {
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountOut: "1.2",
+    });
+    if (quote.kind !== "query") throw new Error("expected query");
+    expect(quote.data).toEqual({
+      pool: POOL,
+      amountSide: "amountOut",
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      estimatedAmountIn: "1.2",
+      maximumAmountIn: "1.206",
+      amountOut: "1.2",
+    });
+
+    const capability = await registry.action("beets", "swap", ACCOUNT, {
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountOut: "1.2",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const swap = flattenCapabilityTree(capability).at(-1);
+    if (!swap) throw new Error("missing Beets transaction");
+    const decoded = decodeFunctionData({ abi: BeetsRouterAbi, data: swap.transaction.data });
+    expect(decoded.functionName).toBe("swapSingleTokenExactOut");
+    expect(decoded.args.slice(3, 5)).toEqual([1_200_000n, 1_206_000n]);
+  });
+
+  it("places the single deposit amount at the pool token index", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("beets", "addLiquidity", ACCOUNT, {
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      amountIn: "5",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const [approval, add] = flattenCapabilityTree(capability);
+    if (!approval || !add) throw new Error("missing Beets transactions");
+    expect(decodeFunctionData({ abi: ERC20Abi, data: approval.transaction.data })).toMatchObject({
+      functionName: "approve",
+      args: [BEETS_ROUTER_ADDRESS, 5_000_000n],
+    });
+    const decoded = decodeFunctionData({ abi: BeetsRouterAbi, data: add.transaction.data });
+    expect(decoded.functionName).toBe("addLiquidityUnbalanced");
+    expect(decoded.args.slice(0, 3)).toEqual([POOL, [0n, 5_000_000n, 0n], expect.any(BigInt)]);
+    expect(decoded.args.slice(3)).toEqual([false, "0x"]);
+  });
+
+  it("quotes add liquidity from the Router and enforces a minimum BPT", async () => {
+    const { registry } = offlineRegistry();
+    const quote = await registry.action("beets", "quoteAddLiquidity", ACCOUNT, {
+      pool: POOL,
+      tokenIn: NATIVE,
+      amountIn: "1",
+    });
+    if (quote.kind !== "query") throw new Error("expected query");
+    expect(quote.data).toEqual({
+      pool: POOL,
+      tokenIn: NATIVE,
+      amountIn: "1",
+      estimatedBptOut: "1000000000000000000",
+      minimumBptOut: "995000000000000000",
+    });
+    const capability = await registry.action("beets", "addLiquidity", ACCOUNT, {
+      pool: POOL,
+      tokenIn: NATIVE,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const [add] = flattenCapabilityTree(capability);
+    if (!add) throw new Error("missing Beets transaction");
+    const decoded = decodeFunctionData({ abi: BeetsRouterAbi, data: add.transaction.data });
+    expect(decoded.args.slice(0, 3)).toEqual([
+      POOL,
+      [1_000_000_000_000_000_000n, 0n, 0n],
+      995_000_000_000_000_000n,
+    ]);
+    expect(decoded.args[3]).toBe(true);
+    expect(add.transaction.value).toBe("0xde0b6b3a7640000");
+  });
+
+  it("removes liquidity single-token without any approval", async () => {
+    const { registry } = offlineRegistry();
+    const quote = await registry.action("beets", "quoteRemoveLiquidity", ACCOUNT, {
+      pool: POOL,
+      tokenOut: USDC_ADDRESS,
+      bptAmountIn: "0.5",
+    });
+    if (quote.kind !== "query") throw new Error("expected query");
+    expect(quote.data).toEqual({
+      pool: POOL,
+      tokenOut: USDC_ADDRESS,
+      bptAmountIn: "0.5",
+      estimatedAmountOut: "500000000000000000",
+      minimumAmountOut: "497500000000000000",
+    });
+    const capability = await registry.action("beets", "removeLiquidity", ACCOUNT, {
+      pool: POOL,
+      tokenOut: USDC_ADDRESS,
+      bptAmountIn: "0.5",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const [remove] = flattenCapabilityTree(capability);
+    if (!remove) throw new Error("missing Beets transaction");
+    const decoded = decodeFunctionData({ abi: BeetsRouterAbi, data: remove.transaction.data });
+    expect(decoded.functionName).toBe("removeLiquiditySingleTokenExactIn");
+    expect(decoded.args.slice(0, 4)).toEqual([
+      POOL,
+      500_000_000_000_000_000n,
+      USDC_ADDRESS,
+      497_500_000_000_000_000n,
+    ]);
+    expect(decoded.args.slice(4)).toEqual([false, "0x"]);
+  });
+
+  it("parses an ERC20 swap receipt from Vault Swap + Transfer changes", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("beets", "swap", ACCOUNT, {
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const transferIn = erc20Transfer(USDC_ADDRESS, ACCOUNT, BEETS_VAULT_ADDRESS, 1_000_000n);
+    const swapEvent = vaultSwapChange(POOL, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 990_000n);
+    const transferOut = erc20Transfer(AUSD_ADDRESS, BEETS_VAULT_ADDRESS, ACCOUNT, 990_000n);
+
+    const receipt = registry.parseReceipt(capability, [transferIn, swapEvent, transferOut]);
+    expect(receipt.outcome).toEqual({
+      operation: "swap",
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1000000",
+      amountOut: "990000",
+      swapFeePercentage: "1000000",
+      swapFeeAmount: "10000",
+    });
+    expect(receipt.changes.map(firstChange)).toEqual([transferIn, swapEvent, transferOut]);
+  });
+
+  it("labels native flows in the swap receipt when a matching native transfer exists", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("beets", "swap", ACCOUNT, {
+      pool: POOL,
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: BEETS_ROUTER_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+    const swapEvent = vaultSwapChange(
+      POOL,
+      WMON_ADDRESS,
+      USDC_ADDRESS,
+      1_000_000_000_000_000_000n,
+      1_000_000n,
+    );
+    const receipt = registry.parseReceipt(capability, [native, swapEvent]);
+    expect(receipt.outcome).toMatchObject({
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1000000000000000000",
+    });
+  });
+
+  it("keeps WMON in the swap receipt when no native transfer matches", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("beets", "swap", ACCOUNT, {
+      pool: POOL,
+      tokenIn: WMON_ADDRESS,
+      tokenOut: USDC_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const swapEvent = vaultSwapChange(
+      POOL,
+      WMON_ADDRESS,
+      USDC_ADDRESS,
+      1_000_000_000_000_000_000n,
+      1_000_000n,
+    );
+    const receipt = registry.parseReceipt(capability, [swapEvent]);
+    expect(receipt.outcome).toMatchObject({ tokenIn: WMON_ADDRESS });
+  });
+
+  it("parses add and remove liquidity receipts from Vault events", async () => {
+    const { registry } = offlineRegistry();
+    const add = await registry.action("beets", "addLiquidity", ACCOUNT, {
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      amountIn: "1",
+    });
+    if (add.kind !== "capability") throw new Error("expected capability");
+    const added = liquidityAddedChange(POOL, ACCOUNT, 0, [0n, 1_000_000n, 0n]);
+    const addReceipt = registry.parseReceipt(add, [added]);
+    expect(addReceipt.outcome).toEqual({
+      operation: "addLiquidity",
+      pool: POOL,
+      provider: ACCOUNT,
+      kind: 0,
+      amounts: ["0", "1000000", "0"],
+      swapFees: ["0", "0", "0"],
+      totalBptSupply: "1000000000000000000",
+    });
+
+    const remove = await registry.action("beets", "removeLiquidity", ACCOUNT, {
+      pool: POOL,
+      tokenOut: USDC_ADDRESS,
+      bptAmountIn: "0.5",
+    });
+    if (remove.kind !== "capability") throw new Error("expected capability");
+    const removed = liquidityRemovedChange(POOL, ACCOUNT, 1, [0n, 500_000n, 0n]);
+    const removeReceipt = registry.parseReceipt(remove, [removed]);
+    expect(removeReceipt.outcome).toMatchObject({
+      operation: "removeLiquidity",
+      kind: 1,
+      amounts: ["0", "500000", "0"],
+    });
+  });
+
+  it("rejects duplicate or mismatched Vault events in receipts", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await registry.action("beets", "swap", ACCOUNT, {
+      pool: POOL,
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const first = vaultSwapChange(POOL, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 990_000n);
+    const second = vaultSwapChange(POOL, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 991_000n);
+    expect(() => registry.parseReceipt(capability, [first, second])).toThrow(
+      "multiple Vault Swap events",
+    );
+    const removed = liquidityRemovedChange(POOL, ACCOUNT, 1, [0n, 500_000n, 0n]);
+    expect(() => registry.parseReceipt(capability, [removed])).toThrow(
+      "Beets Vault emitted LiquidityRemoved",
+    );
+    expect(() => registry.parseReceipt(capability, [])).toThrow("requires a Vault Swap event");
+  });
+
+  it("inspects pool tokens, balances, and the static swap fee", async () => {
+    const { registry } = offlineRegistry();
+    const query = await registry.action("beets", "pool", ACCOUNT, { pool: POOL });
+    if (query.kind !== "query") throw new Error("expected query");
+    expect(query.data).toEqual({
+      pool: POOL,
+      tokens: [...POOL_TOKENS],
+      balancesRaw: BALANCES.map(String),
+      staticSwapFeePercentage: "5000000000000000",
+    });
+  });
+});
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Beets mainnet", () => {
+  it("has deployed Router, Vault, VaultExtension, and VaultExplorer bytecode", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    for (const address of [
+      BEETS_ROUTER_ADDRESS,
+      BEETS_VAULT_ADDRESS,
+      BEETS_VAULT_EXTENSION_ADDRESS,
+      BEETS_VAULT_EXPLORER_ADDRESS,
+    ]) {
+      expect((await runtime.client.getCode({ address }))?.length).toBeGreaterThan(2);
+    }
+  });
+
+  it("pins the Vault and VaultExtension through the VaultExplorer", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    const [vault, extension] = await Promise.all([
+      runtime.client.readContract({
+        address: BEETS_VAULT_EXPLORER_ADDRESS,
+        abi: BeetsVaultExplorerAbi,
+        functionName: "getVault",
+      }),
+      runtime.client.readContract({
+        address: BEETS_VAULT_EXPLORER_ADDRESS,
+        abi: BeetsVaultExplorerAbi,
+        functionName: "getVaultExtension",
+      }),
+    ]);
+    expect(vault.toLowerCase()).toBe(BEETS_VAULT_ADDRESS.toLowerCase());
+    expect(extension.toLowerCase()).toBe(BEETS_VAULT_EXTENSION_ADDRESS.toLowerCase());
+  });
+
+  it("quotes a live native-to-gMON swap", { timeout: 60_000 }, async () => {
+    const runtime = await createRuntime();
+    const quote = await new Registry(runtime).use(Beets).action("beets", "quote", ACCOUNT, {
+      pool: LIVE_WMON_GMON_POOL,
+      tokenIn: NATIVE,
+      tokenOut: GMON_ADDRESS,
+      amountIn: "1",
+    });
+    if (quote.kind !== "query") throw new Error("expected query");
+    expect(quote.data).toMatchObject({ amountSide: "amountIn", amountIn: "1" });
+    expect((quote.data as { minimumAmountOut?: string }).minimumAmountOut).toBeTruthy();
+  });
+});
+
+function offlineRegistry() {
+  const client = {
+    readContract: async ({ address, functionName }: { address: string; functionName: string }) => {
+      if (functionName === "decimals") return BigInt(DECIMALS[address.toLowerCase()] ?? 18);
+      if (functionName === "getPoolTokens") return [...POOL_TOKENS];
+      if (functionName === "getPoolTokenInfo") return [[...POOL_TOKENS], [], [...BALANCES]];
+      if (functionName === "getStaticSwapFeePercentage") return 5_000_000_000_000_000n;
+      throw new Error(`unexpected read ${functionName}`);
+    },
+    call: async ({ to, data }: { to: string; data: Hex }) => {
+      if (to.toLowerCase() !== BEETS_ROUTER_ADDRESS.toLowerCase()) {
+        throw new Error(`unexpected call target ${to}`);
+      }
+      const decoded = decodeFunctionData({ abi: BeetsRouterAbi, data });
+      const args = decoded.args as readonly unknown[];
+      let result: bigint;
+      switch (decoded.functionName) {
+        case "querySwapSingleTokenExactIn":
+          result = args[3] as bigint;
+          break;
+        case "querySwapSingleTokenExactOut":
+          result = args[3] as bigint;
+          break;
+        case "queryAddLiquidityUnbalanced": {
+          const amounts = args[1] as readonly bigint[];
+          result = amounts.reduce((sum: bigint, amount: bigint) => sum + amount, 0n);
+          break;
+        }
+        case "queryRemoveLiquiditySingleTokenExactIn":
+          result = args[1] as bigint;
+          break;
+        default:
+          throw new Error(`unexpected call ${decoded.functionName}`);
+      }
+      return {
+        data: encodeFunctionResult({
+          abi: BeetsRouterAbi,
+          functionName: decoded.functionName,
+          result,
+        }),
+      };
+    },
+  } as unknown as MossRuntime["client"];
+  return { registry: new Registry({ rpcUrl: "http://offline", client }).use(Beets) };
+}
+
+function erc20Transfer(
+  token: `0x${string}`,
+  from: `0x${string}`,
+  to: `0x${string}`,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: token,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      args: { from, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function vaultSwapChange(
+  pool: `0x${string}`,
+  tokenIn: `0x${string}`,
+  tokenOut: `0x${string}`,
+  amountIn: bigint,
+  amountOut: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: BEETS_VAULT_ADDRESS,
+    topics: encodeEventTopics({
+      abi: BeetsVaultAbi,
+      eventName: "Swap",
+      args: { pool, tokenIn, tokenOut },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }, { type: "uint256" }, { type: "uint256" }],
+      [amountIn, amountOut, 1_000_000n, 10_000n],
+    ),
+  };
+}
+
+function liquidityAddedChange(
+  pool: `0x${string}`,
+  provider: `0x${string}`,
+  kind: number,
+  amounts: readonly bigint[],
+): Change {
+  return {
+    kind: "event",
+    address: BEETS_VAULT_ADDRESS,
+    topics: encodeEventTopics({
+      abi: BeetsVaultAbi,
+      eventName: "LiquidityAdded",
+      args: { pool, liquidityProvider: provider, kind },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256[]" }, { type: "uint256[]" }],
+      [1_000_000_000_000_000_000n, [...amounts], amounts.map(() => 0n)],
+    ),
+  };
+}
+
+function liquidityRemovedChange(
+  pool: `0x${string}`,
+  provider: `0x${string}`,
+  kind: number,
+  amounts: readonly bigint[],
+): Change {
+  return {
+    kind: "event",
+    address: BEETS_VAULT_ADDRESS,
+    topics: encodeEventTopics({
+      abi: BeetsVaultAbi,
+      eventName: "LiquidityRemoved",
+      args: { pool, liquidityProvider: provider, kind },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256[]" }, { type: "uint256[]" }],
+      [500_000_000_000_000_000n, [...amounts], amounts.map(() => 0n)],
+    ),
+  };
+}
+
+function firstChange(entry: ReceiptResult["changes"][number]): Change {
+  if (entry.kind === "change") return entry.change;
+  const [child] = entry.changes;
+  if (child?.kind !== "change") throw new Error("expected one nested ReceiptChange");
+  return child.change;
+}

--- a/packages/protocols/beets/tsconfig.json
+++ b/packages/protocols/beets/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test", "test-online", "scripts"]
+}

--- a/packages/protocols/beets/vitest.config.ts
+++ b/packages/protocols/beets/vitest.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  // Stage-3 decorators: V8 cannot parse them natively yet, so the esbuild
+  // transform must lower them (ADR 0001 toolchain constraint). This is also
+  // why the repo pins vitest 3 — vite 8's oxc does not lower them.
+  esbuild: { target: "es2022" },
+  // The keyed online explorer cross-check lives in test-online/ and runs only
+  // through vitest.online.config.ts (pnpm test:abi:online).
+  test: { include: ["test/**/*.test.ts"] },
+  resolve: {
+    // Tests run against workspace sources, not dists, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": src("../../core/src/index.ts"),
+      "@themoss/simulator": src("../../simulator/src/index.ts"),
+      "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/system": src("../../system/src/index.ts"),
+    },
+  },
+});

--- a/packages/protocols/beets/vitest.online.config.ts
+++ b/packages/protocols/beets/vitest.online.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+// The online explorer cross-check suite (pnpm test:abi:online). Kept apart
+// from the offline default so a missing MONADSCAN_API_KEY fails loudly here
+// without ever gating `pnpm test`.
+export default defineConfig({
+  esbuild: { target: "es2022" },
+  test: { include: ["test-online/**/*.test.ts"] },
+  resolve: {
+    // Tests run against workspace sources, not dists, so a stale build can
+    // never produce phantom failures.
+    alias: {
+      "@themoss/core": src("../../core/src/index.ts"),
+      "@themoss/simulator": src("../../simulator/src/index.ts"),
+      "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/system": src("../../system/src/index.ts"),
+      "@themoss/abi-tools": src("../../abi-tools/src/index.ts"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@themoss/protocol-apriori':
         specifier: workspace:*
         version: link:../protocols/apriori
+      '@themoss/protocol-beets':
+        specifier: workspace:*
+        version: link:../protocols/beets
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
@@ -235,6 +238,40 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/beets:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/abi-tools':
+        specifier: workspace:*
+        version: link:../../abi-tools
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
       typescript:
         specifier: ~5.9.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

Adds the Beets (Balancer V3 DEX on Monad mainnet) protocol adapter to the MCP server.

- Capabilities: \swap\ (\swapSingleTokenExactIn\/\swapSingleTokenExactOut\), \ddLiquidity\ (\ddLiquidityUnbalanced\), \emoveLiquidity\ (\emoveLiquiditySingleTokenExactIn\), plus \quote\, \quoteAddLiquidity\, \quoteRemoveLiquidity\, and \pool\ queries
- Native MON wrap/unwrap via WMON on the canonical Balancer v3 Router
- ABIs vendored from balancer/balancer-deployments at pinned commit \c1c3038\ with SHA-256 provenance (\VENDOR.json\)
- Offline tests: ABI pipeline, capabilities, querying
- Online suite (\pnpm test:abi:online\) verifies deployed bytecode selector/topic hashes against the adapter's ABI surface and asserts Router/Vault/VaultExtension wiring via VaultExplorer

## Verification
- \pnpm lint\ (159 files), \pnpm build\, typecheck all pass
- \pnpm test\ green across all packages (beets 18/18, mcp-server 12/12)
- Online ABI explorer suite 5/5 passing