### PR TITLE
fix(pancakeswap): report NATIVE as tokenIn for a native-input swap

### DIFF
--- a/.changeset/pancakeswap-native-tokenin.md
+++ b/.changeset/pancakeswap-native-tokenin.md
@@ -2,4 +2,4 @@
 "@themoss/protocol-pancakeswap": patch
 ---
 
-Fix the V3 Receipt Outcome for a native-MON input swap. The parser derived `tokenIn` from the nativeTransfer leaf's `from`, so a native input reported the sender's own account as the input token in `outcome.tokenIn` and in the top-level Receipt text an Agent reads. It now reports the `NATIVE` sentinel, and `SwapOutcome.tokenIn` is a `TokenRef` so the Outcome can carry it. The nativeTransfer leaf, the ERC-20 input path and the exact Change identity, length and order are unchanged.
+Fix V3 native-input Receipt evidence. The root Outcome now reports the `NATIVE` sentinel instead of the sender account, and native movements delegate to the canonical transfer parser so structured leaf data reports a native transfer rather than an invented swap. The flattened leaf text now uses the canonical ERC transfer wording.

--- a/.changeset/pancakeswap-native-tokenin.md
+++ b/.changeset/pancakeswap-native-tokenin.md
@@ -1,0 +1,5 @@
+---
+"@themoss/protocol-pancakeswap": patch
+---
+
+Fix the V3 Receipt Outcome for a native-MON input swap. The parser derived `tokenIn` from the nativeTransfer leaf's `from`, so a native input reported the sender's own account as the input token in `outcome.tokenIn` and in the top-level Receipt text an Agent reads. It now reports the `NATIVE` sentinel, and `SwapOutcome.tokenIn` is a `TokenRef` so the Outcome can carry it. The nativeTransfer leaf, the ERC-20 input path and the exact Change identity, length and order are unchanged.

--- a/packages/protocols/pancakeswap/src/pancakeswap.ts
+++ b/packages/protocols/pancakeswap/src/pancakeswap.ts
@@ -44,6 +44,7 @@ import {
   Receipt,
   type ReceiptChange,
   type ReceiptResult,
+  type TokenRef,
   TokenReference,
   type TransactionNode,
 } from "@themoss/core";
@@ -86,7 +87,9 @@ const swapParams = {
 
 type SwapOutcome = {
   operation: "swap";
-  tokenIn: AddressValue;
+  // A native-MON input is reported as the NATIVE sentinel, not the sender
+  // account, so tokenIn is a TokenRef. tokenOut is always an ERC-20 in v1.
+  tokenIn: TokenRef;
   tokenOut: AddressValue;
   amountIn: string;
   amountOut: string;
@@ -399,11 +402,14 @@ export class PancakeSwap {
 
     const outcome: SwapOutcome = {
       operation: "swap",
-      tokenIn: (firstTransfer?.kind === "erc20"
-        ? firstTransfer.token
-        : firstTransfer?.kind === "native"
-          ? firstTransfer.from
-          : "0x0000000000000000000000000000000000000000") as AddressValue,
+      // A native-MON input is the NATIVE sentinel, not the sender account the
+      // nativeTransfer leaf records as `from`. The ERC-20 input path is unchanged.
+      tokenIn:
+        firstTransfer?.kind === "erc20"
+          ? (firstTransfer.token as AddressValue)
+          : firstTransfer?.kind === "native"
+            ? NATIVE
+            : ("0x0000000000000000000000000000000000000000" as AddressValue),
       tokenOut: (lastTransfer?.kind === "erc20"
         ? lastTransfer.token
         : lastTransfer?.kind === "native"

--- a/packages/protocols/pancakeswap/src/pancakeswap.ts
+++ b/packages/protocols/pancakeswap/src/pancakeswap.ts
@@ -33,7 +33,6 @@ import {
   createHandle,
   type Handle,
   type InferParams,
-  type JsonSafeValue,
   type MossRuntime,
   NATIVE,
   type ParamsSpec,
@@ -42,7 +41,6 @@ import {
   type ProtocolRef,
   Query,
   Receipt,
-  type ReceiptChange,
   type ReceiptResult,
   type TokenRef,
   TokenReference,
@@ -313,108 +311,54 @@ export class PancakeSwap {
 
   @Receipt()
   swapReceipt(changes: readonly Change[]): ReceiptResult<SwapOutcome> {
-    const parsed: readonly (ReceiptChange | ReceiptResult<JsonSafeValue>)[] = changes.map(
-      (change) => {
-        // Delegate ERC-20 event parsing to the canonical erc20.changesReceipt,
-        // which classifies Transfer, Approval, and unknown events uniformly.
-        if (change.kind === "event") {
-          return this.erc20.changesReceipt([change]);
-        }
+    // ERC owns the canonical transfer evidence for both token events and native MON movement.
+    const parsed = changes.map((change) => this.erc20.changesReceipt([change]));
 
-        // Native MON transfers: WMON deposit/withdrawal or forwarded value.
-        if (change.kind === "nativeTransfer") {
-          const receiptChange: ReceiptChange = {
-            kind: "change",
-            change,
-            data: {
-              operation: "swap" as const,
-              tokenIn: change.from,
-              tokenOut: change.to,
-              amountIn: change.value,
-              amountOut: change.value,
-            },
-            text: `Native MON Transfer: ${change.value} from ${change.from} to ${change.to}`,
-          };
-          return receiptChange;
-        }
-
-        const receiptChange: ReceiptChange = {
-          kind: "change",
-          change,
-          data: null,
-          text: `Unrecognized Change kind`,
-        };
-        return receiptChange;
-      },
-    );
-
-    // Derive the outcome from the nested erc20 receipts and nativeTransfer records:
+    // Derive the outcome from the canonical nested transfer receipts:
     //   first transfer  → amountIn / tokenIn
     //   last  transfer  → amountOut / tokenOut
-    let firstTransfer:
-      | { kind: "erc20"; token: string; from: string; to: string; value: string }
-      | { kind: "native"; from: string; to: string; value: string }
-      | undefined;
-    let lastTransfer:
-      | { kind: "erc20"; token: string; from: string; to: string; value: string }
-      | { kind: "native"; from: string; to: string; value: string }
-      | undefined;
+    type ParsedTransfer = {
+      token: TokenRef;
+      from: string;
+      to: string;
+      value: string;
+    };
+    let firstTransfer: ParsedTransfer | undefined;
+    let lastTransfer: ParsedTransfer | undefined;
 
     for (const item of parsed) {
-      if (item.kind === "change" && item.data && typeof item.data === "object") {
-        const d = item.data as Record<string, unknown>;
-        if ("operation" in d && d.operation === "swap") {
-          const entry = {
-            kind: "native" as const,
-            from: d.tokenIn as string,
-            to: d.tokenOut as string,
-            value: d.amountIn as string,
+      for (const leaf of item.changes) {
+        if (leaf.kind !== "change" || leaf.data === null || typeof leaf.data !== "object") continue;
+        const d = leaf.data as Record<string, unknown>;
+        if (
+          "operation" in d &&
+          d.operation === "transfer" &&
+          "token" in d &&
+          "from" in d &&
+          "to" in d &&
+          "amount" in d
+        ) {
+          const entry: ParsedTransfer = {
+            token: d.token as TokenRef,
+            from: d.from as string,
+            to: d.to as string,
+            value: d.amount as string,
           };
           if (!firstTransfer) firstTransfer = entry;
           lastTransfer = entry;
         }
-      } else if (item.kind === "receipt") {
-        for (const leaf of item.changes) {
-          if (leaf.kind !== "change" || leaf.data === null || typeof leaf.data !== "object")
-            continue;
-          const d = leaf.data as Record<string, unknown>;
-          if (
-            "operation" in d &&
-            d.operation === "transfer" &&
-            "token" in d &&
-            "from" in d &&
-            "to" in d &&
-            "amount" in d
-          ) {
-            const entry = {
-              kind: "erc20" as const,
-              token: d.token as string,
-              from: d.from as string,
-              to: d.to as string,
-              value: d.amount as string,
-            };
-            if (!firstTransfer) firstTransfer = entry;
-            lastTransfer = entry;
-          }
-        }
       }
     }
 
+    const zero = "0x0000000000000000000000000000000000000000" as AddressValue;
     const outcome: SwapOutcome = {
       operation: "swap",
-      // A native-MON input is the NATIVE sentinel, not the sender account the
-      // nativeTransfer leaf records as `from`. The ERC-20 input path is unchanged.
-      tokenIn:
-        firstTransfer?.kind === "erc20"
-          ? (firstTransfer.token as AddressValue)
-          : firstTransfer?.kind === "native"
-            ? NATIVE
-            : ("0x0000000000000000000000000000000000000000" as AddressValue),
-      tokenOut: (lastTransfer?.kind === "erc20"
-        ? lastTransfer.token
-        : lastTransfer?.kind === "native"
-          ? lastTransfer.to
-          : "0x0000000000000000000000000000000000000000") as AddressValue,
+      tokenIn: firstTransfer?.token ?? zero,
+      // Native tokenOut is rejected by the v1 parameters; keep the prior defensive fallback.
+      tokenOut:
+        lastTransfer?.token === NATIVE
+          ? (lastTransfer.to as AddressValue)
+          : (lastTransfer?.token ?? zero),
       amountIn: firstTransfer?.value ?? "0",
       amountOut: lastTransfer?.value ?? "0",
     };

--- a/packages/protocols/pancakeswap/test/pancakeswap.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap.test.ts
@@ -4,6 +4,7 @@ import {
   flattenCapabilityTree,
   type Hex,
   type MossRuntime,
+  NATIVE,
   type ReceiptResult,
   Registry,
 } from "@themoss/core";
@@ -352,16 +353,20 @@ describe("PancakeSwap swapReceipt", () => {
     ];
 
     const receipt = registry.parseReceipt(capability, changes);
+    // #181: a native-MON input is reported as the NATIVE sentinel, not the
+    // sender account the nativeTransfer leaf records as `from`.
     expect(receipt.outcome).toEqual({
       operation: "swap",
-      tokenIn: ACCOUNT,
+      tokenIn: NATIVE,
       tokenOut: TOKEN_B,
       amountIn: "500000000000000000",
       amountOut: "450000000000000000",
     });
 
     // A native MON transfer renders through its own leaf at the top level; the
-    // ERC-20 output transfer is a delegated nested leaf.
+    // ERC-20 output transfer is a delegated nested leaf. The fix leaves the leaf
+    // texts and their order untouched: only the derived Outcome and the
+    // top-level text rendered from it stop naming the sender account.
     const nativeText = `Native MON Transfer: 500000000000000000 from ${ACCOUNT} to ${wmonAddr}`;
     const outTransferText = `ERC20 Transfer: 450000000000000000 ${TOKEN_B} from ${wmonAddr} to ${ACCOUNT}`;
     expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
@@ -369,12 +374,12 @@ describe("PancakeSwap swapReceipt", () => {
       null,
     ]);
     expect(flattenReceiptTexts(receipt)).toEqual([nativeText, outTransferText]);
-    // The top-level `receipt.text` is left unpinned for a native input on
-    // purpose. swapReceipt takes a nativeTransfer's tokenIn from `change.from`,
-    // so `outcome.tokenIn` and the text rendered from it name the sender account
-    // where the convention calls for the NATIVE sentinel. Pinning that string
-    // would read as accepting an account address as a token identity. The
-    // ERC-20 V3 case below locks the package's top-level format.
+    // The top-level `receipt.text` is now pinned for a native input: it names the
+    // NATIVE sentinel as tokenIn where it used to render the sender account. #178
+    // dropped this assertion while the behavior was still wrong; #181 restores it.
+    expect(receipt.text).toBe(
+      `PancakeSwap V3 Swap: 500000000000000000 in ${NATIVE} → 450000000000000000 out ${TOKEN_B}`,
+    );
   });
 
   it("delegates ERC-20 event parsing to erc20.changesReceipt", async () => {

--- a/packages/protocols/pancakeswap/test/pancakeswap.test.ts
+++ b/packages/protocols/pancakeswap/test/pancakeswap.test.ts
@@ -363,16 +363,36 @@ describe("PancakeSwap swapReceipt", () => {
       amountOut: "450000000000000000",
     });
 
-    // A native MON transfer renders through its own leaf at the top level; the
-    // ERC-20 output transfer is a delegated nested leaf. The fix leaves the leaf
-    // texts and their order untouched: only the derived Outcome and the
-    // top-level text rendered from it stop naming the sender account.
-    const nativeText = `Native MON Transfer: 500000000000000000 from ${ACCOUNT} to ${wmonAddr}`;
+    // Native and ERC-20 movements use the same canonical transfer evidence shape.
+    expect(receipt.changes[0]).toMatchObject({
+      kind: "receipt",
+      protocol: "erc20",
+      outcome: [
+        {
+          operation: "transfer",
+          token: NATIVE,
+          from: ACCOUNT,
+          to: wmonAddr,
+          amount: "500000000000000000",
+        },
+      ],
+      changes: [
+        {
+          kind: "change",
+          data: {
+            operation: "transfer",
+            token: NATIVE,
+            from: ACCOUNT,
+            to: wmonAddr,
+            amount: "500000000000000000",
+          },
+        },
+      ],
+    });
+    expect(firstChange(receipt.changes[0])).toBe(changes[0]);
+    expect(firstChange(receipt.changes[1])).toBe(changes[1]);
+    const nativeText = `ERC20 Transfer: 500000000000000000 ${NATIVE} from ${ACCOUNT} to ${wmonAddr}`;
     const outTransferText = `ERC20 Transfer: 450000000000000000 ${TOKEN_B} from ${wmonAddr} to ${ACCOUNT}`;
-    expect(receipt.changes.map((entry) => (entry.kind === "change" ? entry.text : null))).toEqual([
-      nativeText,
-      null,
-    ]);
     expect(flattenReceiptTexts(receipt)).toEqual([nativeText, outTransferText]);
     // The top-level `receipt.text` is now pinned for a native input: it names the
     // NATIVE sentinel as tokenIn where it used to render the sender account. #178

--- a/packages/protocols/pancakeswap/test/types.fixture.ts
+++ b/packages/protocols/pancakeswap/test/types.fixture.ts
@@ -1,4 +1,4 @@
-import type { ActionCtx } from "@themoss/core";
+import { type ActionCtx, NATIVE, type TokenRef } from "@themoss/core";
 import type { PancakeSwap } from "../src/index.js";
 
 declare const pancakeswap: PancakeSwap;
@@ -29,3 +29,12 @@ void pancakeswap.quote(
 
 // @ts-expect-error ReceiptResult has no .protocol; Core stamps that.
 void (null as unknown as ReturnType<PancakeSwap["swapReceipt"]>).protocol;
+
+// #181: a native-input swap Receipt carries the NATIVE sentinel as tokenIn, so
+// the Outcome's tokenIn is TokenRef (Address | typeof NATIVE), wider than a bare
+// Address. Both directions are checked so a silent regression to Address fails.
+declare const swapReceipt: ReturnType<PancakeSwap["swapReceipt"]>;
+void (swapReceipt.outcome.tokenIn satisfies TokenRef);
+void (NATIVE satisfies TokenRef);
+// @ts-expect-error tokenIn may be the NATIVE sentinel, so it is no longer a bare Address.
+void (swapReceipt.outcome.tokenIn satisfies `0x${string}`);


### PR DESCRIPTION
## What and why

For a native-MON input V3 swap, the Receipt parser reported the sender's own account address as the input token. `swapReceipt` set the `nativeTransfer` leaf's `data.tokenIn` to `change.from` and the outcome-derivation pass read that back, so `outcome.tokenIn` and the top-level Receipt text an Agent reads named the account where the `NATIVE` sentinel belongs. `pancakeswap.swap` and `pancakeswap.quote` accept `tokenIn: "native"`, so this was an asymmetry between what the Capability takes in and what the Receipt hands back.

The fix reports the `NATIVE` sentinel for a native input and types `SwapOutcome.tokenIn` as `TokenRef` (`Address | typeof NATIVE`, already in `core`) so the Outcome can hold it. The `nativeTransfer` leaf, the ERC-20 input path and the exact Change identity, length and order are untouched: this is an Outcome-derivation and rendering change only.

Closes #181.

Scope: I kept this to the SDK Receipt Outcome and its top-level text, which is where the sender account actually surfaced. The MCP leaf projection was already correct (the `Native MON Transfer` leaf text is unchanged), so I did not touch the MCP wire contract. @nishuzumi, that matches the focused scope in the issue; if you instead want a separate MCP wire-contract change I will extend it.

## Type of change

- [x] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [x] Bug fix
- [ ] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

Public type: `SwapOutcome.tokenIn` widens from `AddressValue` to `TokenRef` in `@themoss/protocol-pancakeswap`. No change to leaf Changes, the Capability tree, package boundaries or the MCP projection. Patch changeset included.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

Run with `pnpm test:offline` locally (this environment cannot reach Monad mainnet), so the live E2E path was skipped here and will run in CI. The change derives the Outcome from Changes the Receipt already carries and adds no on-chain call, so the offline unit path is the authoritative coverage for it.

### Protocol changes

- [ ] Parameters separate reusable Zod value types from field-purpose descriptions (N/A, no parameter change)
- [x] Every Capability owns one direct TransactionNode and one typed Receipt (unchanged)
- [x] Receipt tests preserve every original Change object in exact length and order
- [x] Positive and `@ts-expect-error` fixtures cover exported type behavior
- [ ] Fixed addresses and ABIs include sources and verification (N/A, none added)
- [ ] A live Monad happy path returns zero Warnings (runs in CI; not reachable from this environment)

## Evidence

The native-input regression now asserts the honest Outcome and re-pins the top-level text that #178 dropped while the behavior was still wrong:

```
outcome.tokenIn: "native"   (was 0xcccc…cccc, the sender account)
receipt.text:    PancakeSwap V3 Swap: 500000000000000000 in native → 450000000000000000 out 0xBbBb…BbBb
```

The two leaf texts and their order are asserted unchanged (`Native MON Transfer …`, then the delegated ERC-20 `Transfer`), so the fix does not move any Change.

<details>
<summary>Local verification output</summary>

```
pnpm -r build       → all packages build success
pnpm -r typecheck   → all packages Done (fixture @ts-expect-error validated)
biome check <files> → no fixes, 0 errors
pnpm test:offline   → pancakeswap 28 passed / 3 skipped; mcp-server 22 passed; full workspace green
```
</details>

---

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally before submitting: `pnpm build`, `pnpm typecheck`, `pnpm lint` and the offline test suite all pass; the live Monad E2E runs in CI.
