### PR TITLE
test: add Receipt text-projection regression coverage (#115)

### DIFF
--- a/packages/erc/test/erc20.test.ts
+++ b/packages/erc/test/erc20.test.ts
@@ -4,6 +4,7 @@ import {
   type Hex,
   type MossRuntime,
   NATIVE,
+  type ReceiptResult,
   Registry,
 } from "@themoss/core";
 import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
@@ -27,6 +28,15 @@ function registryWithDecimals(decimals = 6) {
     } as unknown as MossRuntime["client"],
   };
   return new Registry(runtime).use(ERC20);
+}
+
+// Mirrors the MCP layer's receiptTexts (mcp-server/src/server.ts): the ordered
+// leaf `text` strings an Agent reads. Kept local so the projection contract is
+// asserted without a dependency on the server package.
+function flattenReceiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : flattenReceiptTexts(entry),
+  );
 }
 
 describe("ERC20", () => {
@@ -110,7 +120,44 @@ describe("ERC20", () => {
       { operation: "transfer", token: TOKEN, from: ACCOUNT, to: RECIPIENT, amount: "15" },
       { operation: "approve", token: TOKEN, owner: ACCOUNT, spender: SPENDER, amount: "42" },
     ]);
-    expect(receipt.text).toContain("ERC20 Transfer:");
-    expect(receipt.text).toContain("ERC20 Approval:");
+
+    // Lock the exact leaf text an Agent reads for each Change class. Raw
+    // base-unit amounts and address rendering are the accepted convention.
+    const transferText = `ERC20 Transfer: 15 ${TOKEN} from ${ACCOUNT} to ${RECIPIENT}`;
+    const approvalText = `ERC20 Approval: ${ACCOUNT} approved ${SPENDER} for 42 ${TOKEN}`;
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      transferText,
+      approvalText,
+    ]);
+
+    // Top-level Receipt text joins the leaf texts in order.
+    expect(receipt.text).toBe(`${transferText}; ${approvalText}`);
+
+    // The ordered leaf-text sequence, flattened exactly as receiptTexts projects
+    // it to Agents, locks order and completeness together.
+    expect(flattenReceiptTexts(receipt)).toEqual([transferText, approvalText]);
+  });
+
+  it("renders native transfer text with the NATIVE sentinel and raw base units", () => {
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: RECIPIENT,
+      value: "500000000000000000",
+    } satisfies Change;
+    const protocol = Object.create(ERC20.prototype) as ERC20;
+    const receipt = protocol.changesReceipt([native]);
+    expect(receipt.outcome).toEqual([
+      {
+        operation: "transfer",
+        token: NATIVE,
+        from: ACCOUNT,
+        to: RECIPIENT,
+        amount: "500000000000000000",
+      },
+    ]);
+    const nativeText = `ERC20 Transfer: 500000000000000000 ${NATIVE} from ${ACCOUNT} to ${RECIPIENT}`;
+    expect(receipt.text).toBe(nativeText);
+    expect(flattenReceiptTexts(receipt)).toEqual([nativeText]);
   });
 });

--- a/packages/protocols/_template/test/adapter.test.ts
+++ b/packages/protocols/_template/test/adapter.test.ts
@@ -3,6 +3,7 @@ import {
   flattenCapabilityTree,
   type Hex,
   type MossRuntime,
+  type ReceiptResult,
   Registry,
 } from "@themoss/core";
 import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
@@ -12,6 +13,16 @@ import { EXAMPLE_VAULT_ADDRESS, ExampleProtocol } from "../src/index.js";
 
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
+
+// Mirrors the MCP layer's receiptTexts (mcp-server/src/server.ts): the ordered
+// leaf `text` strings an Agent reads. Kept local so the projection contract is
+// asserted without a dependency on the server package. New protocols scaffolded
+// from this template should copy this helper into their own test file.
+function flattenReceiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : flattenReceiptTexts(entry),
+  );
+}
 
 describe("Protocol template", () => {
   it("registers its exported Protocol directly and builds one transaction", async () => {
@@ -54,5 +65,24 @@ describe("Protocol template", () => {
       kind: "change",
       text: `Native MON Transfer: 1000000000000000000 from ${ACCOUNT} to Package(Template:Vault)`,
     });
+
+    // Canonical Receipt text-projection lock. New protocols scaffolded from this
+    // template should copy this block. Lock the exact leaf text an Agent reads
+    // for each Change class in order. Raw base-unit amounts plus label or raw
+    // address rendering are the accepted convention.
+    const nativeText = `Native MON Transfer: 1000000000000000000 from ${ACCOUNT} to Package(Template:Vault)`;
+    const depositText = `Example Deposit: 1000000000000000000 by ${ACCOUNT}`;
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      nativeText,
+      depositText,
+    ]);
+
+    // Top-level Receipt text. This parser summarizes with its deposit line, so
+    // confirm the exact string rather than assuming a joined form.
+    expect(receipt.text).toBe(depositText);
+
+    // The ordered leaf-text sequence, flattened exactly as receiptTexts projects
+    // it to Agents, locks order and completeness together.
+    expect(flattenReceiptTexts(receipt)).toEqual([nativeText, depositText]);
   });
 });

--- a/packages/protocols/kuru/test/kuru.test.ts
+++ b/packages/protocols/kuru/test/kuru.test.ts
@@ -51,6 +51,15 @@ const MARKETS: readonly MockMarket[] = [
   market(DIRECT_USDC_AUSD_BETTER, USDC_ADDRESS, AUSD_ADDRESS, 6, 6, 11n, 10n),
 ];
 
+// Mirrors the MCP layer's receiptTexts (mcp-server/src/server.ts): the ordered
+// leaf `text` strings an Agent reads. Kept local so the projection contract is
+// asserted without a dependency on the server package.
+function flattenReceiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : flattenReceiptTexts(entry),
+  );
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
@@ -239,6 +248,62 @@ describe("Kuru", () => {
       ],
     });
     expect(receipt.changes.map(firstChange)).toEqual(changes);
+  });
+
+  it("projects the exact Receipt text an Agent reads for every Change class", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const transfer = erc20Transfer(USDC_ADDRESS, ACCOUNT, KURU_ROUTER_ADDRESS, 1_000_000n);
+    const flip = flipOrderUpdatedChange(MON_USDC, 7n, 30n);
+    const firstTrade = tradeChange(MON_USDC, 8n);
+    const flipped = flippedOrderCreatedChange(MON_AUSD);
+    const secondTrade = tradeChange(MON_AUSD, 11n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+    const changes = [transfer, flip, firstTrade, flipped, secondTrade, router] as const;
+
+    const receipt = registry.parseReceipt(capability, changes);
+
+    // Exact leaf text for each Change class the parser produces. Raw base-unit
+    // amounts and address rendering are the accepted convention, so lock the
+    // literal strings.
+    const erc20TransferText = `ERC20 Transfer: 1000000 ${USDC_ADDRESS} from ${ACCOUNT} to ${KURU_ROUTER_ADDRESS}`;
+    const flipText = `Flip Order Updated: order 7 has size 30 emitted by ${MON_USDC}`;
+    const firstTradeText = `Trade Event: 20 at 10 emitted by ${MON_USDC}`;
+    const flippedText = `Flipped Order Created: order ID 11, flipped ID 12, owner ${ACCOUNT}; size 30, price 40, flipped price 50, is buy true, emitted by ${MON_AUSD}`;
+    const secondTradeText = `Trade Event: 20 at 10 emitted by ${MON_AUSD}`;
+    const swapText = `Kuru Swap: 1000000 ${USDC_ADDRESS} to 1200000 ${AUSD_ADDRESS} by ${ACCOUNT}`;
+
+    // The ERC20 transfer is delegated to a nested Receipt, so it reads as null
+    // at the top level and its leaf text lives one level down.
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      null,
+      flipText,
+      firstTradeText,
+      flippedText,
+      secondTradeText,
+      swapText,
+    ]);
+    const nested = receipt.changes[0];
+    if (nested?.kind !== "receipt") throw new Error("expected a nested ERC20 Receipt");
+    expect(nested.text).toBe(erc20TransferText);
+
+    // Top-level Receipt text is the Kuru swap summary with the observed Trade
+    // count, not a join of the leaf texts.
+    expect(receipt.text).toBe(
+      `Kuru Swap: 1000000 ${USDC_ADDRESS} to 1200000 ${AUSD_ADDRESS}; 2 Trade events observed`,
+    );
+
+    // The full ordered leaf-text sequence, flattened exactly as receiptTexts
+    // projects it to Agents, locks order and completeness together. The nested
+    // ERC20 leaf surfaces here.
+    expect(flattenReceiptTexts(receipt)).toEqual([
+      erc20TransferText,
+      flipText,
+      firstTradeText,
+      flippedText,
+      secondTradeText,
+      swapText,
+    ]);
   });
 
   it("represents FlipOrderUpdated before its market Trade", async () => {

--- a/packages/protocols/pancakeswap/test/pancakeswap-v2.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap-v2.test.ts
@@ -30,6 +30,10 @@ import {
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 const PAIR = getAddress("0x1111111111111111111111111111111111111111");
 const SECOND_PAIR = getAddress("0x2222222222222222222222222222222222222222");
+// The Registry projects the Router address to its Package label when it renders
+// Receipt text (labels.Router in the Protocol metadata). Locking the label locks
+// that projection alongside the raw base-unit and checksummed-address convention.
+const ROUTER_LABEL = "Package(Pancakeswap V2:Router)";
 
 describe("PancakeSwapV2", () => {
   it("is self-describing and loads separate human-amount fields", async () => {
@@ -200,6 +204,30 @@ describe("PancakeSwapV2", () => {
       pairs: [PAIR],
     });
     expect(flattenReceiptChanges(receipt)).toEqual(changes);
+
+    // Lock the exact projected text per Change class. Raw base-unit amounts and
+    // checksummed addresses are the accepted convention. The two token transfers
+    // are delegated to erc20.changesReceipt as nested Receipts, so they read as
+    // null at the top level and surface as ERC20 leaves in the flat sequence.
+    const inputTransferText = `ERC20 Transfer: 1000000 ${USDC_ADDRESS} from ${ACCOUNT} to ${PAIR}`;
+    const outputTransferText = `ERC20 Transfer: 20000 ${AUSD_ADDRESS} from ${PAIR} to ${ACCOUNT}`;
+    const syncText = `PancakeSwap Sync: reserves 10000000/20000000 at ${PAIR}`;
+    const swapText = `PancakeSwap Pair Swap: 1000000 in and 20000 out at ${PAIR}`;
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      null,
+      null,
+      syncText,
+      swapText,
+    ]);
+    expect(receipt.text).toBe(
+      `PancakeSwap Swap: 1000000 ${USDC_ADDRESS} to 20000 ${AUSD_ADDRESS} for ${ACCOUNT}`,
+    );
+    expect(flattenReceiptTexts(receipt)).toEqual([
+      inputTransferText,
+      outputTransferText,
+      syncText,
+      swapText,
+    ]);
   });
 
   it("derives native input only from ordered wrap and Pair evidence", async () => {
@@ -230,6 +258,37 @@ describe("PancakeSwapV2", () => {
       amountOut: "20000",
     });
     expect(flattenReceiptChanges(receipt)).toEqual(changes);
+
+    // WMON Deposit renders through its own leaf. The wrap and funding native
+    // transfers plus the WMON funding transfer are delegated ERC20 leaves.
+    const fundingText = `ERC20 Transfer: 1000000000000000000 ${NATIVE} from ${ACCOUNT} to ${ROUTER_LABEL}`;
+    const wrapText = `ERC20 Transfer: 1000000000000000000 ${NATIVE} from ${ROUTER_LABEL} to ${WMON_ADDRESS}`;
+    const depositText = `WMON Deposit: 1000000000000000000 for ${ROUTER_LABEL}`;
+    const wmonToPairText = `ERC20 Transfer: 1000000000000000000 ${WMON_ADDRESS} from ${ROUTER_LABEL} to ${PAIR}`;
+    const outputTransferText = `ERC20 Transfer: 20000 ${USDC_ADDRESS} from ${PAIR} to ${ACCOUNT}`;
+    const syncText = `PancakeSwap Sync: reserves 1000000000000000000/20000 at ${PAIR}`;
+    const swapText = `PancakeSwap Pair Swap: 1000000000000000000 in and 20000 out at ${PAIR}`;
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      null,
+      null,
+      depositText,
+      null,
+      null,
+      syncText,
+      swapText,
+    ]);
+    expect(receipt.text).toBe(
+      `PancakeSwap Swap: 1000000000000000000 ${NATIVE} to 20000 ${USDC_ADDRESS} for ${ACCOUNT}`,
+    );
+    expect(flattenReceiptTexts(receipt)).toEqual([
+      fundingText,
+      wrapText,
+      depositText,
+      wmonToPairText,
+      outputTransferText,
+      syncText,
+      swapText,
+    ]);
   });
 
   it("parses a two-Pair WMON hop in execution order", async () => {
@@ -288,6 +347,37 @@ describe("PancakeSwapV2", () => {
       amountOut: amountOut.toString(),
     });
     expect(flattenReceiptChanges(receipt)).toEqual(changes);
+
+    // WMON Withdrawal renders through its own leaf. The unwrap and payout native
+    // transfers plus the WMON output transfer are delegated ERC20 leaves.
+    const inputTransferText = `ERC20 Transfer: 1000000 ${USDC_ADDRESS} from ${ACCOUNT} to ${PAIR}`;
+    const pairToRouterText = `ERC20 Transfer: 2000000000000000000 ${WMON_ADDRESS} from ${PAIR} to ${ROUTER_LABEL}`;
+    const syncText = `PancakeSwap Sync: reserves 1000000/2000000000000000000 at ${PAIR}`;
+    const swapText = `PancakeSwap Pair Swap: 1000000 in and 2000000000000000000 out at ${PAIR}`;
+    const unwrapText = `ERC20 Transfer: 2000000000000000000 ${NATIVE} from ${WMON_ADDRESS} to ${ROUTER_LABEL}`;
+    const withdrawalText = `WMON Withdrawal: 2000000000000000000 for ${ROUTER_LABEL}`;
+    const payoutText = `ERC20 Transfer: 2000000000000000000 ${NATIVE} from ${ROUTER_LABEL} to ${ACCOUNT}`;
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      null,
+      null,
+      syncText,
+      swapText,
+      null,
+      withdrawalText,
+      null,
+    ]);
+    expect(receipt.text).toBe(
+      `PancakeSwap Swap: 1000000 ${USDC_ADDRESS} to 2000000000000000000 ${NATIVE} for ${ACCOUNT}`,
+    );
+    expect(flattenReceiptTexts(receipt)).toEqual([
+      inputTransferText,
+      pairToRouterText,
+      syncText,
+      swapText,
+      unwrapText,
+      withdrawalText,
+      payoutText,
+    ]);
   });
 
   it("rejects missing or reordered Pair evidence", async () => {
@@ -528,5 +618,14 @@ function wethChange(
 function flattenReceiptChanges(receipt: ReceiptResult): Change[] {
   return receipt.changes.flatMap((entry) =>
     entry.kind === "change" ? [entry.change] : flattenReceiptChanges(entry),
+  );
+}
+
+// Mirrors the MCP layer's receiptTexts (mcp-server/src/server.ts): the ordered
+// leaf `text` strings an Agent reads. Kept local so the projection contract is
+// asserted without a dependency on the server package.
+function flattenReceiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : flattenReceiptTexts(entry),
   );
 }

--- a/packages/protocols/pancakeswap/test/pancakeswap.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap.test.ts
@@ -368,10 +368,13 @@ describe("PancakeSwap swapReceipt", () => {
       nativeText,
       null,
     ]);
-    expect(receipt.text).toBe(
-      `PancakeSwap V3 Swap: 500000000000000000 in ${ACCOUNT} → 450000000000000000 out ${TOKEN_B}`,
-    );
     expect(flattenReceiptTexts(receipt)).toEqual([nativeText, outTransferText]);
+    // The top-level `receipt.text` is left unpinned for a native input on
+    // purpose. swapReceipt takes a nativeTransfer's tokenIn from `change.from`,
+    // so `outcome.tokenIn` and the text rendered from it name the sender account
+    // where the convention calls for the NATIVE sentinel. Pinning that string
+    // would read as accepting an account address as a token identity. The
+    // ERC-20 V3 case below locks the package's top-level format.
   });
 
   it("delegates ERC-20 event parsing to erc20.changesReceipt", async () => {

--- a/packages/protocols/pancakeswap/test/pancakeswap.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap.test.ts
@@ -4,6 +4,7 @@ import {
   flattenCapabilityTree,
   type Hex,
   type MossRuntime,
+  type ReceiptResult,
   Registry,
 } from "@themoss/core";
 import { ERC20Abi } from "@themoss/erc";
@@ -21,6 +22,10 @@ import {
 const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
 const TOKEN_A = getAddress("0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa");
 const TOKEN_B = getAddress("0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb");
+// The Registry projects the Router address to its Package label when it renders
+// Receipt text (labels.Router in the Protocol metadata). Locking the label locks
+// that projection alongside the raw base-unit and checksummed-address convention.
+const ROUTER_LABEL = "Package(Pancakeswap:Router)";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -38,6 +43,15 @@ function firstChange(entry: unknown): Change | undefined {
     return obj.change as Change;
   }
   return entry as Change;
+}
+
+// Mirrors the MCP layer's receiptTexts (mcp-server/src/server.ts): the ordered
+// leaf `text` strings an Agent reads. Kept local so the projection contract is
+// asserted without a dependency on the server package.
+function flattenReceiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : flattenReceiptTexts(entry),
+  );
 }
 
 function erc20Transfer(token: string, from: string, to: string, amount: bigint): Change {
@@ -345,6 +359,19 @@ describe("PancakeSwap swapReceipt", () => {
       amountIn: "500000000000000000",
       amountOut: "450000000000000000",
     });
+
+    // A native MON transfer renders through its own leaf at the top level; the
+    // ERC-20 output transfer is a delegated nested leaf.
+    const nativeText = `Native MON Transfer: 500000000000000000 from ${ACCOUNT} to ${wmonAddr}`;
+    const outTransferText = `ERC20 Transfer: 450000000000000000 ${TOKEN_B} from ${wmonAddr} to ${ACCOUNT}`;
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      nativeText,
+      null,
+    ]);
+    expect(receipt.text).toBe(
+      `PancakeSwap V3 Swap: 500000000000000000 in ${ACCOUNT} → 450000000000000000 out ${TOKEN_B}`,
+    );
+    expect(flattenReceiptTexts(receipt)).toEqual([nativeText, outTransferText]);
   });
 
   it("delegates ERC-20 event parsing to erc20.changesReceipt", async () => {
@@ -387,6 +414,22 @@ describe("PancakeSwap swapReceipt", () => {
       amountIn: "1000000000000000000",
       amountOut: "900000000000000000",
     });
+
+    // Every event is delegated to erc20.changesReceipt as a nested Receipt, so
+    // each reads as null at the top level and as an ERC20 leaf when flattened.
+    // Raw base-unit amounts and checksummed addresses are the accepted convention.
+    const inTransferText = `ERC20 Transfer: 1000000000000000000 ${TOKEN_A} from ${ACCOUNT} to ${ROUTER_LABEL}`;
+    const approvalText = `ERC20 Approval: ${ACCOUNT} approved ${ROUTER_LABEL} for 0 ${TOKEN_A}`;
+    const outTransferText = `ERC20 Transfer: 900000000000000000 ${TOKEN_B} from ${ROUTER_LABEL} to ${ACCOUNT}`;
+    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
+      null,
+      null,
+      null,
+    ]);
+    expect(receipt.text).toBe(
+      `PancakeSwap V3 Swap: 1000000000000000000 in ${TOKEN_A} → 900000000000000000 out ${TOKEN_B}`,
+    );
+    expect(flattenReceiptTexts(receipt)).toEqual([inTransferText, approvalText, outTransferText]);
   });
 
   it("returns zero placeholders when no Transfer changes are present", async () => {


### PR DESCRIPTION
## What

Ordered leaf `text` strings are the only evidence the MCP layer projects to Agents (`mcp-server/src/server.ts` `receiptTexts`). The Agent safety rule is to compare every ordered text with user intent before signing. Yet no protocol package asserted its text formats, so a dropped field, a reordered interpolation or a wrong unit would pass every existing outcome, ordering and rejection test while silently changing exactly what an Agent reads. This adds the missing coverage. Part of #115.

## What it locks

No source or format change. It pins the current projection for every named Receipt-producing package:

- **erc20**: transfer, approval and native-transfer leaf text, plus the top-level `"; "`-joined text.
- **pancakeswap V2**: Sync, Pair Swap, WMON Deposit and WMON Withdrawal leaves, the delegated ERC20 leaves and the fixed top-level `PancakeSwap Swap: ...` text.
- **pancakeswap V3**: the delegated ERC20 transfer/approval leaves, the Native MON Transfer leaf and the top-level `PancakeSwap V3 Swap: ... in ... → ... out ...` text.
- **kuru**: Kuru Swap, Trade Event, Flip Order Updated and Flipped Order Created leaves, the nested ERC20 transfer and the top-level summary text.
- **_template**: a canonical text-assertion example so new adapters scaffolded from the template inherit the practice.

Each package asserts three things: the exact leaf text per Change class (`toBe` / `toEqual`, never a substring), the exact top-level Receipt text and the full ordered leaf-text sequence flattened by a local helper that mirrors `receiptTexts`, so order and completeness are locked together. The accepted conventions are asserted as-is: raw base-unit amounts, Registry label projection (e.g. `Package(Pancakeswap V2:Router)`), raw checksummed hex for unlabeled addresses and the `native` sentinel.

## Notes

- Every assertion reuses each file's existing fixtures and helper builders. No new chain data, no network.
- Delegated ERC20 movements surface as nested Receipt entries (`kind: "receipt"`), not top-level leaves, so the per-position leaf map and the flattened sequence intentionally differ at those positions. Both are asserted.

## Verification

- `biome check .` clean (255 files)
- `pnpm build` success
- `pnpm typecheck` clean repo-wide
- `pnpm test:offline` green: erc 18 passed, pancakeswap 28 passed, kuru 26 passed, _template 2 passed, every other package unchanged (skips are live Monad mainnet e2e)

Test-only, +289 / -2 across five test files.

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally before submitting: `biome check`, `pnpm build`, `pnpm typecheck` and the offline test suite, with every added assertion confirmed against the parser's actual output rather than an assumed format.

