### PR TITLE
fix(kuru): preserve route quote failure provenance

### DIFF
--- a/.changeset/kuru-quote-provenance.md
+++ b/.changeset/kuru-quote-provenance.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-kuru": patch
+---
+
+Preserve Kuru route-quote failure provenance with typed error codes and fail closed when best-route comparison is incomplete.

--- a/packages/protocols/kuru/src/errors.ts
+++ b/packages/protocols/kuru/src/errors.ts
@@ -1,0 +1,38 @@
+import type { AddressValue, TokenRef } from "@themoss/core";
+
+export type KuruQuoteErrorCode =
+  /** Discovery and verification completed, but no candidate route remained. */
+  | "NO_VERIFIED_ROUTE"
+  /** Every exact-input route completed and returned zero output. */
+  | "NO_POSITIVE_QUOTE"
+  /** At least one verified route could not be evaluated, making comparison incomplete. */
+  | "ROUTE_QUOTE_UNAVAILABLE"
+  /** Every target-output route was locally proven unable to satisfy the target. */
+  | "TARGET_OUTPUT_UNSATISFIABLE";
+
+/** Stable context for one verified route whose quote evaluation failed. */
+export type KuruRouteQuoteFailure = {
+  readonly path: readonly TokenRef[];
+  readonly markets: readonly AddressValue[];
+  readonly message: string;
+};
+
+/** A machine-readable Kuru discovery or quote-comparison failure. */
+export class KuruQuoteError extends Error {
+  readonly code: KuruQuoteErrorCode;
+  readonly failures: readonly KuruRouteQuoteFailure[];
+
+  constructor(
+    code: KuruQuoteErrorCode,
+    message: string,
+    options: {
+      readonly failures?: readonly KuruRouteQuoteFailure[];
+      readonly cause?: unknown;
+    } = {},
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "KuruQuoteError";
+    this.code = code;
+    this.failures = options.failures ?? [];
+  }
+}

--- a/packages/protocols/kuru/src/index.ts
+++ b/packages/protocols/kuru/src/index.ts
@@ -1,3 +1,5 @@
 export { KuruOrderbookAbi, KuruRouterAbi } from "./abis/kuru.js";
+export type { KuruQuoteErrorCode, KuruRouteQuoteFailure } from "./errors.js";
+export { KuruQuoteError } from "./errors.js";
 export { KURU_ROUTER_ADDRESS, Kuru } from "./kuru.js";
 export type { KuruSwapOutcome } from "./types.js";

--- a/packages/protocols/kuru/src/kuru.ts
+++ b/packages/protocols/kuru/src/kuru.ts
@@ -25,6 +25,7 @@ import {
 import { ERC20 } from "@themoss/erc";
 import { decodeEventLog, formatUnits, getAddress, isAddress, parseUnits } from "viem";
 import { KuruOrderbookAbi, KuruRouterAbi } from "./abis/kuru.js";
+import { KuruQuoteError, type KuruRouteQuoteFailure } from "./errors.js";
 import type {
   KuruQuote,
   KuruSwapOutcome,
@@ -46,6 +47,7 @@ const KURU_MARKET_DISCOVERY_TIMEOUT_MS = 10_000;
 const MAX_KURU_MARKET_DISCOVERY_BYTES = 1_000_000;
 const MAX_KURU_MARKET_CANDIDATES = 256;
 const MAX_KURU_MARKET_ROUTES = 256;
+const UINT256_MAX = 2n ** 256n - 1n;
 
 const OptionalHumanTokenAmount = PositiveDecimalString.optional().describe(
   'An optional positive base-10 decimal amount in a token\'s display units, such as "1" or "1.5".',
@@ -261,7 +263,12 @@ export class Kuru {
     const [firstRoute] = routes;
     const firstLeg = firstRoute?.[0];
     const lastLeg = firstRoute?.at(-1);
-    if (!firstLeg || !lastLeg) throw new Error("no verified Kuru market path for this token pair");
+    if (!firstLeg || !lastLeg) {
+      throw new KuruQuoteError(
+        "NO_VERIFIED_ROUTE",
+        "no verified Kuru market path for this token pair",
+      );
+    }
     const inputDecimals = firstLeg.inputDecimals;
     const outputDecimals = lastLeg.outputDecimals;
     const slippage = BigInt(params.slippage ?? DEFAULT_SLIPPAGE_BPS);
@@ -379,11 +386,27 @@ export class Kuru {
     const settled = await Promise.allSettled(
       routes.map(async (route) => ({ route, amountOut: await this.#quoteRoute(route, amountIn) })),
     );
-    const quoted = settled.flatMap((result) =>
-      result.status === "fulfilled" && result.value.amountOut > 0n ? [result.value] : [],
-    );
+    const failures: KuruRouteQuoteFailure[] = [];
+    const causes: unknown[] = [];
+    const quoted = [];
+    for (const [index, result] of settled.entries()) {
+      if (result.status === "fulfilled") {
+        if (result.value.amountOut > 0n) quoted.push(result.value);
+        continue;
+      }
+      const route = routes[index];
+      if (!route) throw new Error("Kuru route quote result did not match its route");
+      failures.push(routeQuoteFailure(route, result.reason));
+      causes.push(result.reason);
+    }
+    if (failures.length > 0) throw routeQuoteUnavailable(failures, causes);
     const [first] = quoted;
-    if (!first) throw new Error("no Kuru market path can quote this input amount");
+    if (!first) {
+      throw new KuruQuoteError(
+        "NO_POSITIVE_QUOTE",
+        "every verified Kuru market path returned zero output for this input amount",
+      );
+    }
     return quoted.reduce((best, current) => (current.amountOut > best.amountOut ? current : best));
   }
 
@@ -399,11 +422,28 @@ export class Kuru {
         amountIn: await this.#requiredInput(route, amountOut, inputDecimals, outputDecimals),
       })),
     );
-    const quoted = settled.flatMap((result) =>
-      result.status === "fulfilled" ? [result.value] : [],
-    );
+    const failures: KuruRouteQuoteFailure[] = [];
+    const causes: unknown[] = [];
+    const quoted = [];
+    for (const [index, result] of settled.entries()) {
+      if (result.status === "fulfilled") {
+        quoted.push(result.value);
+        continue;
+      }
+      if (result.reason instanceof TargetOutputUnsatisfiableError) continue;
+      const route = routes[index];
+      if (!route) throw new Error("Kuru route quote result did not match its route");
+      failures.push(routeQuoteFailure(route, result.reason));
+      causes.push(result.reason);
+    }
+    if (failures.length > 0) throw routeQuoteUnavailable(failures, causes);
     const [first] = quoted;
-    if (!first) throw new Error("no Kuru market path can satisfy this output amount");
+    if (!first) {
+      throw new KuruQuoteError(
+        "TARGET_OUTPUT_UNSATISFIABLE",
+        "no verified Kuru market path can satisfy this output amount within the uint256 input range",
+      );
+    }
     return quoted.reduce((best, current) => (current.amountIn < best.amountIn ? current : best));
   }
 
@@ -416,9 +456,12 @@ export class Kuru {
     // ponytail: monotonic reverse quote; replace with an order-book estimator if RPC volume matters.
     let high = scaleUnits(target, outputDecimals, inputDecimals);
     if (high < 1n) high = 1n;
-    for (let attempts = 0; (await this.#quoteRoute(route, high)) < target; attempts += 1) {
-      if (attempts >= 255) throw new Error("Kuru target output exceeds uint256 input range");
-      high *= 2n;
+    if (high > UINT256_MAX) throw new TargetOutputUnsatisfiableError();
+    let highQuote = await this.#quoteRoute(route, high);
+    while (highQuote < target) {
+      if (high === UINT256_MAX) throw new TargetOutputUnsatisfiableError();
+      high = high <= UINT256_MAX / 2n ? high * 2n : UINT256_MAX;
+      highQuote = await this.#quoteRoute(route, high);
     }
     let low = 0n;
     while (low + 1n < high) {
@@ -458,6 +501,36 @@ export class Kuru {
         : { from: KURU_NATIVE },
     );
   }
+}
+
+class TargetOutputUnsatisfiableError extends Error {
+  constructor() {
+    super("Kuru target output exceeds the uint256 input range");
+    this.name = "TargetOutputUnsatisfiableError";
+  }
+}
+
+function routeQuoteFailure(route: Route, reason: unknown): KuruRouteQuoteFailure {
+  return {
+    path: routeTokens(route),
+    markets: route.map(({ market }) => market.address),
+    message: errorMessage(reason),
+  };
+}
+
+function routeQuoteUnavailable(
+  failures: readonly KuruRouteQuoteFailure[],
+  causes: readonly unknown[],
+): KuruQuoteError {
+  const cause =
+    causes.length === 1
+      ? causes[0]
+      : new AggregateError(causes, "multiple verified Kuru route quote evaluations failed");
+  return new KuruQuoteError(
+    "ROUTE_QUOTE_UNAVAILABLE",
+    `${failures.length} verified Kuru route quote evaluation${failures.length === 1 ? "" : "s"} failed; best-route comparison is incomplete`,
+    { failures, cause },
+  );
 }
 
 async function fetchMarketCandidates(tokenIn: TokenRef, tokenOut: TokenRef) {

--- a/packages/protocols/kuru/src/kuru.ts
+++ b/packages/protocols/kuru/src/kuru.ts
@@ -456,7 +456,7 @@ export class Kuru {
     // ponytail: monotonic reverse quote; replace with an order-book estimator if RPC volume matters.
     let high = scaleUnits(target, outputDecimals, inputDecimals);
     if (high < 1n) high = 1n;
-    if (high > UINT256_MAX) throw new TargetOutputUnsatisfiableError();
+    if (high > UINT256_MAX) high = UINT256_MAX;
     let highQuote = await this.#quoteRoute(route, high);
     while (highQuote < target) {
       if (high === UINT256_MAX) throw new TargetOutputUnsatisfiableError();

--- a/packages/protocols/kuru/test/kuru.test.ts
+++ b/packages/protocols/kuru/test/kuru.test.ts
@@ -20,7 +20,7 @@ import {
 } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { KuruOrderbookAbi, KuruRouterAbi } from "../src/abis/kuru.js";
-import { KURU_ROUTER_ADDRESS, Kuru } from "../src/index.js";
+import { KURU_ROUTER_ADDRESS, Kuru, KuruQuoteError } from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 const ZERO = getAddress("0x0000000000000000000000000000000000000000");
@@ -29,6 +29,18 @@ const MON_USDC_WORSE = getAddress("0x2222222222222222222222222222222222222222");
 const MON_AUSD = getAddress("0x3333333333333333333333333333333333333333");
 const DIRECT_USDC_AUSD = getAddress("0x4444444444444444444444444444444444444444");
 const DIRECT_USDC_AUSD_BETTER = getAddress("0x5555555555555555555555555555555555555555");
+const DIRECT_ROUTE_A = getAddress("0x6666666666666666666666666666666666666666");
+const DIRECT_ROUTE_B = getAddress("0x7777777777777777777777777777777777777777");
+const UINT256_MAX = 2n ** 256n - 1n;
+
+type MockQuoteBehavior = {
+  rejectionMessage?: string;
+  rejectAtOrAbove?: bigint;
+  maximumOutput?: bigint;
+  inputNumerator?: bigint;
+  inputDenominator?: bigint;
+  quotedInputs?: bigint[];
+};
 
 type MockMarket = {
   address: `0x${string}`;
@@ -40,6 +52,10 @@ type MockMarket = {
   buyDenominator: bigint;
   sellNumerator: bigint;
   sellDenominator: bigint;
+  pricePrecision?: bigint;
+  sizePrecision?: bigint;
+  buyBehavior?: MockQuoteBehavior;
+  sellBehavior?: MockQuoteBehavior;
   verified?: boolean;
 };
 
@@ -200,6 +216,315 @@ describe("Kuru", () => {
     if (!swap) throw new Error("missing Kuru transaction");
     const decoded = decodeFunctionData({ abi: KuruRouterAbi, data: swap.transaction.data });
     expect(decoded.args.slice(0, 3)).toEqual([[DIRECT_USDC_AUSD], [false], [false]]);
+  });
+
+  it("reports when discovery completes without a verified route", async () => {
+    const { registry } = offlineRegistry([]);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountIn: "1",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      name: "KuruQuoteError",
+      code: "NO_VERIFIED_ROUTE",
+      failures: [],
+    });
+  });
+
+  it("distinguishes all-zero exact-input quotes from unavailable routes", async () => {
+    const markets = [
+      directMarket(DIRECT_ROUTE_A, { maximumOutput: 0n }),
+      directMarket(DIRECT_ROUTE_B, { maximumOutput: 0n }),
+    ];
+    const { registry } = offlineRegistry(markets);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: USDC_ADDRESS,
+        tokenOut: AUSD_ADDRESS,
+        amountIn: "1",
+      }),
+    );
+
+    expect(error).toMatchObject({ code: "NO_POSITIVE_QUOTE", failures: [] });
+  });
+
+  it("retains every exact-input route rejection in stable route order", async () => {
+    const markets = [
+      directMarket(DIRECT_ROUTE_A, { rejectionMessage: "route A RPC failed" }),
+      directMarket(DIRECT_ROUTE_B, { rejectionMessage: "route B decode failed" }),
+    ];
+    const { registry } = offlineRegistry(markets);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: USDC_ADDRESS,
+        tokenOut: AUSD_ADDRESS,
+        amountIn: "1",
+      }),
+    );
+
+    expect(error.code).toBe("ROUTE_QUOTE_UNAVAILABLE");
+    expect(error.failures).toEqual([
+      {
+        path: [USDC_ADDRESS, AUSD_ADDRESS],
+        markets: [DIRECT_ROUTE_A],
+        message: "route A RPC failed",
+      },
+      {
+        path: [USDC_ADDRESS, AUSD_ADDRESS],
+        markets: [DIRECT_ROUTE_B],
+        message: "route B decode failed",
+      },
+    ]);
+    expect(error.cause).toBeInstanceOf(AggregateError);
+    expect((error.cause as AggregateError).errors).toMatchObject([
+      { message: "route A RPC failed" },
+      { message: "route B decode failed" },
+    ]);
+  });
+
+  it("fails closed for mixed zero and rejected exact-input routes", async () => {
+    const { registry } = offlineRegistry([
+      directMarket(DIRECT_ROUTE_A, { maximumOutput: 0n }),
+      directMarket(DIRECT_ROUTE_B, { rejectionMessage: "route B unavailable" }),
+    ]);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: USDC_ADDRESS,
+        tokenOut: AUSD_ADDRESS,
+        amountIn: "1",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      code: "ROUTE_QUOTE_UNAVAILABLE",
+      failures: [{ markets: [DIRECT_ROUTE_B], message: "route B unavailable" }],
+    });
+  });
+
+  it("refuses both quote and swap when a positive exact-input route has an unavailable peer", async () => {
+    const { registry } = offlineRegistry([
+      directMarket(DIRECT_ROUTE_A),
+      directMarket(DIRECT_ROUTE_B, { rejectionMessage: "comparison peer rejected" }),
+    ]);
+    const params = {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    } as const;
+
+    for (const method of ["quote", "swap"] as const) {
+      const error = await kuruQuoteError(registry.action("kuru", method, ACCOUNT, params));
+      expect(error).toMatchObject({
+        code: "ROUTE_QUOTE_UNAVAILABLE",
+        failures: [{ markets: [DIRECT_ROUTE_B], message: "comparison peer rejected" }],
+      });
+      expect(error.cause).toMatchObject({ message: "comparison peer rejected" });
+    }
+  });
+
+  it("selects the largest exact-input result when every route completes", async () => {
+    const { registry } = offlineRegistry([
+      directMarket(DIRECT_ROUTE_A),
+      directMarket(DIRECT_ROUTE_B, undefined, 2n, 1n),
+    ]);
+    const capability = await registry.action("kuru", "swap", ACCOUNT, {
+      tokenIn: USDC_ADDRESS,
+      tokenOut: AUSD_ADDRESS,
+      amountIn: "1",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const swap = flattenCapabilityTree(capability).at(-1);
+    if (!swap) throw new Error("missing Kuru transaction");
+
+    expect(decodeFunctionData({ abi: KuruRouterAbi, data: swap.transaction.data }).args[0]).toEqual(
+      [DIRECT_ROUTE_B],
+    );
+  });
+
+  it("reports target output as unsatisfiable when every route exhausts uint256", async () => {
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, {
+        inputNumerator: 1n,
+        inputDenominator: 10n ** 50n,
+        maximumOutput: 1n,
+      }),
+      reverseMarket(DIRECT_ROUTE_B, {
+        inputNumerator: 1n,
+        inputDenominator: 10n ** 50n,
+        maximumOutput: 1n,
+      }),
+    ]);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountOut: "2",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      code: "TARGET_OUTPUT_UNSATISFIABLE",
+      failures: [],
+    });
+  });
+
+  it("retains every unavailable target-output route", async () => {
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, { rejectionMessage: "target route A transport failed" }),
+      reverseMarket(DIRECT_ROUTE_B, { rejectionMessage: "target route B call failed" }),
+    ]);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountOut: "2",
+      }),
+    );
+
+    expect(error.code).toBe("ROUTE_QUOTE_UNAVAILABLE");
+    expect(error.failures).toEqual([
+      {
+        path: [NATIVE, USDC_ADDRESS],
+        markets: [DIRECT_ROUTE_A],
+        message: "target route A transport failed",
+      },
+      {
+        path: [NATIVE, USDC_ADDRESS],
+        markets: [DIRECT_ROUTE_B],
+        message: "target route B call failed",
+      },
+    ]);
+  });
+
+  it("fails closed when a satisfying target-output route has an unavailable peer", async () => {
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, { inputNumerator: 1n, inputDenominator: 10n ** 50n }),
+      reverseMarket(DIRECT_ROUTE_B, { rejectionMessage: "target comparison unavailable" }),
+    ]);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountOut: "2",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      code: "ROUTE_QUOTE_UNAVAILABLE",
+      failures: [{ markets: [DIRECT_ROUTE_B], message: "target comparison unavailable" }],
+    });
+  });
+
+  it("selects a satisfying target-output route when its peer is deterministically unsatisfiable", async () => {
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, { inputNumerator: 1n, inputDenominator: 10n ** 50n }),
+      reverseMarket(DIRECT_ROUTE_B, {
+        inputNumerator: 1n,
+        inputDenominator: 10n ** 50n,
+        maximumOutput: 1n,
+      }),
+    ]);
+    const capability = await registry.action("kuru", "swap", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountOut: "2",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const swap = flattenCapabilityTree(capability).at(-1);
+    if (!swap) throw new Error("missing Kuru transaction");
+
+    expect(decodeFunctionData({ abi: KuruRouterAbi, data: swap.transaction.data }).args[0]).toEqual(
+      [DIRECT_ROUTE_A],
+    );
+  });
+
+  it("selects the minimum input when every target-output route satisfies the target", async () => {
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, { inputNumerator: 1n, inputDenominator: 2n * 10n ** 50n }),
+      reverseMarket(DIRECT_ROUTE_B, { inputNumerator: 1n, inputDenominator: 10n ** 50n }),
+    ]);
+    const capability = await registry.action("kuru", "swap", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountOut: "2",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const swap = flattenCapabilityTree(capability).at(-1);
+    if (!swap) throw new Error("missing Kuru transaction");
+
+    expect(decodeFunctionData({ abi: KuruRouterAbi, data: swap.transaction.data }).args[0]).toEqual(
+      [DIRECT_ROUTE_B],
+    );
+  });
+
+  it("preserves earlier-route preference when target-output inputs tie", async () => {
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, { inputNumerator: 1n, inputDenominator: 10n ** 50n }),
+      reverseMarket(DIRECT_ROUTE_B, { inputNumerator: 1n, inputDenominator: 10n ** 50n }),
+    ]);
+    const capability = await registry.action("kuru", "swap", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountOut: "2",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const swap = flattenCapabilityTree(capability).at(-1);
+    if (!swap) throw new Error("missing Kuru transaction");
+
+    expect(decodeFunctionData({ abi: KuruRouterAbi, data: swap.transaction.data }).args[0]).toEqual(
+      [DIRECT_ROUTE_A],
+    );
+  });
+
+  it("quotes UINT256_MAX at most once and never exceeds it during reverse search", async () => {
+    const quotedInputs: bigint[] = [];
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, {
+        inputNumerator: 1n,
+        inputDenominator: 10n ** 50n,
+        maximumOutput: 1n,
+        quotedInputs,
+      }),
+    ]);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountOut: "2",
+      }),
+    );
+
+    expect(error.code).toBe("TARGET_OUTPUT_UNSATISFIABLE");
+    expect(quotedInputs.at(-1)).toBe(UINT256_MAX);
+    expect(quotedInputs.filter((amount) => amount === UINT256_MAX)).toHaveLength(1);
+    expect(quotedInputs.every((amount) => amount <= UINT256_MAX)).toBe(true);
+  });
+
+  it("keeps a quote rejection encountered during reverse search unavailable", async () => {
+    const { registry } = offlineRegistry([
+      reverseMarket(DIRECT_ROUTE_A, {
+        inputNumerator: 1n,
+        inputDenominator: 10n ** 60n,
+        rejectionMessage: "reverse-search RPC rejected",
+        rejectAtOrAbove: 8n * 10n ** 50n,
+      }),
+    ]);
+    const error = await kuruQuoteError(
+      registry.action("kuru", "quote", ACCOUNT, {
+        tokenIn: NATIVE,
+        tokenOut: USDC_ADDRESS,
+        amountOut: "2",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      code: "ROUTE_QUOTE_UNAVAILABLE",
+      failures: [{ message: "reverse-search RPC rejected" }],
+    });
   });
 
   it("translates ordered Changes without reconstructing the planned path", async () => {
@@ -604,6 +929,17 @@ async function swapCapability(registry: Registry) {
   return capability;
 }
 
+async function kuruQuoteError(action: Promise<unknown>): Promise<KuruQuoteError> {
+  try {
+    await action;
+  } catch (error) {
+    expect(error).toBeInstanceOf(KuruQuoteError);
+    if (error instanceof KuruQuoteError) return error;
+    throw error;
+  }
+  throw new Error("expected a KuruQuoteError");
+}
+
 function offlineRegistry(
   markets: readonly MockMarket[] = MARKETS,
   fetchMock = marketDiscoveryFetch(markets),
@@ -623,8 +959,8 @@ function offlineRegistry(
       if (!entry) throw new Error(`unknown market ${String(args[0])}`);
       if (entry.verified === false) return [0, 0n, ZERO, 0n, ZERO, 0n, 0, 0n, 0n, 0n, 0n];
       return [
-        10 ** entry.quoteDecimals,
-        10n ** BigInt(entry.baseDecimals),
+        entry.pricePrecision ?? 10 ** entry.quoteDecimals,
+        entry.sizePrecision ?? 10n ** BigInt(entry.baseDecimals),
         entry.base,
         BigInt(entry.baseDecimals),
         entry.quote,
@@ -636,7 +972,17 @@ function offlineRegistry(
         0n,
       ];
     },
-    call: async ({ to, account, data }: { to: string; account: string; data: Hex }) => {
+    call: async ({
+      to,
+      account,
+      data,
+      value,
+    }: {
+      to: string;
+      account: string;
+      data: Hex;
+      value?: bigint;
+    }) => {
       const entry = byAddress.get(to.toLowerCase());
       if (!entry) throw new Error(`unexpected call ${to}`);
       const decoded = decodeFunctionData({ abi: KuruOrderbookAbi, data });
@@ -653,22 +999,39 @@ function offlineRegistry(
         throw new Error("Kuru quotes must use the zero-address preview sender");
       }
       const size = decoded.args[0];
-      const result =
+      const behavior =
         decoded.functionName === "placeAndExecuteMarketBuy"
-          ? convertUnits(
-              size,
-              entry.quoteDecimals,
-              entry.baseDecimals,
-              entry.buyNumerator,
-              entry.buyDenominator,
-            )
-          : convertUnits(
-              size,
-              entry.baseDecimals,
-              entry.quoteDecimals,
-              entry.sellNumerator,
-              entry.sellDenominator,
-            );
+          ? entry.buyBehavior
+          : entry.sellBehavior;
+      const quotedInput = value ?? size;
+      behavior?.quotedInputs?.push(quotedInput);
+      if (
+        behavior?.rejectionMessage &&
+        (behavior.rejectAtOrAbove === undefined || quotedInput >= behavior.rejectAtOrAbove)
+      ) {
+        throw new Error(behavior.rejectionMessage);
+      }
+      let result =
+        behavior?.inputNumerator !== undefined
+          ? (quotedInput * behavior.inputNumerator) / (behavior.inputDenominator ?? 1n)
+          : decoded.functionName === "placeAndExecuteMarketBuy"
+            ? convertUnits(
+                size,
+                entry.quoteDecimals,
+                entry.baseDecimals,
+                entry.buyNumerator,
+                entry.buyDenominator,
+              )
+            : convertUnits(
+                size,
+                entry.baseDecimals,
+                entry.quoteDecimals,
+                entry.sellNumerator,
+                entry.sellDenominator,
+              );
+      if (behavior?.maximumOutput !== undefined && result > behavior.maximumOutput) {
+        result = behavior.maximumOutput;
+      }
       return {
         data: encodeFunctionResult({
           abi: KuruOrderbookAbi,
@@ -719,6 +1082,26 @@ function market(
     sellDenominator,
     buyNumerator: sellDenominator,
     buyDenominator: sellNumerator,
+  };
+}
+
+function directMarket(
+  address: `0x${string}`,
+  sellBehavior?: MockQuoteBehavior,
+  sellNumerator = 1n,
+  sellDenominator = 1n,
+): MockMarket {
+  return {
+    ...market(address, USDC_ADDRESS, AUSD_ADDRESS, 6, 6, sellNumerator, sellDenominator),
+    sellBehavior,
+  };
+}
+
+function reverseMarket(address: `0x${string}`, sellBehavior: MockQuoteBehavior): MockMarket {
+  return {
+    ...market(address, ZERO, USDC_ADDRESS, 50, 0, 1n, 1n),
+    sizePrecision: 1n,
+    sellBehavior,
   };
 }
 

--- a/packages/protocols/kuru/test/kuru.test.ts
+++ b/packages/protocols/kuru/test/kuru.test.ts
@@ -16,6 +16,7 @@ import {
   encodeAbiParameters,
   encodeEventTopics,
   encodeFunctionResult,
+  formatUnits,
   getAddress,
 } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -501,6 +502,52 @@ describe("Kuru", () => {
     expect(error.code).toBe("TARGET_OUTPUT_UNSATISFIABLE");
     expect(quotedInputs.at(-1)).toBe(UINT256_MAX);
     expect(quotedInputs.filter((amount) => amount === UINT256_MAX)).toHaveLength(1);
+    expect(quotedInputs.every((amount) => amount <= UINT256_MAX)).toBe(true);
+  });
+
+  it("evaluates a capped oversized initial estimate before finding a favorable route input", async () => {
+    const quotedInputs: bigint[] = [];
+    const inputDenominator = UINT256_MAX / 4n;
+    expect(2n * 10n ** 80n).toBeGreaterThan(UINT256_MAX);
+    const { registry } = offlineRegistry([
+      reverseMarket(
+        DIRECT_ROUTE_A,
+        {
+          inputNumerator: 1n,
+          inputDenominator,
+          quotedInputs,
+        },
+        { baseDecimals: 80, sizePrecision: 10n ** 30n },
+      ),
+    ]);
+    const quote = await registry.action("kuru", "quote", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountOut: "2",
+    });
+    if (quote.kind !== "query") throw new Error("expected target-output query");
+
+    expect(quotedInputs[0]).toBe(UINT256_MAX);
+    expect(quotedInputs.every((amount) => amount <= UINT256_MAX)).toBe(true);
+    const expectedAmountIn = 2n * inputDenominator;
+    expect(expectedAmountIn).toBeLessThanOrEqual(UINT256_MAX);
+    expect(quote.data).toMatchObject({
+      amountSide: "amountOut",
+      estimatedAmountIn: formatUnits(expectedAmountIn, 80),
+      path: [NATIVE, USDC_ADDRESS],
+    });
+
+    const capability = await registry.action("kuru", "swap", ACCOUNT, {
+      tokenIn: NATIVE,
+      tokenOut: USDC_ADDRESS,
+      amountOut: "2",
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const swap = flattenCapabilityTree(capability).at(-1);
+    if (!swap) throw new Error("missing Kuru transaction");
+    const decoded = decodeFunctionData({ abi: KuruRouterAbi, data: swap.transaction.data });
+    expect(decoded.args[0]).toEqual([DIRECT_ROUTE_A]);
+    expect(decoded.args[5]).toBeLessThanOrEqual(UINT256_MAX);
     expect(quotedInputs.every((amount) => amount <= UINT256_MAX)).toBe(true);
   });
 
@@ -1097,10 +1144,14 @@ function directMarket(
   };
 }
 
-function reverseMarket(address: `0x${string}`, sellBehavior: MockQuoteBehavior): MockMarket {
+function reverseMarket(
+  address: `0x${string}`,
+  sellBehavior: MockQuoteBehavior,
+  options: { baseDecimals?: number; sizePrecision?: bigint } = {},
+): MockMarket {
   return {
-    ...market(address, ZERO, USDC_ADDRESS, 50, 0, 1n, 1n),
-    sizePrecision: 1n,
+    ...market(address, ZERO, USDC_ADDRESS, options.baseDecimals ?? 50, 0, 1n, 1n),
+    sizePrecision: options.sizePrecision ?? 1n,
     sellBehavior,
   };
 }

--- a/packages/protocols/kuru/test/types.fixture.ts
+++ b/packages/protocols/kuru/test/types.fixture.ts
@@ -1,6 +1,11 @@
 import { type ActionCtx, NATIVE } from "@themoss/core";
 import { USDC_ADDRESS } from "@themoss/system";
-import type { Kuru } from "../src/index.js";
+import {
+  type Kuru,
+  KuruQuoteError,
+  type KuruQuoteErrorCode,
+  type KuruRouteQuoteFailure,
+} from "../src/index.js";
 
 declare const kuru: Kuru;
 declare const ctx: ActionCtx;
@@ -23,3 +28,42 @@ const conflictingAmounts: Parameters<Kuru["quote"]>[0] = {
   amountOut: "1",
 };
 void kuru.quote(conflictingAmounts, ctx);
+
+const noVerifiedRoute: KuruQuoteErrorCode = "NO_VERIFIED_ROUTE";
+const noPositiveQuote: KuruQuoteErrorCode = "NO_POSITIVE_QUOTE";
+const routeQuoteUnavailable: KuruQuoteErrorCode = "ROUTE_QUOTE_UNAVAILABLE";
+const targetOutputUnsatisfiable: KuruQuoteErrorCode = "TARGET_OUTPUT_UNSATISFIABLE";
+void [noVerifiedRoute, noPositiveQuote, routeQuoteUnavailable, targetOutputUnsatisfiable];
+
+const routeFailure: KuruRouteQuoteFailure = {
+  path: [NATIVE, USDC_ADDRESS],
+  markets: [USDC_ADDRESS],
+  message: "market preview rejected",
+};
+const quoteError = new KuruQuoteError("ROUTE_QUOTE_UNAVAILABLE", "comparison incomplete", {
+  failures: [routeFailure],
+  cause: new Error("market preview rejected"),
+});
+const inferredCode: KuruQuoteErrorCode = quoteError.code;
+void inferredCode;
+
+// @ts-expect-error unknown Kuru quote error code
+new KuruQuoteError("UNKNOWN_QUOTE_FAILURE", "unknown");
+
+// @ts-expect-error route failure context requires market addresses
+const malformedFailure: KuruRouteQuoteFailure = {
+  path: [NATIVE, USDC_ADDRESS],
+  message: "missing markets",
+};
+void malformedFailure;
+
+// @ts-expect-error public error code is readonly
+quoteError.code = "NO_POSITIVE_QUOTE";
+// @ts-expect-error public route failures are readonly
+quoteError.failures = [];
+// @ts-expect-error route failure message is readonly
+routeFailure.message = "changed";
+// @ts-expect-error route failure paths are readonly
+routeFailure.path.push(NATIVE);
+// @ts-expect-error route failure markets are readonly
+routeFailure.markets.push(USDC_ADDRESS);


### PR DESCRIPTION
## What and why

Kuru evaluated every verified direct and via-MON route with `Promise.allSettled()`, but discarded rejected evaluations. That collapsed deterministic zero/unsatisfiable results with unavailable RPC or contract calls and could select a “best” route from only the fulfilled subset.

This change preserves route-quote provenance with a Kuru-local typed error contract and makes both `kuru.quote` and `kuru.swap` fail closed whenever route comparison is incomplete.

## Error contract

`@themoss/protocol-kuru` now exports:

- `KuruQuoteError`, with readonly `code` and structured readonly `failures`
- `KuruQuoteErrorCode`
- `KuruRouteQuoteFailure`, containing the token `path`, market addresses, and original rejection message

Stable codes:

- `NO_VERIFIED_ROUTE`: discovery and verification completed with no route
- `NO_POSITIVE_QUOTE`: every exact-input route completed with zero output
- `ROUTE_QUOTE_UNAVAILABLE`: one or more route evaluations rejected, so comparison is incomplete
- `TARGET_OUTPUT_UNSATISFIABLE`: every target-output route was locally proven unable to satisfy the target within the uint256 input domain

Single rejected reasons are retained as `Error.cause`; multiple rejected reasons are retained in an `AggregateError` cause. Every rejected route remains available as ordered structured failure context.

## Exact-input behavior

Every verified route is evaluated. Any rejection produces `ROUTE_QUOTE_UNAVAILABLE`, including positive-plus-rejected and zero-plus-rejected mixtures. When all routes complete, zero results are excluded, the largest positive output wins, and strict comparison preserves earlier/direct-route preference on ties. All-zero completed results produce `NO_POSITIVE_QUOTE`.

## Target-output behavior

Reverse quoting now distinguishes an internal locally proven unsatisfiable state from a rejected quote operation. The bounded search uses `2n ** 256n - 1n`, never quotes above uint256, clamps an oversized 1:1 initial estimate to `UINT256_MAX` and actually evaluates that valid maximum, clamps the final doubling to the maximum valid input, and only binary-searches after finding a satisfying upper bound. A route is unsatisfiable only when a successful quote at `UINT256_MAX` remains below the target.

Any unavailable route produces `ROUTE_QUOTE_UNAVAILABLE`, even if another route succeeds. A successful route may be selected alongside a deterministically unsatisfiable peer because that comparison is complete. All-unsatisfiable routes produce `TARGET_OUTPUT_UNSATISFIABLE`; successful routes minimize input with stable earlier-route tie behavior.

## Conservative revert boundary

This PR does not guess Kuru contract-revert semantics. Arbitrary `eth_call` rejection, RPC/transport failure, decode failure, or unexpected contract revert remains `ROUTE_QUOTE_UNAVAILABLE`. Only exhaustion proven by the adapter’s own bounded uint256 reverse search is classified as deterministic target-output unsatisfiability.

## Public API impact

This is a patch release for `@themoss/protocol-kuru`. Generated `tsup --dts` declarations expose the new class and literal/type contracts. Compile-time fixtures cover all accepted codes, constructor inference, readonly route context, unknown-code rejection, malformed context rejection, and readonly mutation rejection.

## Verification

Local results for current head `1a172a6`:

- `pnpm lint` — passed
- `pnpm build` — passed, including Kuru ESM and declaration output
- `pnpm typecheck` — passed
- `pnpm test` — passed: 288/288 repository tests, including live suites
- `pnpm test:offline` — passed: 273 passed, 15 existing live/e2e tests skipped by `MOSS_SKIP_E2E`
- `pnpm --filter @themoss/protocol-kuru test` — passed: 42/42, including 2 Monad-mainnet live tests
- `git diff --check` — passed

`pnpm install --frozen-lockfile` passed before the focused capped-search follow-up; the follow-up does not change dependencies or the lockfile. `MONADSCAN_API_KEY` was unavailable, so `pnpm --filter @themoss/protocol-kuru test:abi:online` was not run. This PR does not modify ABIs.

These are local results, separate from GitHub-hosted checks. GitHub currently exposes no pull-request workflow runs and no commit status contexts for head `1a172a6`; no remote check is claimed as passed.

## Scope

Only Kuru quote/discovery error semantics, Kuru offline mocks and regression coverage, public type fixtures, and one Kuru patch changeset are changed. Core, Registry, MCP transport, Simulator, Capability trees, Receipt parsing, discovery limits, addresses, ABIs, and unrelated protocols are unchanged.

## AI assistance

This contribution was implemented with OpenAI Codex assistance. The implementation, public API, tests, generated declarations, scope, and live/local verification were reviewed in the working tree before publication.

Closes #161.