### PR TITLE
test: add Receipt text projection regression coverage

### DIFF
--- a/packages/erc/test/erc20-receipt-text.test.ts
+++ b/packages/erc/test/erc20-receipt-text.test.ts
@@ -1,0 +1,111 @@
+import { type Change, type Hex, NATIVE, type ReceiptResult } from "@themoss/core";
+import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { ierc20Abi } from "../src/abis/erc.js";
+import { ERC20 } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const RECIPIENT = getAddress("0x1111111111111111111111111111111111111111");
+const TOKEN = getAddress("0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa");
+const SPENDER = getAddress("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB");
+
+const protocol = Object.create(ERC20.prototype) as ERC20;
+
+/** Mirrors mcp-server's `receiptTexts`: the exact ordered leaf-text projection Agents read. */
+function receiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : receiptTexts(entry),
+  );
+}
+
+function erc20TransferChange(token: string, from: string, to: string, amount: bigint): Change {
+  return {
+    kind: "event",
+    address: token as `0x${string}`,
+    topics: encodeEventTopics({
+      abi: ierc20Abi,
+      eventName: "Transfer",
+      args: { from: from as `0x${string}`, to: to as `0x${string}` },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function erc20ApprovalChange(
+  token: string,
+  owner: string,
+  spender: string,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: token as `0x${string}`,
+    topics: encodeEventTopics({
+      abi: ierc20Abi,
+      eventName: "Approval",
+      args: { owner: owner as `0x${string}`, spender: spender as `0x${string}` },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+describe("ERC20 Receipt text projections", () => {
+  it("locks the exact leaf text for an ERC-20 Transfer Change", () => {
+    const change = erc20TransferChange(TOKEN, ACCOUNT, RECIPIENT, 15n);
+    const receipt = protocol.changesReceipt([change]);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "change",
+      text: `ERC20 Transfer: 15 ${TOKEN} from ${ACCOUNT} to ${RECIPIENT}`,
+    });
+  });
+
+  it("locks the exact leaf text for an ERC-20 Approval Change", () => {
+    const change = erc20ApprovalChange(TOKEN, ACCOUNT, SPENDER, 42n);
+    const receipt = protocol.changesReceipt([change]);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "change",
+      text: `ERC20 Approval: ${ACCOUNT} approved ${SPENDER} for 42 ${TOKEN}`,
+    });
+  });
+
+  it("locks the exact leaf text for a native MON transfer Change, using the NATIVE sentinel", () => {
+    const change: Change = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: RECIPIENT,
+      value: "500000000000000000",
+    };
+    const receipt = protocol.changesReceipt([change]);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "change",
+      text: `ERC20 Transfer: 500000000000000000 ${NATIVE} from ${ACCOUNT} to ${RECIPIENT}`,
+    });
+  });
+
+  it("locks the single-change transferReceipt top-level text to the one leaf text", () => {
+    const change = erc20TransferChange(TOKEN, ACCOUNT, RECIPIENT, 15n);
+    const receipt = protocol.transferReceipt([change]);
+    expect(receipt.text).toBe(`ERC20 Transfer: 15 ${TOKEN} from ${ACCOUNT} to ${RECIPIENT}`);
+  });
+
+  it("locks the single-change approveReceipt top-level text to the one leaf text", () => {
+    const change = erc20ApprovalChange(TOKEN, ACCOUNT, SPENDER, 42n);
+    const receipt = protocol.approveReceipt([change]);
+    expect(receipt.text).toBe(`ERC20 Approval: ${ACCOUNT} approved ${SPENDER} for 42 ${TOKEN}`);
+  });
+
+  it("locks the multi-change changesReceipt top-level text to a semicolon join, and the exact ordered leaf-text sequence", () => {
+    const transfer = erc20TransferChange(TOKEN, ACCOUNT, RECIPIENT, 15n);
+    const approval = erc20ApprovalChange(TOKEN, ACCOUNT, SPENDER, 42n);
+    const receipt = protocol.changesReceipt([transfer, approval]);
+
+    expect(receipt.text).toBe(
+      `ERC20 Transfer: 15 ${TOKEN} from ${ACCOUNT} to ${RECIPIENT}; ` +
+        `ERC20 Approval: ${ACCOUNT} approved ${SPENDER} for 42 ${TOKEN}`,
+    );
+    expect(receiptTexts(receipt)).toEqual([
+      `ERC20 Transfer: 15 ${TOKEN} from ${ACCOUNT} to ${RECIPIENT}`,
+      `ERC20 Approval: ${ACCOUNT} approved ${SPENDER} for 42 ${TOKEN}`,
+    ]);
+  });
+});

--- a/packages/protocols/_template/test/adapter.test.ts
+++ b/packages/protocols/_template/test/adapter.test.ts
@@ -3,6 +3,7 @@ import {
   flattenCapabilityTree,
   type Hex,
   type MossRuntime,
+  type ReceiptResult,
   Registry,
 } from "@themoss/core";
 import { encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
@@ -55,4 +56,43 @@ describe("Protocol template", () => {
       text: `Native MON Transfer: 1000000000000000000 from ${ACCOUNT} to Package(Template:Vault)`,
     });
   });
+
+  // Text-assertion example (issue #115): lock the top-level Receipt text format
+  // and the exact ordered leaf-text sequence Agents actually read (mirrors
+  // mcp-server's `receiptTexts` traversal), not just one leaf via toMatchObject.
+  it("locks the top-level Receipt text and the exact ordered leaf-text sequence", async () => {
+    const registry = new Registry(runtime).use(ExampleProtocol);
+    const capability = await registry.action("template", "deposit", ACCOUNT, { amount: "1" });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const native = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: EXAMPLE_VAULT_ADDRESS,
+      value: "1000000000000000000",
+    } satisfies Change;
+    const deposited = {
+      kind: "event",
+      address: EXAMPLE_VAULT_ADDRESS,
+      topics: encodeEventTopics({
+        abi: ExampleVaultAbi,
+        eventName: "Deposited",
+        args: { account: ACCOUNT },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }], [10n ** 18n]),
+    } satisfies Change;
+    const receipt = registry.parseReceipt(capability, [native, deposited]);
+
+    expect(receipt.text).toBe(`Example Deposit: 1000000000000000000 by ${ACCOUNT}`);
+    expect(receiptTexts(receipt)).toEqual([
+      `Native MON Transfer: 1000000000000000000 from ${ACCOUNT} to Package(Template:Vault)`,
+      `Example Deposit: 1000000000000000000 by ${ACCOUNT}`,
+    ]);
+  });
 });
+
+/** Mirrors mcp-server's `receiptTexts`: the exact ordered leaf-text projection Agents read. */
+function receiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : receiptTexts(entry),
+  );
+}

--- a/packages/protocols/kuru/test/kuru-receipt-text.test.ts
+++ b/packages/protocols/kuru/test/kuru-receipt-text.test.ts
@@ -1,0 +1,214 @@
+import {
+  type Change,
+  type Hex,
+  type MossRuntime,
+  NATIVE,
+  type ReceiptResult,
+  Registry,
+} from "@themoss/core";
+import { AUSD_ADDRESS, USDC_ADDRESS } from "@themoss/system";
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, getAddress } from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { KuruOrderbookAbi, KuruRouterAbi } from "../src/abis/kuru.js";
+import { KURU_ROUTER_ADDRESS, Kuru } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const DIRECT_USDC_AUSD = getAddress("0x4444444444444444444444444444444444444444");
+
+/** Mirrors mcp-server's `receiptTexts`: the exact ordered leaf-text projection Agents read. */
+function receiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : receiptTexts(entry),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Kuru Receipt text projections", () => {
+  it("locks the exact leaf text for a KuruRouterSwap Change", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+    const trade = tradeChange(DIRECT_USDC_AUSD, 1n);
+
+    const receipt = registry.parseReceipt(capability, [trade, router]);
+    expect(receipt.changes[1]).toMatchObject({
+      kind: "change",
+      text: `Kuru Swap: 1000000 ${USDC_ADDRESS} to 1200000 ${AUSD_ADDRESS} by ${ACCOUNT}`,
+    });
+  });
+
+  it("locks the exact leaf text for a Trade Change", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const trade = tradeChange(DIRECT_USDC_AUSD, 7n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    const receipt = registry.parseReceipt(capability, [trade, router]);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "change",
+      text: `Trade Event: 20 at 10 emitted by ${DIRECT_USDC_AUSD}`,
+    });
+  });
+
+  it("delegates a native-MON Change to erc20.changesReceipt, using the NATIVE sentinel", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const native: Change = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: DIRECT_USDC_AUSD,
+      value: "1000000000000000000",
+    };
+    const trade = tradeChange(DIRECT_USDC_AUSD, 1n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    const receipt = registry.parseReceipt(capability, [native, trade, router]);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "receipt",
+      changes: [
+        {
+          kind: "change",
+          text: `ERC20 Transfer: 1000000000000000000 ${NATIVE} from ${ACCOUNT} to ${DIRECT_USDC_AUSD}`,
+        },
+      ],
+    });
+  });
+
+  it("locks the top-level swap Receipt text format and the exact ordered leaf-text sequence", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const trade = tradeChange(DIRECT_USDC_AUSD, 3n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    const receipt = registry.parseReceipt(capability, [trade, router]);
+    expect(receipt.text).toBe(
+      `Kuru Swap: 1000000 ${USDC_ADDRESS} to 1200000 ${AUSD_ADDRESS}; 1 Trade event observed`,
+    );
+    expect(receiptTexts(receipt)).toEqual([
+      `Trade Event: 20 at 10 emitted by ${DIRECT_USDC_AUSD}`,
+      `Kuru Swap: 1000000 ${USDC_ADDRESS} to 1200000 ${AUSD_ADDRESS} by ${ACCOUNT}`,
+    ]);
+  });
+
+  it("pluralizes the trailing Trade-event count in the top-level text for multiple Trades", async () => {
+    const { registry } = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const firstTrade = tradeChange(DIRECT_USDC_AUSD, 3n);
+    const secondTrade = tradeChange(DIRECT_USDC_AUSD, 4n);
+    const router = routerSwapChange(ACCOUNT, USDC_ADDRESS, AUSD_ADDRESS, 1_000_000n, 1_200_000n);
+
+    const receipt = registry.parseReceipt(capability, [firstTrade, secondTrade, router]);
+    expect(receipt.text).toBe(
+      `Kuru Swap: 1000000 ${USDC_ADDRESS} to 1200000 ${AUSD_ADDRESS}; 2 Trade events observed`,
+    );
+  });
+});
+
+async function swapCapability(registry: Registry) {
+  const capability = await registry.action("kuru", "swap", ACCOUNT, {
+    tokenIn: USDC_ADDRESS,
+    tokenOut: AUSD_ADDRESS,
+    amountIn: "1",
+  });
+  if (capability.kind !== "capability") throw new Error("expected capability");
+  return capability;
+}
+
+function offlineRegistry() {
+  const market = {
+    address: DIRECT_USDC_AUSD,
+    base: USDC_ADDRESS,
+    quote: AUSD_ADDRESS,
+    baseDecimals: 6,
+    quoteDecimals: 6,
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [{ market: market.address, baseasset: market.base, quoteasset: market.quote }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    ),
+  );
+  const client = {
+    readContract: async ({
+      functionName,
+      args,
+    }: {
+      functionName: string;
+      args: readonly unknown[];
+    }) => {
+      if (functionName !== "verifiedMarket") throw new Error(`unexpected read ${functionName}`);
+      if (String(args[0]).toLowerCase() !== market.address.toLowerCase()) {
+        throw new Error(`unknown market ${String(args[0])}`);
+      }
+      return [
+        10 ** market.quoteDecimals,
+        10n ** BigInt(market.baseDecimals),
+        market.base,
+        BigInt(market.baseDecimals),
+        market.quote,
+        BigInt(market.quoteDecimals),
+        0,
+        0n,
+        0n,
+        0n,
+        0n,
+      ];
+    },
+    call: async ({ data }: { data: Hex }) => {
+      const decoded = decodeFunctionData({ abi: KuruOrderbookAbi, data });
+      const size = decoded.args[0] as bigint;
+      return { data: encodeAbiParameters([{ type: "uint256" }], [size]) };
+    },
+  } as unknown as MossRuntime["client"];
+  return { registry: new Registry({ rpcUrl: "http://offline", client }).use(Kuru) };
+}
+
+function tradeChange(address: `0x${string}`, orderId: bigint): Change {
+  return eventChange(
+    address,
+    KuruOrderbookAbi,
+    "Trade",
+    [orderId, ACCOUNT, false, 10n, 0n, KURU_ROUTER_ADDRESS, ACCOUNT, 20n],
+    ["uint40", "address", "bool", "uint256", "uint96", "address", "address", "uint96"],
+  );
+}
+
+function routerSwapChange(
+  sender: `0x${string}`,
+  tokenIn: `0x${string}`,
+  tokenOut: `0x${string}`,
+  amountIn: bigint,
+  amountOut: bigint,
+): Change {
+  return eventChange(
+    KURU_ROUTER_ADDRESS,
+    KuruRouterAbi,
+    "KuruRouterSwap",
+    [sender, tokenIn, tokenOut, amountIn, amountOut],
+    ["address", "address", "address", "uint256", "uint256"],
+  );
+}
+
+function eventChange(
+  address: `0x${string}`,
+  abi: typeof KuruRouterAbi | typeof KuruOrderbookAbi,
+  eventName: "Trade" | "KuruRouterSwap",
+  values: readonly unknown[],
+  types: readonly string[],
+): Change {
+  return {
+    kind: "event",
+    address,
+    topics: encodeEventTopics({ abi, eventName } as never) as readonly Hex[],
+    data: encodeAbiParameters(types.map((type) => ({ type })) as never, values as never),
+  };
+}

--- a/packages/protocols/pancakeswap/test/pancakeswap-receipt-text.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap-receipt-text.test.ts
@@ -1,0 +1,124 @@
+import { type Change, type MossRuntime, type ReceiptResult, Registry } from "@themoss/core";
+import { ERC20Abi } from "@themoss/erc";
+import { encodeAbiParameters, encodeEventTopics, getAddress, type Hex } from "viem";
+import { describe, expect, it } from "vitest";
+import { PANCAKESWAP_V3_ROUTER_ADDRESS, PancakeSwap } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const TOKEN_A = getAddress("0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa");
+const TOKEN_B = getAddress("0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb");
+// The Protocol declares `labels: { Router: PANCAKESWAP_V3_ROUTER_ADDRESS }`, so Receipt
+// label rendering replaces the raw Router address with this Package label in text.
+const ROUTER_LABEL = "Package(Pancakeswap:Router)";
+
+/** Mirrors mcp-server's `receiptTexts`: the exact ordered leaf-text projection Agents read. */
+function receiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : receiptTexts(entry),
+  );
+}
+
+function erc20Transfer(token: string, from: string, to: string, amount: bigint): Change {
+  return {
+    kind: "event",
+    address: token as `0x${string}`,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      args: { from: from as `0x${string}`, to: to as `0x${string}` },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function offlineRegistry() {
+  return new Registry({
+    rpcUrl: "http://offline",
+    client: {
+      readContract: async ({ functionName }: { functionName: string }) => {
+        if (functionName === "decimals") return 18;
+        if (functionName === "getPool") return "0x63e48B725540A3Db24ACF6682a29f877808C53F2";
+        if (functionName === "token0") return TOKEN_A;
+        throw new Error(`unexpected readContract ${functionName}`);
+      },
+      call: async () => ({
+        data: encodeAbiParameters([{ type: "uint256" }], [900_000_000_000_000_000n]),
+      }),
+    } as unknown as MossRuntime["client"],
+  }).use(PancakeSwap);
+}
+
+async function swapCapability(registry: Registry) {
+  const capability = await registry.action("pancakeswap", "swap", ACCOUNT, {
+    tokenIn: TOKEN_A,
+    tokenOut: TOKEN_B,
+    amount: "1",
+    fee: 3000,
+    slippage: 50,
+  });
+  if (capability.kind !== "capability") throw new Error("expected capability");
+  return capability;
+}
+
+describe("PancakeSwap V3 Receipt text projections", () => {
+  it("locks the exact leaf text for a native MON transfer Change", async () => {
+    const registry = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const change: Change = {
+      kind: "nativeTransfer",
+      from: ACCOUNT,
+      to: PANCAKESWAP_V3_ROUTER_ADDRESS,
+      value: "500000000000000000",
+    };
+    const receipt = registry.parseReceipt(capability, [change]);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "change",
+      text: `Native MON Transfer: 500000000000000000 from ${ACCOUNT} to ${ROUTER_LABEL}`,
+    });
+  });
+
+  it("delegates ERC-20 Transfer Changes to erc20.changesReceipt for their leaf text", async () => {
+    const registry = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const changes = [
+      erc20Transfer(TOKEN_A, ACCOUNT, PANCAKESWAP_V3_ROUTER_ADDRESS, 1_000_000_000_000_000_000n),
+      erc20Transfer(TOKEN_B, PANCAKESWAP_V3_ROUTER_ADDRESS, ACCOUNT, 900_000_000_000_000_000n),
+    ];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "receipt",
+      changes: [
+        {
+          kind: "change",
+          text: `ERC20 Transfer: 1000000000000000000 ${TOKEN_A} from ${ACCOUNT} to ${ROUTER_LABEL}`,
+        },
+      ],
+    });
+    expect(receipt.changes[1]).toMatchObject({
+      kind: "receipt",
+      changes: [
+        {
+          kind: "change",
+          text: `ERC20 Transfer: 900000000000000000 ${TOKEN_B} from ${ROUTER_LABEL} to ${ACCOUNT}`,
+        },
+      ],
+    });
+  });
+
+  it("locks the top-level swap Receipt text format and the exact ordered leaf-text sequence", async () => {
+    const registry = offlineRegistry();
+    const capability = await swapCapability(registry);
+    const changes = [
+      erc20Transfer(TOKEN_A, ACCOUNT, PANCAKESWAP_V3_ROUTER_ADDRESS, 1_000_000_000_000_000_000n),
+      erc20Transfer(TOKEN_B, PANCAKESWAP_V3_ROUTER_ADDRESS, ACCOUNT, 900_000_000_000_000_000n),
+    ];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.text).toBe(
+      `PancakeSwap V3 Swap: 1000000000000000000 in ${TOKEN_A} → 900000000000000000 out ${TOKEN_B}`,
+    );
+    expect(receiptTexts(receipt)).toEqual([
+      `ERC20 Transfer: 1000000000000000000 ${TOKEN_A} from ${ACCOUNT} to ${ROUTER_LABEL}`,
+      `ERC20 Transfer: 900000000000000000 ${TOKEN_B} from ${ROUTER_LABEL} to ${ACCOUNT}`,
+    ]);
+  });
+});

--- a/packages/protocols/pancakeswap/test/pancakeswap-v2-receipt-text.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap-v2-receipt-text.test.ts
@@ -1,0 +1,206 @@
+import { type Change, type Hex, NATIVE, type ReceiptResult, Registry } from "@themoss/core";
+import { ERC20Abi, WETH9Abi } from "@themoss/erc";
+import { AUSD_ADDRESS, USDC_ADDRESS, WMON_ADDRESS } from "@themoss/system";
+import { encodeAbiParameters, encodeEventTopics, getAddress, type PublicClient } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { pancakeV2PairAbi } from "../src/abis/v2-pair.js";
+import { PANCAKESWAP_V2_ROUTER_ADDRESS, PancakeSwapV2 } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+const PAIR = getAddress("0x1111111111111111111111111111111111111111");
+const AMOUNT = 10n ** 18n;
+// The Protocol declares `labels: { Router: ..., Factory: ... }`, so Receipt label
+// rendering replaces the raw Router address with this Package label in text.
+const ROUTER_LABEL = "Package(Pancakeswap V2:Router)";
+
+/** Mirrors mcp-server's `receiptTexts`: the exact ordered leaf-text projection Agents read. */
+function receiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : receiptTexts(entry),
+  );
+}
+
+function offlineRegistry() {
+  const client = {
+    readContract: vi.fn(
+      async ({ functionName, args }: { functionName: string; args?: readonly unknown[] }) => {
+        if (functionName === "decimals") return 6;
+        if (functionName === "name") return "Mock token";
+        if (functionName === "symbol") return "MOCK";
+        const path = args?.[1] as readonly `0x${string}`[] | undefined;
+        const amount = (args?.[0] as bigint | undefined) ?? 0n;
+        if (!path) throw new Error(`unexpected read ${functionName}`);
+        if (functionName === "getAmountsOut") return [amount, 20_000n];
+        throw new Error(`unexpected read ${functionName}`);
+      },
+    ),
+  } as unknown as PublicClient;
+  return new Registry({ rpcUrl: "http://offline", client }).use(PancakeSwapV2);
+}
+
+async function swapCapability(
+  registry: Registry,
+  tokenIn: `0x${string}` | typeof NATIVE,
+  tokenOut: `0x${string}` | typeof NATIVE,
+) {
+  const capability = await registry.action("pancakeswap-v2", "swap", ACCOUNT, {
+    tokenIn,
+    tokenOut,
+    amountIn: "1",
+  });
+  if (capability.kind !== "capability") throw new Error("expected Capability");
+  return capability;
+}
+
+function nativeChange(from: `0x${string}`, to: `0x${string}`, value: bigint): Change {
+  return { kind: "nativeTransfer", from, to, value: value.toString() };
+}
+
+function transferChange(
+  token: `0x${string}`,
+  from: `0x${string}`,
+  to: `0x${string}`,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: token,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      args: { from, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function syncChange(pair: `0x${string}`, reserve0: bigint, reserve1: bigint): Change {
+  return {
+    kind: "event",
+    address: pair,
+    topics: encodeEventTopics({ abi: pancakeV2PairAbi, eventName: "Sync" }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint112" }, { type: "uint112" }], [reserve0, reserve1]),
+  };
+}
+
+function swapChange(
+  pair: `0x${string}`,
+  amount0In: bigint,
+  amount1In: bigint,
+  amount0Out: bigint,
+  amount1Out: bigint,
+  to: `0x${string}`,
+): Change {
+  return {
+    kind: "event",
+    address: pair,
+    topics: encodeEventTopics({
+      abi: pancakeV2PairAbi,
+      eventName: "Swap",
+      args: { sender: PANCAKESWAP_V2_ROUTER_ADDRESS, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }, { type: "uint256" }, { type: "uint256" }],
+      [amount0In, amount1In, amount0Out, amount1Out],
+    ),
+  };
+}
+
+function wethChange(
+  eventName: "Deposit" | "Withdrawal",
+  account: `0x${string}`,
+  amount: bigint,
+): Change {
+  return {
+    kind: "event",
+    address: WMON_ADDRESS,
+    topics: encodeEventTopics({
+      abi: WETH9Abi,
+      eventName,
+      args: eventName === "Deposit" ? { dst: account } : { src: account },
+    } as never) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+describe("PancakeSwap v2 Receipt text projections", () => {
+  it("locks the exact leaf text for a WMON Deposit Change", async () => {
+    const registry = offlineRegistry();
+    const capability = await swapCapability(registry, NATIVE, USDC_ADDRESS);
+    const changes = [
+      nativeChange(ACCOUNT, PANCAKESWAP_V2_ROUTER_ADDRESS, AMOUNT),
+      nativeChange(PANCAKESWAP_V2_ROUTER_ADDRESS, WMON_ADDRESS, AMOUNT),
+      wethChange("Deposit", PANCAKESWAP_V2_ROUTER_ADDRESS, AMOUNT),
+      transferChange(WMON_ADDRESS, PANCAKESWAP_V2_ROUTER_ADDRESS, PAIR, AMOUNT),
+      transferChange(USDC_ADDRESS, PAIR, ACCOUNT, 20_000n),
+      syncChange(PAIR, AMOUNT, 20_000n),
+      swapChange(PAIR, AMOUNT, 0n, 0n, 20_000n, ACCOUNT),
+    ];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.changes[2]).toMatchObject({
+      kind: "change",
+      text: `WMON Deposit: ${AMOUNT} for ${ROUTER_LABEL}`,
+    });
+  });
+
+  it("locks the exact leaf text for a WMON Withdrawal Change", async () => {
+    const registry = offlineRegistry();
+    const capability = await swapCapability(registry, USDC_ADDRESS, NATIVE);
+    const amountOut = 2n * AMOUNT;
+    const changes = [
+      transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n),
+      transferChange(WMON_ADDRESS, PAIR, PANCAKESWAP_V2_ROUTER_ADDRESS, amountOut),
+      syncChange(PAIR, 1_000_000n, amountOut),
+      swapChange(PAIR, 1_000_000n, 0n, 0n, amountOut, PANCAKESWAP_V2_ROUTER_ADDRESS),
+      nativeChange(WMON_ADDRESS, PANCAKESWAP_V2_ROUTER_ADDRESS, amountOut),
+      wethChange("Withdrawal", PANCAKESWAP_V2_ROUTER_ADDRESS, amountOut),
+      nativeChange(PANCAKESWAP_V2_ROUTER_ADDRESS, ACCOUNT, amountOut),
+    ];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.changes[5]).toMatchObject({
+      kind: "change",
+      text: `WMON Withdrawal: ${amountOut} for ${ROUTER_LABEL}`,
+    });
+  });
+
+  it("locks the exact leaf text for Sync and Swap Pair Changes, and the top-level Receipt text", async () => {
+    const registry = offlineRegistry();
+    const capability = await swapCapability(registry, USDC_ADDRESS, AUSD_ADDRESS);
+    const changes = [
+      transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n),
+      transferChange(AUSD_ADDRESS, PAIR, ACCOUNT, 20_000n),
+      syncChange(PAIR, 10_000_000n, 20_000_000n),
+      swapChange(PAIR, 1_000_000n, 0n, 0n, 20_000n, ACCOUNT),
+    ];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.changes[2]).toMatchObject({
+      kind: "change",
+      text: `PancakeSwap Sync: reserves 10000000/20000000 at ${PAIR}`,
+    });
+    expect(receipt.changes[3]).toMatchObject({
+      kind: "change",
+      text: `PancakeSwap Pair Swap: 1000000 in and 20000 out at ${PAIR}`,
+    });
+    expect(receipt.text).toBe(
+      `PancakeSwap Swap: 1000000 ${USDC_ADDRESS} to 20000 ${AUSD_ADDRESS} for ${ACCOUNT}`,
+    );
+  });
+
+  it("locks the exact ordered leaf-text sequence for a direct-pair swap flow", async () => {
+    const registry = offlineRegistry();
+    const capability = await swapCapability(registry, USDC_ADDRESS, AUSD_ADDRESS);
+    const changes = [
+      transferChange(USDC_ADDRESS, ACCOUNT, PAIR, 1_000_000n),
+      transferChange(AUSD_ADDRESS, PAIR, ACCOUNT, 20_000n),
+      syncChange(PAIR, 10_000_000n, 20_000_000n),
+      swapChange(PAIR, 1_000_000n, 0n, 0n, 20_000n, ACCOUNT),
+    ];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receiptTexts(receipt)).toEqual([
+      `ERC20 Transfer: 1000000 ${USDC_ADDRESS} from ${ACCOUNT} to ${PAIR}`,
+      `ERC20 Transfer: 20000 ${AUSD_ADDRESS} from ${PAIR} to ${ACCOUNT}`,
+      `PancakeSwap Sync: reserves 10000000/20000000 at ${PAIR}`,
+      `PancakeSwap Pair Swap: 1000000 in and 20000 out at ${PAIR}`,
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #115

Scope kept strictly test/template-only, per the issue's notes and the earlier scope proposed by @pillowtalk-Qy in the issue thread — no Receipt parser, rendering, or format code changed in `packages/erc`, `packages/protocols/kuru`, `packages/protocols/pancakeswap`, or `packages/mcp-server`.

## What's covered

- **erc** (`erc20-receipt-text.test.ts`): exact leaf text for ERC20 Transfer, Approval, and native-MON transfer Changes (locking the `NATIVE` sentinel rendering); the single-change `transferReceipt`/`approveReceipt` top-level text; the multi-change `changesReceipt` semicolon-joined top-level text; the full ordered flattened leaf-text sequence for a multi-Change flow.
- **kuru** (`kuru-receipt-text.test.ts`): exact leaf text for `KuruRouterSwap` and `Trade` Changes; native-MON Change delegation to `erc20.changesReceipt`; the top-level swap Receipt text, including the Trade-event-count pluralization (`1 Trade event observed` vs `2 Trade events observed`); the full ordered flattened leaf-text sequence.
- **pancakeswap** (V3, `pancakeswap-receipt-text.test.ts`): exact leaf text for native MON transfer Changes; ERC-20 Transfer delegation to `erc20.changesReceipt`; the top-level swap Receipt text; the full ordered flattened leaf-text sequence.
- **pancakeswap-v2** (`pancakeswap-v2-receipt-text.test.ts`): exact leaf text for WMON `Deposit`/`Withdrawal`, `Sync`, and `Swap` Changes; the top-level swap Receipt text; the full ordered flattened leaf-text sequence.
- **protocols/_template**: extended `adapter.test.ts` with a text-assertion example that locks the top-level Receipt text *and* the full ordered leaf-text sequence (not just one leaf via `toMatchObject`, as the existing example did), so new protocols inherit the fuller practice.

The "full ordered flattened leaf-text sequence" assertions in each file use a local `receiptTexts` helper that mirrors `mcp-server/src/server.ts`'s private `receiptTexts` traversal exactly (`entry.kind === "change" ? [entry.text] : receiptTexts(entry)`) — it isn't exported from `mcp-server`, so each test file replicates the same logic rather than changing that package's exports.

All new assertions lock the existing raw base-unit amount and address/NATIVE/Package-label rendering convention described in the issue; none of them change it. Note that PancakeSwap (V3 and v2) declare `labels: { Router: ... }` on their Protocol, so Receipt label rendering resolves the router address to `Package(Pancakeswap:Router)` / `Package(Pancakeswap V2:Router)` in text — the relevant assertions lock that rendered form rather than the raw router address, since that's Registry's actual observed output.

## Verification

- `pnpm lint` — clean (259 files checked).
- `pnpm build` — clean.
- `pnpm typecheck` — clean across all 19 workspace projects.
- `pnpm test` for the four affected packages, run offline (`MOSS_SKIP_E2E=1`, no live Monad mainnet RPC in this environment): `@themoss/erc`, `@themoss/protocol-kuru`, `@themoss/protocol-pancakeswap`, `@themoss/protocol-template` — 96 tests passed, 0 failed. The live Monad mainnet e2e suites in these packages were skipped by that flag and are untouched by this change.