### PR TITLE
test(aave): quarantine pending reserve until address-book guard clears

### DIFF
--- a/packages/protocols/aave/test/aave.test.ts
+++ b/packages/protocols/aave/test/aave.test.ts
@@ -42,6 +42,26 @@ const UNLISTED = getAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
 const STUB_TREASURY = getAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
 /**
+ * Issue #185: a live governance listing whose first official address-book
+ * release is still inside ADR 0007's seven-day supply-chain guard. It is
+ * test-only: the adapter
+ * must not accept it until an eligible official release can be vendored. Exact
+ * equality below still fails closed on every other unknown reserve, and this
+ * quarantine expires when 4.66.2 becomes eligible.
+ */
+const PENDING_RESERVES = [
+  {
+    sourceId: "PT_AUSD_8OCT2026",
+    symbol: "PT-AUSD-8OCT2026",
+    decimals: 6,
+    underlying: getAddress("0x9FC74f8Ed616B5BaF52a170caa97d6d3898602d1"),
+    aToken: getAddress("0xb93Ce4EB85eBA317f954Dadcbe112Ce6c3af9ae4"),
+    variableDebtToken: getAddress("0x4d2D334Ff7b0A82394bc95668d99369e9EE06748"),
+    eligibleAfter: "2026-09-03T02:00:12.549Z",
+  },
+] as const;
+
+/**
  * Seed accounts for the live role search below. Simulation is read-only and Moss
  * never signs, so naming a real account costs nothing and needs no key, but no
  * account we do not control keeps a position: the one the live withdraw was
@@ -1163,9 +1183,10 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Aave mainnet", () => {
       functionName: "getReservesList",
     });
     // Checksum with one argument: map would otherwise hand getAddress the
-    // array index as an EIP-1191 chain id.
+    // array index as an EIP-1191 chain id. A reviewed quarantine keeps the gate
+    // exact without exposing a release that has not cleared the age guard.
     expect([...listed].map((address) => getAddress(address)).sort()).toEqual(
-      AAVE_RESERVES.map(({ underlying }) => underlying).sort(),
+      [...AAVE_RESERVES, ...PENDING_RESERVES].map(({ underlying }) => underlying).sort(),
     );
     for (const reserve of AAVE_RESERVES) {
       const data = await registry.action("aave", "reserve", ACCOUNT, { asset: reserve.underlying });
@@ -1192,6 +1213,44 @@ describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Aave mainnet", () => {
         args: [reserve.underlying],
       });
       expect(getAddress(onChain.stableDebtTokenAddress), reserve.symbol).toBe(ZERO);
+    }
+    for (const pending of PENDING_RESERVES) {
+      expect(
+        Date.now(),
+        `${pending.sourceId} cleared the address-book age guard; vendor it and remove this quarantine`,
+      ).toBeLessThan(Date.parse(pending.eligibleAfter));
+      expect(AAVE_RESERVES.some(({ underlying }) => underlying === pending.underlying)).toBe(false);
+
+      const metadata = await registry.action("erc20", "metadata", ACCOUNT, {
+        token: pending.underlying,
+      });
+      if (metadata.kind !== "query") throw new Error("expected a Query");
+      expect(metadata.data, pending.sourceId).toMatchObject({
+        symbol: pending.symbol,
+        decimals: pending.decimals,
+      });
+
+      const onChain = await runtime.client.readContract({
+        address: AAVE_POOL_ADDRESS,
+        abi: AavePoolAbi,
+        functionName: "getReserveData",
+        args: [pending.underlying],
+      });
+      expect(
+        {
+          aToken: getAddress(onChain.aTokenAddress),
+          stableDebtToken: getAddress(onChain.stableDebtTokenAddress),
+          variableDebtToken: getAddress(onChain.variableDebtTokenAddress),
+        },
+        pending.sourceId,
+      ).toEqual({
+        aToken: pending.aToken,
+        stableDebtToken: ZERO,
+        variableDebtToken: pending.variableDebtToken,
+      });
+      for (const address of [pending.underlying, pending.aToken, pending.variableDebtToken]) {
+        expect((await runtime.client.getCode({ address }))?.length, address).toBeGreaterThan(2);
+      }
     }
   });
 


### PR DESCRIPTION
## What and why

Aave Monad activated `PT-AUSD-8OCT2026`, so the live Pool now returns 13 reserves while Moss's age-eligible vendored address book still contains 12. That deterministic drift made the shared Linux CI fail for unrelated PRs.

The first official address-book release containing the listing is `@aave-dao/aave-address-book@4.66.2`, published at `2026-08-27T02:00:12.549Z`. Vendoring it immediately would bypass ADR 0007's mandatory seven-day supply-chain guard. This PR therefore restores the live tripwire without exposing the unaged reserve in production.

Refs #185. **Issue #185 must remain open after this PR.**

## Change

The Aave live test adds one reviewed, test-only `PENDING_RESERVES` record and keeps exact set equality over:

```text
production AAVE_RESERVES + reviewed pending reserves = live Pool reserves
```

For the pending reserve, CI also checks read-only:

- ERC symbol `PT-AUSD-8OCT2026` and 6 decimals;
- exact aToken and variable-debt token, with zero stable-debt token;
- deployed code for the underlying and both position tokens;
- absence from production `AAVE_RESERVES`.

Any other listing/removal/address drift still fails closed. The quarantine expires at `2026-09-03T02:00:12.549Z`, the same instant the updater can admit 4.66.2 under its `publishedAt <= now - 7d` rule. Missing the follow-up deliberately makes CI red with an actionable vendor/remove message.

## Production impact

None. No production source, vendored file, generated ABI/address book, public asset set, dependency, lockfile, Receipt parser, or runtime behavior changes. The adapter continues to reject the pending underlying. No changeset is required for this test-only guard.

## Follow-up required in #185

After the release clears the guard:

1. run unpinned `pnpm --filter @themoss/protocol-aave update:abis`;
2. vendor and audit the eligible official release;
3. preserve the on-chain display symbol rather than the upstream underscore identifier;
4. remove the quarantine;
5. re-check capability scope because the reserve is currently active and supply-only in base configuration (`borrowingEnabled=false`).

## Verification

- `pnpm install --offline --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:offline`
- `pnpm --filter @themoss/protocol-aave test` — full read-only Monad suite green
- `git diff --check`
- three independent reviewers: mergeable, no blockers
- mutations for expiry, unknown underlying, metadata, position-token addresses, code, and production overlap all fail at the intended seam

---

AI assistance was used for diagnosis, implementation, and review. All chain interaction was read-only; no transaction was signed or submitted.
