### PR TITLE
feat(simulator): expose pinned base block

### DIFF
--- a/.changeset/simulator-pinned-block.md
+++ b/.changeset/simulator-pinned-block.md
@@ -1,0 +1,5 @@
+---
+"@themoss/simulator": patch
+---
+
+Expose the base block pinned by the trace simulator for a simulation run.

--- a/.changeset/simulator-pinned-block.md
+++ b/.changeset/simulator-pinned-block.md
@@ -2,4 +2,4 @@
 "@themoss/simulator": patch
 ---
 
-Expose the base block pinned by the trace simulator for a simulation run.
+Expose the authoritative pinned simulation base block on each `SimulateOutcome` as `simulatorPinnedBlock`, scoped to the run that produced it: filled from the block the run already resolved (no extra chain query), absent when base-block resolution fails, and retained even when the run later reverts or halts.

--- a/docs/adr/0002-simulation-via-debug-tracecall.md
+++ b/docs/adr/0002-simulation-via-debug-tracecall.md
@@ -29,7 +29,11 @@ Monad retains logs inside a failed child frame even though the frame reports `er
   different base states. Verified 2026-07-20 on `rpc.monad.xyz`:
   `debug_traceCall` accepts an explicit block number together with
   `stateOverrides`. If the base block cannot be resolved, simulation halts
-  before the first trace. Re-verified the same day that `eth_simulateV1`,
+  before the first trace. The pinned base block is exposed through
+  `Simulator.getPinnedBlockNumber()` so consumers can cite the exact base
+  state provenance of a run without re-querying the chain: it stays
+  `undefined` until a run pins its block, and never leaks a previous run's
+  block after a resolution failure. Re-verified the same day that `eth_simulateV1`,
   `debug_traceCallMany`, `trace_callMany`, and `eth_callMany` all remain
   unavailable (`-32601`) on `rpc.monad.xyz` and `rpc-mainnet.monadinfra.com`.
 - Monad's `debug_traceCall` **enforces sender balance** (discovered 2026-07-07: a 2-MON transfer from an underfunded address is rejected with `insufficient balance`, unlike geth's default). The simulator therefore pre-funds the transaction sender via a balance override — matching `eth_simulateV1`'s validation-off semantics. Simulation answers "what would this transaction do", not "can the account afford it"; affordability is the wallet's question at signing time.

--- a/docs/adr/0002-simulation-via-debug-tracecall.md
+++ b/docs/adr/0002-simulation-via-debug-tracecall.md
@@ -29,11 +29,14 @@ Monad retains logs inside a failed child frame even though the frame reports `er
   different base states. Verified 2026-07-20 on `rpc.monad.xyz`:
   `debug_traceCall` accepts an explicit block number together with
   `stateOverrides`. If the base block cannot be resolved, simulation halts
-  before the first trace. The pinned base block is exposed through
-  `Simulator.getPinnedBlockNumber()` so consumers can cite the exact base
-  state provenance of a run without re-querying the chain: it stays
-  `undefined` until a run pins its block, and never leaks a previous run's
-  block after a resolution failure. Re-verified the same day that `eth_simulateV1`,
+  before the first trace. Every `SimulateOutcome` carries the run's pinned
+  base block as `simulatorPinnedBlock` so consumers can cite the exact base
+  state provenance of that invocation without re-querying the chain: it is
+  filled from the block the run already resolved, is absent when resolution
+  failed, and is retained even when the run later reverts or halts.
+  Provenance is scoped to one `simulate()` invocation — repeated or
+  overlapping runs each return their own block, and no shared latest-run
+  state exists on the simulator instance. Re-verified the same day that `eth_simulateV1`,
   `debug_traceCallMany`, `trace_callMany`, and `eth_callMany` all remain
   unavailable (`-32601`) on `rpc.monad.xyz` and `rpc-mainnet.monadinfra.com`.
 - Monad's `debug_traceCall` **enforces sender balance** (discovered 2026-07-07: a 2-MON transfer from an underfunded address is rejected with `insufficient balance`, unlike geth's default). The simulator therefore pre-funds the transaction sender via a balance override — matching `eth_simulateV1`'s validation-off semantics. Simulation answers "what would this transaction do", not "can the account afford it"; affordability is the wallet's question at signing time.

--- a/packages/simulator/src/index.ts
+++ b/packages/simulator/src/index.ts
@@ -58,6 +58,25 @@ export interface SimulateOutcome {
 
 export interface Simulator {
   simulate(root: CapabilityNode): Promise<SimulateOutcome>;
+  /**
+   * The base block pinned by the most recent simulate() invocation, or
+   * undefined when no invocation has successfully pinned one yet.
+   *
+   * Semantics:
+   * - Exact identity: the returned block is the one the run resolved once and
+   *   reused for every trace, gas estimate, and state diff (ADR 0002). It is
+   *   never re-queried and never falls back to `latest`.
+   * - Per-run freshness: the exposed state resets at the start of each
+   *   simulate() invocation, so after a failed base-block resolution the
+   *   previous run's block is never reported.
+   * - Post-pin halts: once a run has resolved its base block, the block stays
+   *   available even when the run later halts (trace failure, revert, receipt
+   *   failure, or state-chain failure).
+   * - Availability: the value reflects the most recent invocation that
+   *   completed block pinning. Overlapping concurrent simulate() calls on the
+   *   same instance are not concurrency-safe.
+   */
+  getPinnedBlockNumber?(): Promise<Hex | undefined>;
 }
 
 export interface SimulatorOptions {
@@ -72,8 +91,19 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
   const gasBudget = options.gasPerTx ?? DEFAULT_SIMULATION_GAS;
   const prefund: `0x${string}` = `0x${(options.prefundWei ?? DEFAULT_PREFUND_WEI).toString(16)}`;
 
+  // Base block pinned by the most recent simulate() run. Fail-closed:
+  // undefined until a run resolves and pins its block (ADR 0002).
+  let pinnedBlock: Hex | undefined;
+
   return {
+    async getPinnedBlockNumber(): Promise<Hex | undefined> {
+      return pinnedBlock;
+    },
+
     async simulate(root): Promise<SimulateOutcome> {
+      // Reset the exposed pinned block before resolving the new base block so
+      // a resolution failure can never leak the previous run's block.
+      pinnedBlock = undefined;
       const executable = flattenCapabilityTree(root);
       const overrides: StateOverrides = {};
       const results: TransactionSimulation[] = [];
@@ -98,6 +128,10 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
         }
         return { results, halted: { transactionIndex: 0, reason } };
       }
+
+      // This is the exact block every trace, gas estimate, and state diff in
+      // the run is pinned to; keep it exposed even if the run halts later.
+      pinnedBlock = block;
 
       for (const [transactionIndex, { capability, transaction }] of executable.entries()) {
         const sender = transaction.from.toLowerCase() as keyof StateOverrides;

--- a/packages/simulator/src/index.ts
+++ b/packages/simulator/src/index.ts
@@ -54,29 +54,20 @@ export interface TransactionSimulation {
 export interface SimulateOutcome {
   results: TransactionSimulation[];
   halted?: { transactionIndex: number; reason: string };
+  /**
+   * The exact base block this simulate() invocation resolved once and reused
+   * for every trace, gas estimate, and state diff in the run (ADR 0002). It is
+   * filled from the run's already-resolved block — reading it never queries
+   * the chain. Absent when base-block resolution failed, so no fabricated or
+   * stale block is ever reported. Scoped to this outcome: repeated or
+   * overlapping simulate() calls each carry their own block, and the value is
+   * retained even when the run later reverts or halts.
+   */
+  simulatorPinnedBlock?: Hex;
 }
 
 export interface Simulator {
   simulate(root: CapabilityNode): Promise<SimulateOutcome>;
-  /**
-   * The base block pinned by the most recent simulate() invocation, or
-   * undefined when no invocation has successfully pinned one yet.
-   *
-   * Semantics:
-   * - Exact identity: the returned block is the one the run resolved once and
-   *   reused for every trace, gas estimate, and state diff (ADR 0002). It is
-   *   never re-queried and never falls back to `latest`.
-   * - Per-run freshness: the exposed state resets at the start of each
-   *   simulate() invocation, so after a failed base-block resolution the
-   *   previous run's block is never reported.
-   * - Post-pin halts: once a run has resolved its base block, the block stays
-   *   available even when the run later halts (trace failure, revert, receipt
-   *   failure, or state-chain failure).
-   * - Availability: the value reflects the most recent invocation that
-   *   completed block pinning. Overlapping concurrent simulate() calls on the
-   *   same instance are not concurrency-safe.
-   */
-  getPinnedBlockNumber?(): Promise<Hex | undefined>;
 }
 
 export interface SimulatorOptions {
@@ -91,19 +82,8 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
   const gasBudget = options.gasPerTx ?? DEFAULT_SIMULATION_GAS;
   const prefund: `0x${string}` = `0x${(options.prefundWei ?? DEFAULT_PREFUND_WEI).toString(16)}`;
 
-  // Base block pinned by the most recent simulate() run. Fail-closed:
-  // undefined until a run resolves and pins its block (ADR 0002).
-  let pinnedBlock: Hex | undefined;
-
   return {
-    async getPinnedBlockNumber(): Promise<Hex | undefined> {
-      return pinnedBlock;
-    },
-
     async simulate(root): Promise<SimulateOutcome> {
-      // Reset the exposed pinned block before resolving the new base block so
-      // a resolution failure can never leak the previous run's block.
-      pinnedBlock = undefined;
       const executable = flattenCapabilityTree(root);
       const overrides: StateOverrides = {};
       const results: TransactionSimulation[] = [];
@@ -130,8 +110,8 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
       }
 
       // This is the exact block every trace, gas estimate, and state diff in
-      // the run is pinned to; keep it exposed even if the run halts later.
-      pinnedBlock = block;
+      // the run is pinned to; every outcome returned from here on carries it,
+      // even when the run halts later.
 
       for (const [transactionIndex, { capability, transaction }] of executable.entries()) {
         const sender = transaction.from.toLowerCase() as keyof StateOverrides;
@@ -157,7 +137,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             warnings: [{ code: "TRACE_FAILED", message: reason }],
             gas: null,
           });
-          return { results, halted: { transactionIndex, reason } };
+          return { results, halted: { transactionIndex, reason }, simulatorPinnedBlock: block };
         }
 
         if (frame.error) {
@@ -171,7 +151,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             warnings: [{ code: "REVERTED", message: `transaction reverted: ${reason}` }],
             gas: null,
           });
-          return { results, halted: { transactionIndex, reason } };
+          return { results, halted: { transactionIndex, reason }, simulatorPinnedBlock: block };
         }
 
         let changes: readonly Change[];
@@ -191,7 +171,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             warnings: [warning],
             gas: null,
           });
-          return { results, halted: { transactionIndex, reason } };
+          return { results, halted: { transactionIndex, reason }, simulatorPinnedBlock: block };
         }
 
         let receipt: Receipt;
@@ -217,7 +197,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             ],
             gas: null,
           });
-          return { results, halted: { transactionIndex, reason } };
+          return { results, halted: { transactionIndex, reason }, simulatorPinnedBlock: block };
         }
 
         const gas = await estimateGasWithOverrides(runtime.client, call, block, overrides);
@@ -244,7 +224,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
               warnings: [{ code: "STATE_CHAIN_FAILED", message: reason }],
               gas: gas?.toString() ?? null,
             });
-            return { results, halted: { transactionIndex, reason } };
+            return { results, halted: { transactionIndex, reason }, simulatorPinnedBlock: block };
           }
         }
         results.push({
@@ -258,7 +238,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
           gas: gas?.toString() ?? null,
         });
       }
-      return { results };
+      return { results, simulatorPinnedBlock: block };
     },
   };
 }

--- a/packages/simulator/test/receipt-simulator.test.ts
+++ b/packages/simulator/test/receipt-simulator.test.ts
@@ -324,3 +324,118 @@ describe("Capability simulation", () => {
     });
   });
 });
+
+describe("Pinned block API", () => {
+  const BLOCK_A = "0xabc";
+  const BLOCK_B = "0xdef";
+
+  function pinnedBlockRuntime(
+    blocks: string[],
+    requests: { method: string; params: unknown[] }[],
+    failTrace = false,
+  ): MossRuntime {
+    let blockIndex = 0;
+    return {
+      rpcUrl: "http://offline",
+      client: {
+        request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+          requests.push({ method, params: params ?? [] });
+          if (method === "eth_blockNumber") {
+            if (blockIndex >= blocks.length) throw new Error("rpc unreachable");
+            return blocks[blockIndex++];
+          }
+          if (method === "eth_estimateGas") return "0x5208";
+          const tracer = (params?.[2] as { tracer?: string } | undefined)?.tracer;
+          if (tracer === "callTracer") {
+            if (failTrace) throw new Error("debug_traceCall unavailable");
+            return { type: "CALL", from: A, to: B, logs: [] } satisfies CallFrame;
+          }
+          if (tracer === "prestateTracer") return { pre: {}, post: {} } satisfies PrestateDiff;
+          throw new Error(`unexpected RPC method ${method}`);
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal debug RPC fixture
+      } as any,
+    };
+  }
+
+  it("returns undefined before the first simulation without fabricating a block", async () => {
+    const requests: { method: string; params: unknown[] }[] = [];
+    const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A], requests), {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    });
+    expect(await simulator.getPinnedBlockNumber?.()).toBeUndefined();
+    // No RPC of any kind happened before the first simulate.
+    expect(requests).toEqual([]);
+  });
+
+  it("exposes the exact block used by every trace, gas estimate, and diff without extra RPC", async () => {
+    const requests: { method: string; params: unknown[] }[] = [];
+    const simulator = createTraceSimulator(pinnedBlockRuntime([PINNED_BLOCK], requests), {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    });
+
+    const outcome = await simulator.simulate(capability("parent", C, [capability("child", B)]));
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results).toHaveLength(2);
+
+    const pinned = await simulator.getPinnedBlockNumber?.();
+    expect(pinned).toBe(PINNED_BLOCK);
+
+    // Every trace, diff, and gas estimate pinned the getter's block.
+    const blockUsing = requests.filter(
+      ({ method }) => method === "debug_traceCall" || method === "eth_estimateGas",
+    );
+    expect(blockUsing.length).toBeGreaterThan(0);
+    for (const { params } of blockUsing) {
+      expect(params[1]).toBe(PINNED_BLOCK);
+    }
+
+    // The getter itself issued no second eth_blockNumber.
+    expect(requests.filter(({ method }) => method === "eth_blockNumber")).toHaveLength(1);
+  });
+
+  it("reports the latest run's block across repeated simulations", async () => {
+    const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A, BLOCK_B], []), {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    });
+
+    await simulator.simulate(capability("fixture", B));
+    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_A);
+
+    await simulator.simulate(capability("fixture", B));
+    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_B);
+  });
+
+  it("never leaks the previous run's block after a base-block resolution failure", async () => {
+    const simulator = createTraceSimulator(
+      // Only one block: the second simulate() resolution fails fail-closed.
+      pinnedBlockRuntime([BLOCK_A], []),
+      { receipt: (node, changes) => coveringReceipt(node.protocol, changes) },
+    );
+
+    await simulator.simulate(capability("fixture", B));
+    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_A);
+
+    const outcome = await simulator.simulate(capability("fixture", B));
+    expect(outcome.halted).toBeDefined();
+    expect(await simulator.getPinnedBlockNumber?.()).toBeUndefined();
+  });
+
+  it("keeps the pinned block available after a post-pin halt", async () => {
+    const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A], [], true), {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    });
+
+    const outcome = await simulator.simulate(capability("fixture", B));
+    expect(outcome.halted).toBeDefined();
+    // The run pinned BLOCK_A before the trace failed, so it stays exposed.
+    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_A);
+  });
+
+  it("the createTraceSimulator return value implements the optional getter", async () => {
+    const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A], []), {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    });
+    expect(simulator.getPinnedBlockNumber).toBeTypeOf("function");
+  });
+});

--- a/packages/simulator/test/receipt-simulator.test.ts
+++ b/packages/simulator/test/receipt-simulator.test.ts
@@ -185,6 +185,9 @@ describe("Capability simulation", () => {
       { code: "STATE_CHAIN_FAILED", message: "prestate unavailable" },
     ]);
     expect(outcome.halted).toEqual({ transactionIndex: 0, reason: "prestate unavailable" });
+    // The run pinned its base block before state chaining failed, so the
+    // halted outcome still carries that provenance.
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
   });
 
   it("returns no Receipt for a revert and stops later transactions", async () => {
@@ -215,6 +218,8 @@ describe("Capability simulation", () => {
     expect(outcome.results[0]?.receipt).toBeUndefined();
     expect(outcome.results[0]?.warnings[0]?.code).toBe("REVERTED");
     expect(outcome.halted).toEqual({ transactionIndex: 0, reason: "execution reverted" });
+    // The reverted run still used its resolved base block for the trace.
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
   });
 
   it("turns unavailable trace evidence into a terminal Warning", async () => {
@@ -235,6 +240,9 @@ describe("Capability simulation", () => {
       { code: "TRACE_FAILED", message: "debug_traceCall unavailable" },
     ]);
     expect(outcome.halted?.transactionIndex).toBe(0);
+    // The base block resolved before the trace failed, so the halted outcome
+    // retains the block the run actually pinned.
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
   });
 
   it("halts before any trace when the base block cannot be resolved", async () => {
@@ -258,6 +266,8 @@ describe("Capability simulation", () => {
       { code: "TRACE_FAILED", message: "rpc unreachable" },
     ]);
     expect(outcome.halted).toEqual({ transactionIndex: 0, reason: "rpc unreachable" });
+    // Base-block resolution failed: no fabricated pin and no stale block.
+    expect(outcome.simulatorPinnedBlock).toBeUndefined();
   });
 
   it("classifies forged Change coverage and halts before later work", async () => {
@@ -291,6 +301,7 @@ describe("Capability simulation", () => {
       transactionIndex: 0,
       reason: "Receipt Change 0 does not retain the original object in order",
     });
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
     expect(requests).toEqual([
       { method: "eth_blockNumber" },
       { method: "debug_traceCall", tracer: "callTracer" },
@@ -322,12 +333,21 @@ describe("Capability simulation", () => {
       transactionIndex: 0,
       reason: "parser rejected ambiguous evidence",
     });
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
   });
 });
 
-describe("Pinned block API", () => {
+describe("Pinned base block on SimulateOutcome", () => {
   const BLOCK_A = "0xabc";
   const BLOCK_B = "0xdef";
+
+  function deferredGate(): { promise: Promise<void>; open: () => void } {
+    let open = () => {};
+    const promise = new Promise<void>((resolve) => {
+      open = resolve;
+    });
+    return { promise, open };
+  }
 
   function pinnedBlockRuntime(
     blocks: string[],
@@ -358,30 +378,17 @@ describe("Pinned block API", () => {
     };
   }
 
-  it("returns undefined before the first simulation without fabricating a block", async () => {
+  it("exposes the exact block every trace, gas estimate, and diff used, without extra RPC", async () => {
     const requests: { method: string; params: unknown[] }[] = [];
-    const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A], requests), {
+    const outcome = await createTraceSimulator(pinnedBlockRuntime([PINNED_BLOCK], requests), {
       receipt: (node, changes) => coveringReceipt(node.protocol, changes),
-    });
-    expect(await simulator.getPinnedBlockNumber?.()).toBeUndefined();
-    // No RPC of any kind happened before the first simulate.
-    expect(requests).toEqual([]);
-  });
+    }).simulate(capability("parent", C, [capability("child", B)]));
 
-  it("exposes the exact block used by every trace, gas estimate, and diff without extra RPC", async () => {
-    const requests: { method: string; params: unknown[] }[] = [];
-    const simulator = createTraceSimulator(pinnedBlockRuntime([PINNED_BLOCK], requests), {
-      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
-    });
-
-    const outcome = await simulator.simulate(capability("parent", C, [capability("child", B)]));
     expect(outcome.halted).toBeUndefined();
     expect(outcome.results).toHaveLength(2);
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
 
-    const pinned = await simulator.getPinnedBlockNumber?.();
-    expect(pinned).toBe(PINNED_BLOCK);
-
-    // Every trace, diff, and gas estimate pinned the getter's block.
+    // Every trace, diff, and gas estimate pinned the outcome's block.
     const blockUsing = requests.filter(
       ({ method }) => method === "debug_traceCall" || method === "eth_estimateGas",
     );
@@ -390,52 +397,108 @@ describe("Pinned block API", () => {
       expect(params[1]).toBe(PINNED_BLOCK);
     }
 
-    // The getter itself issued no second eth_blockNumber.
+    // The provenance is the run's already-resolved block: no second
+    // eth_blockNumber was issued for it.
     expect(requests.filter(({ method }) => method === "eth_blockNumber")).toHaveLength(1);
   });
 
-  it("reports the latest run's block across repeated simulations", async () => {
+  it("returns each run's own block across repeated simulations", async () => {
     const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A, BLOCK_B], []), {
       receipt: (node, changes) => coveringReceipt(node.protocol, changes),
     });
 
-    await simulator.simulate(capability("fixture", B));
-    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_A);
+    const first = await simulator.simulate(capability("fixture", B));
+    const second = await simulator.simulate(capability("fixture", B));
 
-    await simulator.simulate(capability("fixture", B));
-    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_B);
+    expect(first.simulatorPinnedBlock).toBe(BLOCK_A);
+    expect(second.simulatorPinnedBlock).toBe(BLOCK_B);
+    // Reading the first outcome after the second run still reports run 1's block.
+    expect(first.simulatorPinnedBlock).toBe(BLOCK_A);
   });
 
-  it("never leaks the previous run's block after a base-block resolution failure", async () => {
+  it("leaves the field absent when base-block resolution fails, never leaking the previous run", async () => {
     const simulator = createTraceSimulator(
       // Only one block: the second simulate() resolution fails fail-closed.
       pinnedBlockRuntime([BLOCK_A], []),
       { receipt: (node, changes) => coveringReceipt(node.protocol, changes) },
     );
 
-    await simulator.simulate(capability("fixture", B));
-    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_A);
+    const first = await simulator.simulate(capability("fixture", B));
+    expect(first.simulatorPinnedBlock).toBe(BLOCK_A);
 
-    const outcome = await simulator.simulate(capability("fixture", B));
-    expect(outcome.halted).toBeDefined();
-    expect(await simulator.getPinnedBlockNumber?.()).toBeUndefined();
+    const failed = await simulator.simulate(capability("fixture", B));
+    expect(failed.halted).toBeDefined();
+    expect(failed.simulatorPinnedBlock).toBeUndefined();
   });
 
-  it("keeps the pinned block available after a post-pin halt", async () => {
-    const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A], [], true), {
+  it("retains the pinned block on a post-pin halt", async () => {
+    const outcome = await createTraceSimulator(pinnedBlockRuntime([BLOCK_A], [], true), {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    }).simulate(capability("fixture", B));
+
+    expect(outcome.halted).toBeDefined();
+    // The run pinned BLOCK_A before the trace failed, so its outcome keeps it.
+    expect(outcome.simulatorPinnedBlock).toBe(BLOCK_A);
+  });
+
+  it("keeps independent pinned blocks for overlapping runs on one instance", async () => {
+    const requests: { method: string; params: unknown[] }[] = [];
+    // Gates park both simulate() calls mid-flight so they genuinely overlap on
+    // the same simulator instance: run A resolves BLOCK_A and stalls on its
+    // first trace while run B resolves BLOCK_B and completes.
+    const resolutionGate = deferredGate();
+    const traceGate = deferredGate();
+    let blockIndex = 0;
+    let callIndex = 0;
+    const runtime: MossRuntime = {
+      rpcUrl: "http://offline",
+      client: {
+        request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+          requests.push({ method, params: params ?? [] });
+          if (method === "eth_blockNumber") {
+            const which = blockIndex++;
+            await resolutionGate.promise;
+            return which === 0 ? BLOCK_A : BLOCK_B;
+          }
+          if (method === "eth_estimateGas") return "0x5208";
+          const tracer = (params?.[2] as { tracer?: string } | undefined)?.tracer;
+          if (tracer === "callTracer") {
+            if (callIndex++ === 0) await traceGate.promise;
+            return { type: "CALL", from: A, to: B, logs: [] } satisfies CallFrame;
+          }
+          if (tracer === "prestateTracer") return { pre: {}, post: {} } satisfies PrestateDiff;
+          throw new Error(`unexpected RPC method ${method}`);
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal debug RPC fixture
+      } as any,
+    };
+    const simulator = createTraceSimulator(runtime, {
       receipt: (node, changes) => coveringReceipt(node.protocol, changes),
     });
 
-    const outcome = await simulator.simulate(capability("fixture", B));
-    expect(outcome.halted).toBeDefined();
-    // The run pinned BLOCK_A before the trace failed, so it stays exposed.
-    expect(await simulator.getPinnedBlockNumber?.()).toBe(BLOCK_A);
-  });
+    const runA = simulator.simulate(capability("fixture", B));
+    const runB = simulator.simulate(capability("fixture", B));
 
-  it("the createTraceSimulator return value implements the optional getter", async () => {
-    const simulator = createTraceSimulator(pinnedBlockRuntime([BLOCK_A], []), {
-      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
-    });
-    expect(simulator.getPinnedBlockNumber).toBeTypeOf("function");
+    // Both runs are parked on their block resolution: genuinely overlapping.
+    resolutionGate.open();
+    // Run B finishes entirely while run A is still parked on its first trace.
+    const outcomeB = await runB;
+    traceGate.open();
+    const outcomeA = await runA;
+
+    expect(outcomeA.simulatorPinnedBlock).toBe(BLOCK_A);
+    expect(outcomeB.simulatorPinnedBlock).toBe(BLOCK_B);
+
+    // Each run's trace and gas estimate used the block its own outcome reports.
+    const blocksUsed = new Map<string, number>();
+    for (const { method, params } of requests) {
+      if (method === "debug_traceCall" || method === "eth_estimateGas") {
+        const block = params[1] as string;
+        blocksUsed.set(block, (blocksUsed.get(block) ?? 0) + 1);
+      }
+    }
+    expect(blocksUsed.get(BLOCK_A)).toBe(2); // callTracer + estimateGas
+    expect(blocksUsed.get(BLOCK_B)).toBe(2);
+    expect(requests.filter(({ method }) => method === "eth_blockNumber")).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## What and why

Refs #172.

The trace simulator already resolves one authoritative base block for each
`simulate()` invocation and reuses that exact block for trace calls, gas
estimation, and state-diff tracing.

This PR exposes that provenance directly on the `SimulateOutcome` for that
invocation.

It does not re-query the chain and does not change simulation behavior.

## API

`Simulator.simulate(root): Promise<SimulateOutcome>` is unchanged.
`SimulateOutcome` gains an additive optional field:

`simulatorPinnedBlock?: Hex`

Semantics:

- absent when base-block resolution did not succeed;
- present once the invocation resolved its authoritative simulation block;
- success, revert, and post-pin halted outcomes retain that run's block;
- repeated invocations retain their own provenance;
- overlapping invocations cannot overwrite one another because provenance is
  carried by each outcome rather than shared simulator state;
- no additional `eth_blockNumber` request is performed.

## Type of change

- [x] Core / simulator / MCP server
- [x] Documentation
- [ ] Protocol / Capability / Query
- [ ] Bug fix
- [ ] Tooling / dependency

## Framework and package impact

Changed:

- `packages/simulator/src/index.ts`
- simulator pinned-block regression tests
- ADR 0002
- patch changeset for `@themoss/simulator`

The API is an additive optional field on `SimulateOutcome`.

No Kuru implementation or Receipt semantics are changed.

## Verification

Completed locally from upstream `main`
`43de24fc5696788d7fb79dacc98da62826ffdb85`:

- `pnpm --filter @themoss/simulator test` — 19 passed across 3 files
- `pnpm --filter @themoss/simulator build` — passed
- `pnpm --filter @themoss/simulator typecheck` — passed
- `pnpm lint` — passed, 162 files
- `pnpm build` — passed
- `pnpm typecheck` — passed
- `pnpm test:offline` — 263 passed, 15 skipped
- `pnpm test` — 278 passed
- `git diff --check` — passed

Focused coverage verifies:

- the exact resolved block is returned on the outcome;
- reading the provenance performs no second `eth_blockNumber`;
- trace, gas estimation, and state-diff tracing use the same block;
- a resolution failure exposes no stale pin;
- a post-pin halt retains that run's block provenance;
- repeated runs retain independent blocks;
- overlapping runs retain independent provenance.

## Protocol changes

N/A.

## Security / execution scope

This PR does not add or change:

- signing;
- transaction broadcasting;
- wallet mutation;
- private-key handling;
- transaction execution semantics.

It only exposes simulation provenance already selected internally.

## Parallax context

Parallax currently uses the temporary fork pin
`ef15448e166f31c891e80dba5073dae04a052a2b`.

Parallax has confirmed that `SimulateOutcome.simulatorPinnedBlock` is
compatible and preferred over the getter design; this PR does not modify the
Parallax repository.

The simulator pin must not be replaced by a stage RPC `blockNumber` or by a
fresh query for the latest block.

After this upstream API is merged and an immutable Moss revision containing
the required Kuru Receipt support and pinned-block provenance is confirmed,
Parallax can migrate its consumer and rerun Live acceptance.

## Issue

Refs #172.
