### PR TITLE
fix(core): bound the Receipt-side traversal against the parameter budget

### DIFF
--- a/.changeset/bound-receipt-traversal.md
+++ b/.changeset/bound-receipt-traversal.md
@@ -1,0 +1,11 @@
+---
+"@themoss/core": patch
+---
+
+Bound the Receipt-side traversal in `framework.ts`. `flattenReceipt` and the
+JSON check it runs on each `outcome` and `ReceiptChange` data now walk an
+explicit stack against the shared `CAPABILITY_TREE_LIMITS` parameter budget,
+cumulative across one whole Receipt tree, with a Receipt nesting bound beside
+it. A deeply nested Receipt now fails with a typed `CapabilityTreeError` and a
+tree path instead of an untyped `RangeError`, the same way the input side does
+after #142. Change identity, length and order are unchanged.

--- a/packages/core/src/framework.ts
+++ b/packages/core/src/framework.ts
@@ -385,63 +385,74 @@ function assertBoundedParams(value: unknown, path: string, budget: TreeBudget): 
   }
 }
 
-function assertJsonSafe(value: unknown, path: string, seen = new WeakSet<object>()): void {
-  if (value === null || typeof value === "string" || typeof value === "boolean") return;
-  if (typeof value === "number") {
-    if (!Number.isFinite(value)) throw new TypeError(`${path} contains a non-finite number`);
-    return;
-  }
-  if (typeof value !== "object") {
-    throw new TypeError(`${path} contains a non-JSON-safe ${typeof value}`);
-  }
-  if (seen.has(value)) throw new TypeError(`${path} contains a cycle`);
-  seen.add(value);
-  if (Array.isArray(value)) {
-    for (const [index, entry] of value.entries()) {
-      assertJsonSafe(entry, `${path}[${index}]`, seen);
-    }
-  } else {
-    const prototype = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) {
-      throw new TypeError(`${path} contains a non-plain object`);
-    }
-    if (Object.getOwnPropertySymbols(value).length > 0) {
-      throw new TypeError(`${path} contains a symbol key`);
-    }
-    for (const [key, entry] of Object.entries(value)) {
-      assertJsonSafe(entry, `${path}.${key}`, seen);
-    }
-  }
-  seen.delete(value);
-}
+type ReceiptFrame =
+  | { task: "receipt"; node: unknown; path: string; depth: number }
+  | { task: "change"; child: ReceiptChange; path: string }
+  | { task: "leave"; node: object };
 
-function flattenReceipt(
-  receipt: ReceiptResult,
-  path = "Receipt",
-  seen = new WeakSet<object>(),
-): ReceiptChange[] {
-  if (!receipt || typeof receipt !== "object" || receipt.kind !== "receipt") {
-    throw new Error(`${path} is not a Receipt`);
-  }
-  if (seen.has(receipt)) throw new Error(`${path} contains a Receipt cycle`);
-  seen.add(receipt);
-  assertJsonSafe(receipt.outcome, `${path}.outcome`);
-  requireText(receipt.text, `${path}.text`);
-  if (!Array.isArray(receipt.changes)) throw new Error(`${path}.changes must be an array`);
+/**
+ * Validates and flattens one Receipt tree with an explicit stack, keeping the
+ * depth-first order of the previous recursive traversal. The parameter budgets
+ * from CAPABILITY_TREE_LIMITS are enforced cumulatively across every outcome
+ * and ReceiptChange data in the whole tree, beside a Receipt nesting bound, so
+ * an adversarially deep Receipt fails with a typed CapabilityTreeError and a
+ * tree path instead of an untyped RangeError, the same way the input side does.
+ */
+function flattenReceipt(receipt: ReceiptResult): ReceiptChange[] {
   const leaves: ReceiptChange[] = [];
-  for (const [index, child] of receipt.changes.entries()) {
-    const childPath = `${path}.changes[${index}]`;
-    if (child?.kind === "change") {
-      requireText(child.text, `${childPath}.text`);
-      assertJsonSafe(child.data, `${childPath}.data`);
-      leaves.push(child);
-    } else if (child?.kind === "receipt") {
-      leaves.push(...flattenReceipt(child, childPath, seen));
-    } else {
-      throw new Error(`${childPath} is not a Receipt or ReceiptChange`);
+  const ancestors = new WeakSet<object>();
+  const budget: TreeBudget = {
+    capabilities: 0,
+    parameterNodes: 0,
+    parameterCharacters: 0,
+    calldataBytes: 0,
+  };
+  const stack: ReceiptFrame[] = [{ task: "receipt", node: receipt, path: "Receipt", depth: 1 }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop();
+    if (!frame) break;
+    if (frame.task === "leave") {
+      ancestors.delete(frame.node);
+      continue;
     }
+    if (frame.task === "change") {
+      requireText(frame.child.text, `${frame.path}.text`);
+      assertBoundedParams(frame.child.data, `${frame.path}.data`, budget);
+      leaves.push(frame.child);
+      continue;
+    }
+    const { node, path, depth } = frame;
+    if (!node || typeof node !== "object" || (node as ReceiptResult).kind !== "receipt") {
+      throw new Error(`${path} is not a Receipt`);
+    }
+    if (ancestors.has(node)) throw new Error(`${path} contains a Receipt cycle`);
+    if (depth > CAPABILITY_TREE_LIMITS.maxCapabilityDepth) {
+      throw new CapabilityTreeError(
+        "CAPABILITY_DEPTH",
+        path,
+        `Receipt depth exceeds ${CAPABILITY_TREE_LIMITS.maxCapabilityDepth}`,
+      );
+    }
+    ancestors.add(node);
+    const current = node as ReceiptResult;
+    assertBoundedParams(current.outcome, `${path}.outcome`, budget);
+    requireText(current.text, `${path}.text`);
+    if (!Array.isArray(current.changes)) throw new Error(`${path}.changes must be an array`);
+    const children: ReceiptFrame[] = [];
+    for (const [index, child] of current.changes.entries()) {
+      const childPath = `${path}.changes[${index}]`;
+      if (child?.kind === "change") {
+        children.push({ task: "change", child, path: childPath });
+      } else if (child?.kind === "receipt") {
+        children.push({ task: "receipt", node: child, path: childPath, depth: depth + 1 });
+      } else {
+        throw new Error(`${childPath} is not a Receipt or ReceiptChange`);
+      }
+    }
+    stack.push({ task: "leave", node });
+    stack.push(...children.toReversed());
   }
-  seen.delete(receipt);
   return leaves;
 }
 

--- a/packages/core/src/framework.ts
+++ b/packages/core/src/framework.ts
@@ -439,6 +439,17 @@ function flattenReceipt(receipt: ReceiptResult): ReceiptChange[] {
     assertBoundedParams(current.outcome, `${path}.outcome`, budget);
     requireText(current.text, `${path}.text`);
     if (!Array.isArray(current.changes)) throw new Error(`${path}.changes must be an array`);
+    // Bound the fanout before materializing child frames, so an over-wide
+    // changes array fails with a typed error rather than allocating a frame per
+    // child and then spreading an unbounded array into push() (a RangeError).
+    // Mirrors the array lookahead in assertBoundedParams.
+    if (budget.parameterNodes + current.changes.length > CAPABILITY_TREE_LIMITS.maxParameterNodes) {
+      throw new CapabilityTreeError(
+        "PARAMETER_COUNT",
+        path,
+        `total parameter nodes exceed ${CAPABILITY_TREE_LIMITS.maxParameterNodes}`,
+      );
+    }
     const children: ReceiptFrame[] = [];
     for (const [index, child] of current.changes.entries()) {
       const childPath = `${path}.changes[${index}]`;

--- a/packages/core/test/receipt-bounds.test.ts
+++ b/packages/core/test/receipt-bounds.test.ts
@@ -119,6 +119,22 @@ describe("Receipt traversal bounds", () => {
     expectReceiptError(overBudget, "PARAMETER_COUNT");
   });
 
+  it("fails an over-wide changes array with a typed error instead of a spread RangeError", () => {
+    const c = change(0);
+    const receipt: ReceiptResult = {
+      kind: "receipt",
+      outcome: null,
+      text: "root",
+      changes: Array.from({ length: 200_000 }, () => ({
+        kind: "change" as const,
+        change: c,
+        data: null,
+        text: "leaf",
+      })),
+    };
+    expectReceiptError(receipt, "PARAMETER_COUNT");
+  });
+
   it("flattens a valid Receipt tree, preserving Change identity, length and order", () => {
     const first = change(0);
     const second = change(1);

--- a/packages/core/test/receipt-bounds.test.ts
+++ b/packages/core/test/receipt-bounds.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAPABILITY_TREE_LIMITS,
+  CapabilityTreeError,
+  type CapabilityTreeErrorCode,
+  type Change,
+  type JsonSafeValue,
+  type ReceiptChange,
+  ReceiptCoverageError,
+  type ReceiptResult,
+  verifyReceiptCoverage,
+} from "../src/index.js";
+
+const FROM = "0x1111111111111111111111111111111111111111" as const;
+const TO = "0x2222222222222222222222222222222222222222" as const;
+
+function change(id: number): Change {
+  return { kind: "nativeTransfer", from: FROM, to: TO, value: String(id) };
+}
+
+/** A `null` wrapped in `depth` nested arrays, so the innermost value is at depth `depth`. */
+function nestedValue(depth: number): JsonSafeValue {
+  let value: JsonSafeValue = null;
+  for (let level = 1; level < depth; level += 1) value = [value];
+  return value;
+}
+
+/** A chain of `depth` Receipts, each holding the next one as its only change. */
+function nestedReceipt(depth: number): ReceiptResult {
+  let node: ReceiptResult = { kind: "receipt", outcome: null, text: "leaf receipt", changes: [] };
+  for (let level = 1; level < depth; level += 1) {
+    node = { kind: "receipt", outcome: null, text: `level ${level}`, changes: [node] };
+  }
+  return node;
+}
+
+/** An array of `count` nulls, worth `count + 1` parameter nodes. */
+function wideValue(count: number): JsonSafeValue {
+  return Array.from({ length: count }, () => null);
+}
+
+function expectReceiptError(receipt: ReceiptResult, code: CapabilityTreeErrorCode): void {
+  let caught: unknown;
+  try {
+    verifyReceiptCoverage([], receipt);
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(CapabilityTreeError);
+  const treeError = caught as CapabilityTreeError;
+  expect(treeError.code).toBe(code);
+  expect(treeError.path.startsWith("Receipt")).toBe(true);
+  expect(treeError.message).toContain(code);
+  expect(treeError.message).toContain(treeError.path);
+}
+
+describe("Receipt traversal bounds", () => {
+  it("fails an adversarially deep outcome with a typed error instead of a RangeError", () => {
+    const receipt: ReceiptResult = {
+      kind: "receipt",
+      outcome: nestedValue(50_000),
+      text: "root",
+      changes: [],
+    };
+    expectReceiptError(receipt, "PARAMETER_DEPTH");
+  });
+
+  it("fails an adversarially deep ReceiptChange data with a typed error", () => {
+    const receipt: ReceiptResult = {
+      kind: "receipt",
+      outcome: null,
+      text: "root",
+      changes: [{ kind: "change", change: change(0), data: nestedValue(50_000), text: "leaf" }],
+    };
+    let caught: unknown;
+    try {
+      verifyReceiptCoverage([], receipt);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(CapabilityTreeError);
+    const treeError = caught as CapabilityTreeError;
+    expect(treeError.code).toBe("PARAMETER_DEPTH");
+    expect(treeError.path).toContain(".data");
+  });
+
+  it("accepts the Receipt nesting limit and rejects one level deeper with a typed error", () => {
+    const atLimit = nestedReceipt(CAPABILITY_TREE_LIMITS.maxCapabilityDepth);
+    expect(() => verifyReceiptCoverage([], atLimit)).not.toThrow();
+    expectReceiptError(
+      nestedReceipt(CAPABILITY_TREE_LIMITS.maxCapabilityDepth + 1),
+      "CAPABILITY_DEPTH",
+    );
+  });
+
+  it("fails an adversarially deep Receipt chain with a typed error instead of a RangeError", () => {
+    expectReceiptError(nestedReceipt(50_000), "CAPABILITY_DEPTH");
+  });
+
+  it("enforces the parameter node budget cumulatively across outcome and data", () => {
+    const within = CAPABILITY_TREE_LIMITS.maxParameterNodes - 1000;
+    const c = change(0);
+    const withinBudget: ReceiptResult = {
+      kind: "receipt",
+      outcome: wideValue(within),
+      text: "root",
+      changes: [{ kind: "change", change: c, data: null, text: "leaf" }],
+    };
+    // The outcome alone stays under the node budget.
+    expect(() => verifyReceiptCoverage([c], withinBudget)).not.toThrow();
+
+    const overBudget: ReceiptResult = {
+      kind: "receipt",
+      outcome: wideValue(within),
+      text: "root",
+      changes: [{ kind: "change", change: change(0), data: wideValue(2000), text: "leaf" }],
+    };
+    // The same outcome plus a second payload on the leaf crosses the shared budget.
+    expectReceiptError(overBudget, "PARAMETER_COUNT");
+  });
+
+  it("flattens a valid Receipt tree, preserving Change identity, length and order", () => {
+    const first = change(0);
+    const second = change(1);
+    const tree: ReceiptResult = {
+      kind: "receipt",
+      outcome: { ok: true },
+      text: "root",
+      changes: [
+        { kind: "change", change: first, data: { index: 0 }, text: "leaf 0" },
+        {
+          kind: "receipt",
+          outcome: null,
+          text: "group",
+          changes: [
+            {
+              kind: "change",
+              change: second,
+              data: { index: 1 },
+              text: "leaf 1",
+            } satisfies ReceiptChange,
+          ],
+        },
+      ],
+    };
+    expect(() => verifyReceiptCoverage([first, second], tree)).not.toThrow();
+    // Order is retained, so the wrong order fails coverage rather than the bounds.
+    expect(() => verifyReceiptCoverage([second, first], tree)).toThrow(ReceiptCoverageError);
+  });
+});


### PR DESCRIPTION
Part 1 of #147: the Receipt-side traversal.

`flattenReceipt` and the JSON-safety check it ran on each `outcome` and `ReceiptChange` data recursed with no depth, node or character budget, so a deeply nested Receipt failed with an untyped `RangeError` instead of a typed `CapabilityTreeError`. This gives both the explicit-stack shape `flattenCapabilityTree` and `assertBoundedParams` already use, enforces the existing `CAPABILITY_TREE_LIMITS` parameter budgets (depth, nodes, characters) cumulatively across one whole Receipt tree, and adds a Receipt nesting bound beside them, reusing the existing `CapabilityTreeError` codes and paths so the MCP error string keeps its shape. Change identity, length and order are unchanged.

Tests cover an adversarially deep `outcome`, an adversarially deep `child.data`, the Receipt nesting limit at the boundary and one past it, an adversarially deep Receipt chain, and that the parameter node budget is cumulative across `outcome` and a leaf's `data`.

Part 2 (routing a Bound Protocol `binding` through the same budget) is left out for now: it depends on #61 landing the `binding` field first, as the issue notes.

Verified with `pnpm lint`, `pnpm build`, `pnpm typecheck` across the workspace and the `@themoss/core` test suite.
