### PR TITLE
feat(protocols): add Merkl rewards claim adapter for Monad mainnet

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,6 +14,7 @@
       "@themoss/protocol-clober",
       "@themoss/protocol-kintsu",
       "@themoss/protocol-kuru",
+      "@themoss/protocol-merkl",
       "@themoss/protocol-monad-cards",
       "@themoss/protocol-morpho",
       "@themoss/protocol-nadfun",

--- a/.changeset/quiet-trees-claim.md
+++ b/.changeset/quiet-trees-claim.md
@@ -1,0 +1,6 @@
+---
+"@themoss/protocol-merkl": minor
+"@themoss/mcp-server": minor
+---
+
+Add Merkl reward discovery and safe self-claiming on Monad mainnet, and include the adapter in the default MCP composition.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | Clober | `@themoss/protocol-clober` | `swap` | `quote` |
 | aPriori | `@themoss/protocol-apriori` | `stake`, `unstake`, `claim` | — |
+| Merkl | `@themoss/protocol-merkl` | `claim` | `rewards` |
 | Morpho | `@themoss/protocol-morpho` | `supply`, `withdraw` | `position`, `vaultInfo` |
 | Nad.fun | `@themoss/protocol-nadfun` | — | `quoteBuy`, `quoteSell`, `tokenStatus` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,6 +28,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | Kuru | `@themoss/protocol-kuru` | `swap` | `quote` |
 | Clober | `@themoss/protocol-clober` | `swap` | `quote` |
 | aPriori | `@themoss/protocol-apriori` | `stake`、`unstake`、`claim` | — |
+| Merkl | `@themoss/protocol-merkl` | `claim` | `rewards` |
 | Morpho | `@themoss/protocol-morpho` | `supply`、`withdraw` | `position`、`vaultInfo` |
 | Nad.fun | `@themoss/protocol-nadfun` | — | `quoteBuy`、`quoteSell`、`tokenStatus` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -30,6 +30,7 @@
     "@themoss/protocol-clober": "workspace:*",
     "@themoss/protocol-kintsu": "workspace:*",
     "@themoss/protocol-kuru": "workspace:*",
+    "@themoss/protocol-merkl": "workspace:*",
     "@themoss/protocol-monad-cards": "workspace:*",
     "@themoss/protocol-morpho": "workspace:*",
     "@themoss/protocol-nadfun": "workspace:*",

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -4,6 +4,7 @@ import * as apriori from "@themoss/protocol-apriori";
 import * as clober from "@themoss/protocol-clober";
 import * as kintsu from "@themoss/protocol-kintsu";
 import * as kuru from "@themoss/protocol-kuru";
+import * as merkl from "@themoss/protocol-merkl";
 import * as monadCards from "@themoss/protocol-monad-cards";
 import * as morpho from "@themoss/protocol-morpho";
 import * as nadfun from "@themoss/protocol-nadfun";
@@ -21,6 +22,7 @@ export const defaultProtocolModules = [
   clober,
   kintsu,
   kuru,
+  merkl,
   monadCards,
   morpho,
   nadfun,

--- a/packages/mcp-server/test/composition.test.ts
+++ b/packages/mcp-server/test/composition.test.ts
@@ -5,6 +5,36 @@ import { defaultProtocolModules } from "../src/composition.js";
 const runtime = { rpcUrl: "http://offline", client: {} as MossRuntime["client"] };
 
 describe("default MCP Protocol composition", () => {
+  it("discovers and loads Merkl through the real default Registry composition", () => {
+    const registry = new Registry(runtime).use(...defaultProtocolModules);
+    const discovered = registry.discover({ protocol: "merkl" });
+
+    expect(discovered).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ protocol: "merkl", method: "rewards", kind: "query" }),
+        expect.objectContaining({ protocol: "merkl", method: "claim", kind: "capability" }),
+      ]),
+    );
+    expect(discovered).toHaveLength(2);
+
+    const loaded = registry.load([
+      { protocol: "merkl", method: "rewards" },
+      { protocol: "merkl", method: "claim" },
+    ]);
+    expect(loaded).toHaveLength(2);
+    expect(loaded.find((item) => item.method === "rewards")).toMatchObject({
+      kind: "query",
+      protocol: "merkl",
+      params: { account: { description: expect.stringContaining("Public account") } },
+    });
+    expect(loaded.find((item) => item.method === "claim")).toMatchObject({
+      kind: "capability",
+      protocol: "merkl",
+      verb: "claim",
+      params: { tokens: { description: expect.stringContaining("merkl.rewards") } },
+    });
+  });
+
   it("includes the Nad.fun Protocol module", () => {
     const nadfunModule = defaultProtocolModules.find((module) => "NadFun" in module);
 

--- a/packages/mcp-server/test/readme.test.ts
+++ b/packages/mcp-server/test/readme.test.ts
@@ -24,6 +24,7 @@ const expectedPackageOrder = [
   "@themoss/protocol-kuru",
   "@themoss/protocol-clober",
   "@themoss/protocol-apriori",
+  "@themoss/protocol-merkl",
   "@themoss/protocol-morpho",
   "@themoss/protocol-nadfun",
   "@themoss/protocol-pancakeswap",

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       "@themoss/protocol-clober": src("../protocols/clober/src/index.ts"),
       "@themoss/protocol-kintsu": src("../protocols/kintsu/src/index.ts"),
       "@themoss/protocol-kuru": src("../protocols/kuru/src/index.ts"),
+      "@themoss/protocol-merkl": src("../protocols/merkl/src/index.ts"),
       "@themoss/protocol-morpho": src("../protocols/morpho/src/index.ts"),
       "@themoss/protocol-nadfun": src("../protocols/nadfun/src/index.ts"),
       "@themoss/protocol-pancakeswap": src("../protocols/pancakeswap/src/index.ts"),

--- a/packages/protocols/merkl/README.md
+++ b/packages/protocols/merkl/README.md
@@ -1,0 +1,75 @@
+# @themoss/protocol-merkl
+
+Moss Protocol adapter for discovering and safely self-claiming [Merkl](https://merkl.xyz/) incentives on Monad mainnet (chain ID `143`). Merkl aggregates incentive distributions from lending, staking, liquidity, and other protocols into Merkle trees; this package adds a pre-signing explanation and verification layer for those rewards.
+
+## Surface
+
+- Query `merkl.rewards({ account })` inspects any public account.
+- Capability `merkl.claim({ tokens })` claims 1–16 unique reward tokens, preserving the requested order.
+
+`rewards` reports each token's API cumulative earned amount, API-reported claimed amount, authoritative current on-chain claimed amount, incremental amount claimable now, pending amount, proof availability, effective on-chain recipient, and availability reason. Campaign breakdowns are included as API-derived metadata only; their names and amounts are not on-chain verified.
+
+`claim` is strictly self-claim-only. The user is always `ActionCtx.account`. The Agent cannot provide a user, Distributor, recipient, amount, proof, or arbitrary calldata. The Capability owns exactly one direct `Distributor.claim` transaction and needs no approvals.
+
+## Deployment and upgrade tripwire
+
+| Contract | Address | Verification |
+| --- | --- | --- |
+| Distributor ERC-1967/UUPS proxy | `0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae` | Published by the [official Monad protocol registry](https://github.com/monad-developers/protocols/blob/main/mainnet/merkl.jsonc) and [Merkl contract-address documentation](https://docs.merkl.xyz/integrate-merkl/smart-contract-addresses) |
+| Current implementation | `0x3f0fa7847b1b2e4515a93e05b29f115d9bb51d85` | [Explorer-verified `Distributor`](https://monadscan.com/address/0x3f0fa7847b1b2e4515a93e05b29f115d9bb51d85) |
+
+`abis.json` pins both runtime bytecode hashes and the current EIP-1967 implementation. The normal live deployment suite verifies chain ID 143, both code hashes, the proxy slot, required function selectors and `Claimed` topic, and the current read surface. Any implementation or incompatible bytecode change fails clearly and requires a human ABI review.
+
+## Trust and amount model
+
+The official Merkl API endpoint is an off-chain candidate source:
+
+```text
+GET https://api.merkl.xyz/v4/users/{account}/rewards?chainId=143
+GET https://api.merkl.xyz/v4/users/{account}/rewards?chainId=143&reloadChainId=143
+```
+
+The Query uses the normal endpoint. Claim construction uses Merkl's fresh-reload mechanism and rejects network errors, schema drift, wrong chains, malformed addresses/uints/proofs, duplicates, and inconsistent records. There is no stale hard-coded fallback.
+
+Merkl API `amount` is cumulative earned value and is the amount passed to the Distributor. The incremental value payable now is:
+
+```text
+claimable = API cumulative amount - Distributor.claimed(account, token)
+```
+
+The on-chain claimed value takes precedence over the API's claimed field. `pending` is reported separately and is never added to transaction amounts. Before constructing calldata, the adapter reads the active root and claimed values, locally verifies every proof using `keccak256(abi.encode(user, token, cumulativeAmount))` with sorted proof pairs, and requires a strictly positive incremental amount.
+
+For each token the effective recipient is resolved exactly as the deployed Distributor does: token-specific mapping, then account-wide mapping at token zero, then the account itself. Claim construction rejects any redirect away from `ActionCtx.account`, including a default redirect. A mapping explicitly set to the same account is accepted.
+
+## Receipt evidence
+
+The pure Receipt parser accepts only the observed execution order confirmed by a live Monad simulation: for every reward, a Distributor-emitted `Claimed(user, token, incrementalAmount)` followed by that token contract's `Transfer(Distributor, user, incrementalAmount)`. It authenticates all emitters and parties, matches exact positive amounts, rejects duplicate/missing/ambiguous/decoy evidence and every unexplained Change, and preserves original Change identity, length, and order. ERC-20 Transfer Changes are delegated unchanged to the injected `@themoss/erc` Protocol.
+
+The typed outcome reports only execution-proven facts:
+
+```ts
+{
+  operation: "claim";
+  account: AddressValue;
+  rewards: readonly { token: AddressValue; amount: string }[];
+}
+```
+
+It deliberately does not reconstruct cumulative amounts, proofs, campaigns, or the planned token list.
+
+## Risk metadata and exclusions
+
+Claims are inflow-only. Moss Registry currently rejects an empty risk list and Core has no accepted inflow label, so `merkl.claim` temporarily carries `risk: ["fundOut"]`, following the existing aPriori claim precedent. This is a compatibility placeholder, not a semantic description, and should be replaced when the framework accepts `fundIn` or an equivalent label.
+
+This v1 package does not expose claiming for another user, operator or main-operator controls, `toggleOperator`, `toggleMainOperatorStatus`, recipient configuration, `setClaimRecipient`, `claimWithRecipient`, callback data or contract callbacks, swaps, vault deposits, campaign management, disputes, tree updates, governance/admin methods, cross-chain claiming, or arbitrary Distributor addresses.
+
+## ABI provenance and verification
+
+The committed `src/abis/distributor.ts` contains the full 73-entry ABI fetched from the explorer-verified active implementation, following ADR 0007. It is generated by the shared deterministic renderer; the source table pins the canonical full-ABI SHA-256, and `test/abis.test.ts` re-renders and hashes it so hand edits fail. Refresh and independently compare it with:
+
+```bash
+MONADSCAN_API_KEY=... pnpm update:abis
+MONADSCAN_API_KEY=... pnpm test:abi:online
+```
+
+Normal `pnpm test` includes keyless deployment verification and a real unsigned Monad self-claim simulation unless `MOSS_SKIP_E2E` is set. `MOSS_RPC_URL` overrides the repository default RPC. The live fixture can be maintained with `MERKL_LIVE_ACCOUNT` and `MERKL_LIVE_TOKEN`; loss of a positive claim fails explicitly rather than silently skipping. No signing, sending, private key, or storage mutation is used.

--- a/packages/protocols/merkl/README.md
+++ b/packages/protocols/merkl/README.md
@@ -7,7 +7,7 @@ Moss Protocol adapter for discovering and safely self-claiming [Merkl](https://m
 - Query `merkl.rewards({ account })` inspects any public account.
 - Capability `merkl.claim({ tokens })` claims 1–16 unique reward tokens, preserving the requested order.
 
-`rewards` reports each token's API cumulative earned amount, API-reported claimed amount, authoritative current on-chain claimed amount, incremental amount claimable now, pending amount, proof availability, effective on-chain recipient, and availability reason. Campaign breakdowns are included as API-derived metadata only; their names and amounts are not on-chain verified.
+`rewards` reports each token's API cumulative earned amount, API-reported claimed amount, authoritative current on-chain claimed amount, incremental amount claimable now, pending amount, proof availability, effective on-chain recipient, and availability reason. It verifies each proof against the active on-chain root before setting `claimableNow`. Campaign breakdowns are included as API-derived metadata only; their names and amounts are not on-chain verified.
 
 `claim` is strictly self-claim-only. The user is always `ActionCtx.account`. The Agent cannot provide a user, Distributor, recipient, amount, proof, or arbitrary calldata. The Capability owns exactly one direct `Distributor.claim` transaction and needs no approvals.
 
@@ -29,7 +29,7 @@ GET https://api.merkl.xyz/v4/users/{account}/rewards?chainId=143
 GET https://api.merkl.xyz/v4/users/{account}/rewards?chainId=143&reloadChainId=143
 ```
 
-The Query uses the normal endpoint. Claim construction uses Merkl's fresh-reload mechanism and rejects network errors, schema drift, wrong chains, malformed addresses/uints/proofs, duplicates, and inconsistent records. There is no stale hard-coded fallback.
+The Query uses the normal endpoint. Claim construction uses Merkl's fresh-reload mechanism and rejects network errors, schema drift, wrong chains, malformed addresses/uints/proofs, duplicates, and inconsistent records. Requests have a 10-second end-to-end timeout and bounded response, reward, breakdown, and proof sizes. Cumulative claim amounts are limited to the Distributor's `uint208` storage range. There is no stale hard-coded fallback.
 
 Merkl API `amount` is cumulative earned value and is the amount passed to the Distributor. The incremental value payable now is:
 
@@ -37,7 +37,7 @@ Merkl API `amount` is cumulative earned value and is the amount passed to the Di
 claimable = API cumulative amount - Distributor.claimed(account, token)
 ```
 
-The on-chain claimed value takes precedence over the API's claimed field. `pending` is reported separately and is never added to transaction amounts. Before constructing calldata, the adapter reads the active root and claimed values, locally verifies every proof using `keccak256(abi.encode(user, token, cumulativeAmount))` with sorted proof pairs, and requires a strictly positive incremental amount.
+The on-chain claimed value takes precedence over the API's claimed field. `pending` is reported separately and is never added to transaction amounts. Both Query and claim construction locally verify proofs using `keccak256(abi.encode(user, token, cumulativeAmount))` with sorted proof pairs; an empty proof is valid for a single-leaf tree when the leaf itself equals the active root. Claim construction also requires a strictly positive incremental amount.
 
 For each token the effective recipient is resolved exactly as the deployed Distributor does: token-specific mapping, then account-wide mapping at token zero, then the account itself. Claim construction rejects any redirect away from `ActionCtx.account`, including a default redirect. A mapping explicitly set to the same account is accepted.
 
@@ -59,7 +59,7 @@ It deliberately does not reconstruct cumulative amounts, proofs, campaigns, or t
 
 ## Risk metadata and exclusions
 
-Claims are inflow-only. Moss Registry currently rejects an empty risk list and Core has no accepted inflow label, so `merkl.claim` temporarily carries `risk: ["fundOut"]`, following the existing aPriori claim precedent. This is a compatibility placeholder, not a semantic description, and should be replaced when the framework accepts `fundIn` or an equivalent label.
+The claim is inflow-only. `fundOut` is a temporary Registry-compatible placeholder. The maintainer-approved representation is tracked in [#164](https://github.com/nishuzumi/moss/issues/164) and should replace this label once Core resolves that issue.
 
 This v1 package does not expose claiming for another user, operator or main-operator controls, `toggleOperator`, `toggleMainOperatorStatus`, recipient configuration, `setClaimRecipient`, `claimWithRecipient`, callback data or contract callbacks, swaps, vault deposits, campaign management, disputes, tree updates, governance/admin methods, cross-chain claiming, or arbitrary Distributor addresses.
 

--- a/packages/protocols/merkl/README.md
+++ b/packages/protocols/merkl/README.md
@@ -59,7 +59,7 @@ It deliberately does not reconstruct cumulative amounts, proofs, campaigns, or t
 
 ## Risk metadata and exclusions
 
-The claim is inflow-only. `fundOut` is a temporary Registry-compatible placeholder. The maintainer-approved representation is tracked in [#164](https://github.com/nishuzumi/moss/issues/164) and should replace this label once Core resolves that issue.
+The claim is inflow-only and uses the explicitly authored `risk: []` now supported by Core. This records that the operation was reviewed and none of the current closed-set RiskLabels accurately applies. Receipt tests retain the relevant Changes and assert that no asset leaves the acting account, as required by [#164](https://github.com/nishuzumi/moss/issues/164).
 
 This v1 package does not expose claiming for another user, operator or main-operator controls, `toggleOperator`, `toggleMainOperatorStatus`, recipient configuration, `setClaimRecipient`, `claimWithRecipient`, callback data or contract callbacks, swaps, vault deposits, campaign management, disputes, tree updates, governance/admin methods, cross-chain claiming, or arbitrary Distributor addresses.
 

--- a/packages/protocols/merkl/abis.json
+++ b/packages/protocols/merkl/abis.json
@@ -1,0 +1,9 @@
+{
+  "distributor": {
+    "proxy": "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae",
+    "implementation": "0x3f0fa7847b1b2e4515a93e05b29f115d9bb51d85",
+    "proxyRuntimeCodeHash": "0x1663c7ebc964dfa69a98528bccf3431438c5149fbabb8313d33374df61f3985a",
+    "implementationRuntimeCodeHash": "0x9c2edb9dffd093d12e7361203d857bf6d1bd208fcc1aeff7a8b6ac73323a04e7",
+    "allowedExplorerOnly": []
+  }
+}

--- a/packages/protocols/merkl/package.json
+++ b/packages/protocols/merkl/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@themoss/protocol-merkl",
+  "version": "0.0.0",
+  "description": "Moss Protocol adapter for Merkl rewards on Monad mainnet",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:abi:online": "vitest run --config vitest.online.config.ts",
+    "update:abis": "tsx scripts/update-abis.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "@themoss/erc": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/abi-tools": "workspace:*",
+    "@themoss/simulator": "workspace:*",
+    "@themoss/system": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/merkl/scripts/abis.ts
+++ b/packages/protocols/merkl/scripts/abis.ts
@@ -1,0 +1,8 @@
+export const DISTRIBUTOR_ABI_SOURCE = {
+  exportName: "distributor",
+  file: "distributor.ts",
+  address: "0x3f0fa7847b1b2e4515a93e05b29f115d9bb51d85",
+  // sha256(JSON.stringify(full explorer ABI)); forces an intentional review
+  // before update:abis accepts explorer surface drift.
+  abiSha256: "83eafd156f2c6815d5b4ac4f3b49896864336036ecec6d76abaea765bc2d4909",
+} as const;

--- a/packages/protocols/merkl/scripts/update-abis.ts
+++ b/packages/protocols/merkl/scripts/update-abis.ts
@@ -1,0 +1,29 @@
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { fetchAbi, renderAbiModule } from "@themoss/abi-tools";
+import { DISTRIBUTOR_ABI_SOURCE } from "./abis.js";
+
+const key = process.env.MONADSCAN_API_KEY;
+if (!key) {
+  throw new Error(
+    "MONADSCAN_API_KEY is not set; create one at https://info.monadscan.com/myapikey/ and export it.",
+  );
+}
+
+const abi = await fetchAbi(DISTRIBUTOR_ABI_SOURCE.address, key);
+const digest = createHash("sha256").update(JSON.stringify(abi)).digest("hex");
+if (digest !== DISTRIBUTOR_ABI_SOURCE.abiSha256) {
+  throw new Error(
+    `Explorer ABI changed: expected sha256 ${DISTRIBUTOR_ABI_SOURCE.abiSha256}, received ${digest}; review the full deployed implementation ABI and update the recorded digest intentionally`,
+  );
+}
+writeFileSync(
+  new URL(`../src/abis/${DISTRIBUTOR_ABI_SOURCE.file}`, import.meta.url),
+  renderAbiModule({
+    exportName: DISTRIBUTOR_ABI_SOURCE.exportName,
+    address: DISTRIBUTOR_ABI_SOURCE.address,
+    abi,
+    retrievedAt: new Date(),
+  }),
+);
+console.log(`src/abis/${DISTRIBUTOR_ABI_SOURCE.file}: ${abi.length} ABI entries`);

--- a/packages/protocols/merkl/src/abis/distributor.ts
+++ b/packages/protocols/merkl/src/abis/distributor.ts
@@ -1,0 +1,1058 @@
+// ABI origin: explorer (ADR 0007)
+//   Source:    https://monadscan.com/address/0x3f0fa7847b1b2e4515a93e05b29f115d9bb51d85
+//   Endpoint:  Etherscan V2 (chainid=143, module=contract, action=getabi)
+//   Retrieved: 2026-08-07 (UTC)
+
+export const distributorAbi = [
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDispute",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidLengths",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProof",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidReturnMessage",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidUninitializedRoot",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoDispute",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotGovernor",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotGovernorOrGuardian",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotTrusted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotUpgradeable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotWhitelisted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnresolvedDispute",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "beacon",
+        "type": "address"
+      }
+    ],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "ClaimRecipientUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_disputeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DisputeAmountUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint48",
+        "name": "_disputePeriod",
+        "type": "uint48"
+      }
+    ],
+    "name": "DisputePeriodUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "valid",
+        "type": "bool"
+      }
+    ],
+    "name": "DisputeResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_disputeToken",
+        "type": "address"
+      }
+    ],
+    "name": "DisputeTokenUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "Disputed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newEpochDuration",
+        "type": "uint32"
+      }
+    ],
+    "name": "EpochDurationUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isWhitelisted",
+        "type": "bool"
+      }
+    ],
+    "name": "MainOperatorStatusUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "OperatorClaimingToggled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isWhitelisted",
+        "type": "bool"
+      }
+    ],
+    "name": "OperatorToggled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Recovered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "Revoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "merkleRoot",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "ipfsHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint48",
+        "name": "endOfDisputePeriod",
+        "type": "uint48"
+      }
+    ],
+    "name": "TreeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "eoa",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "trust",
+        "type": "bool"
+      }
+    ],
+    "name": "TrustedToggled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "UpgradeabilityRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "CALLBACK_SUCCESS",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [
+      {
+        "internalType": "contract IAccessControlManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "canUpdateMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "users",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[][]",
+        "name": "proofs",
+        "type": "bytes32[][]"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimRecipient",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "users",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes32[][]",
+        "name": "proofs",
+        "type": "bytes32[][]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "recipients",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "datas",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "claimWithRecipient",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimed",
+    "outputs": [
+      {
+        "internalType": "uint208",
+        "name": "amount",
+        "type": "uint208"
+      },
+      {
+        "internalType": "uint48",
+        "name": "timestamp",
+        "type": "uint48"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "merkleRoot",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disputeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disputePeriod",
+    "outputs": [
+      {
+        "internalType": "uint48",
+        "name": "",
+        "type": "uint48"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disputeToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "disputeTree",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disputer",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "endOfDisputePeriod",
+    "outputs": [
+      {
+        "internalType": "uint48",
+        "name": "",
+        "type": "uint48"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getEpochDuration",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "epochDuration",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMerkleRoot",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IAccessControlManager",
+        "name": "_accessControlManager",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastTree",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "merkleRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "ipfsHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "mainOperators",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "onlyOperatorCanClaim",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "operators",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountToRecover",
+        "type": "uint256"
+      }
+    ],
+    "name": "recoverERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "valid",
+        "type": "bool"
+      }
+    ],
+    "name": "resolveDispute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "revokeTree",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "revokeUpgradeability",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "setClaimRecipient",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_disputeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setDisputeAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint48",
+        "name": "_disputePeriod",
+        "type": "uint48"
+      }
+    ],
+    "name": "setDisputePeriod",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_disputeToken",
+        "type": "address"
+      }
+    ],
+    "name": "setDisputeToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "epochDuration",
+        "type": "uint32"
+      }
+    ],
+    "name": "setEpochDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "toggleMainOperatorStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "toggleOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "trustAddress",
+        "type": "address"
+      }
+    ],
+    "name": "toggleTrusted",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tree",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "merkleRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "ipfsHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "merkleRoot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "ipfsHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct MerkleTree",
+        "name": "_tree",
+        "type": "tuple"
+      }
+    ],
+    "name": "updateTree",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "upgradeabilityDeactivated",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+] as const;

--- a/packages/protocols/merkl/src/adapter.ts
+++ b/packages/protocols/merkl/src/adapter.ts
@@ -1,0 +1,381 @@
+import {
+  type ActionCtx,
+  Address,
+  type AddressValue,
+  Capability,
+  type Change,
+  type Handle,
+  type Hex,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  type ProtocolRef,
+  Query,
+  Receipt,
+  type ReceiptResult,
+} from "@themoss/core";
+import { ERC20, ERC20Abi } from "@themoss/erc";
+import { concatHex, decodeEventLog, encodeAbiParameters, getAddress, keccak256 } from "viem";
+import { distributorAbi } from "./abis/distributor.js";
+import { fetchMerklRewardCandidates } from "./api.js";
+import type {
+  MerklClaimOutcome,
+  MerklReward,
+  MerklRewardCandidate,
+  MerklRewardsResult,
+} from "./types.js";
+
+// Monad mainnet canonical sources:
+// - Monad protocol registry: https://github.com/monad-developers/protocols/blob/main/mainnet/merkl.jsonc
+// - Merkl docs: https://docs.merkl.xyz/integrate-merkl/smart-contract-addresses
+// The address is an ERC-1967/UUPS proxy. abis.json and the online suites pin
+// its deployed bytecode and current implementation.
+export const MERKL_DISTRIBUTOR_ADDRESS: AddressValue = "0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae";
+
+export const MERKL_DISTRIBUTOR_IMPLEMENTATION: AddressValue =
+  "0x3f0fa7847b1b2e4515a93e05b29f115d9bb51d85";
+
+export const MAX_MERKL_CLAIM_TOKENS = 16;
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+const ZERO_ROOT = `0x${"00".repeat(32)}` as Hex;
+
+const RewardTokenList = Address.array()
+  .min(1)
+  .max(MAX_MERKL_CLAIM_TOKENS)
+  .refine(
+    (tokens) => new Set(tokens.map((token) => token.toLowerCase())).size === tokens.length,
+    "Reward token addresses must be unique.",
+  )
+  .describe(`An ordered list of 1 through ${MAX_MERKL_CLAIM_TOKENS} unique EVM token addresses.`);
+
+const rewardsParams = {
+  account: {
+    type: Address,
+    description: "Public account whose Monad Merkl rewards are inspected.",
+  },
+} satisfies ParamsSpec;
+
+const claimParams = {
+  tokens: {
+    type: RewardTokenList,
+    description: "Reward tokens selected from the current merkl.rewards result, in claim order.",
+  },
+} satisfies ParamsSpec;
+
+interface RewardOnchainState {
+  onchainClaimedAmount: bigint;
+  effectiveRecipient: AddressValue;
+}
+
+@Protocol({
+  name: "merkl",
+  category: "rewards",
+  description:
+    "Merkl reward discovery and safe self-claiming through the fixed Monad mainnet Distributor.",
+  contracts: {
+    distributor: { abi: distributorAbi, addr: MERKL_DISTRIBUTOR_ADDRESS },
+  },
+  protocols: {
+    erc20: ERC20,
+  },
+  labels: {
+    Distributor: MERKL_DISTRIBUTOR_ADDRESS,
+  },
+})
+export class MerklProtocol {
+  declare distributor: Handle<typeof distributorAbi>;
+  declare erc20: ProtocolRef<ERC20>;
+
+  @Query({
+    intent: "Inspect an account's Merkl rewards on Monad mainnet",
+    params: rewardsParams,
+    tags: ["rewards", "merkle", "incentives"],
+  })
+  async rewards(params: InferParams<typeof rewardsParams>): Promise<MerklRewardsResult> {
+    const candidates = await fetchMerklRewardCandidates(params.account, { reload: false });
+    const [merkleRoot, defaultRecipient] = await Promise.all([
+      this.distributor.read.getMerkleRoot(),
+      this.distributor.read.claimRecipient([params.account, ZERO_ADDRESS]),
+    ]);
+    const states = await Promise.all(
+      candidates.map((candidate) =>
+        this.#readRewardState(params.account, candidate.token, defaultRecipient),
+      ),
+    );
+
+    return {
+      account: getAddress(params.account),
+      merkleRoot,
+      rewards: candidates.map((candidate, index) =>
+        queryReward(params.account, merkleRoot, candidate, states[index] as RewardOnchainState),
+      ),
+    };
+  }
+
+  @Capability<MerklProtocol, typeof claimParams>({
+    intent: "Claim selected Merkl reward tokens to the acting account",
+    verb: "claim",
+    params: claimParams,
+    receipt: "claimReceipt",
+    // The claim is inflow-only. Registry currently rejects an empty risk list
+    // and core has no accepted fundIn label; follow the aPriori claim precedent
+    // until the framework gains a semantically correct inflow label.
+    risk: ["fundOut"],
+    tags: ["rewards", "merkle", "batch-claim", "incentives"],
+  })
+  async claim(params: InferParams<typeof claimParams>, ctx: ActionCtx) {
+    const account = getAddress(ctx.account);
+    const candidates = await fetchMerklRewardCandidates(account, { reload: true });
+    const byToken = new Map(
+      candidates.map((candidate) => [candidate.token.toLowerCase(), candidate]),
+    );
+    const selected = params.tokens.map((token) => {
+      const candidate = byToken.get(token.toLowerCase());
+      if (!candidate)
+        throw new Error(`Merkl has no current reward record for selected token ${token}`);
+      return candidate;
+    });
+
+    const [merkleRoot, defaultRecipient] = await Promise.all([
+      this.distributor.read.getMerkleRoot(),
+      this.distributor.read.claimRecipient([account, ZERO_ADDRESS]),
+    ]);
+    if (sameHex(merkleRoot, ZERO_ROOT)) {
+      throw new Error("Merkl Distributor has no active Merkle root");
+    }
+    const states = await Promise.all(
+      selected.map((candidate) =>
+        this.#readRewardState(account, candidate.token, defaultRecipient),
+      ),
+    );
+
+    selected.forEach((candidate, index) => {
+      const state = states[index] as RewardOnchainState;
+      if (candidate.cumulativeAmount <= state.onchainClaimedAmount) {
+        throw new Error(
+          `Merkl reward ${candidate.token} has no positive incremental claim: cumulative ${candidate.cumulativeAmount}, on-chain claimed ${state.onchainClaimedAmount}`,
+        );
+      }
+      if (!sameHex(candidate.root, merkleRoot)) {
+        throw new Error(
+          `Merkl reward ${candidate.token} proof root ${candidate.root} does not match active root ${merkleRoot}`,
+        );
+      }
+      if (
+        !verifyMerklProof(
+          account,
+          candidate.token,
+          candidate.cumulativeAmount,
+          candidate.proofs,
+          merkleRoot,
+        )
+      ) {
+        throw new Error(`Merkl reward ${candidate.token} proof does not match the active root`);
+      }
+      if (!sameAddress(state.effectiveRecipient, account)) {
+        throw new Error(
+          `Merkl reward ${candidate.token} redirects claims to ${state.effectiveRecipient}; safe self-claim requires recipient ${account}`,
+        );
+      }
+    });
+
+    return [
+      this.distributor.claim([
+        selected.map(() => account),
+        selected.map((candidate) => candidate.token),
+        selected.map((candidate) => candidate.cumulativeAmount),
+        selected.map((candidate) => candidate.proofs),
+      ]),
+    ];
+  }
+
+  @Receipt()
+  claimReceipt(changes: readonly Change[]): ReceiptResult<MerklClaimOutcome> {
+    if (changes.length === 0 || changes.length % 2 !== 0) {
+      throw new Error("Merkl claim Receipt requires one ordered Claimed/Transfer pair per reward");
+    }
+
+    let account: AddressValue | undefined;
+    const seenTokens = new Set<string>();
+    const rewards: MerklClaimOutcome["rewards"][number][] = [];
+    const parsed: ReceiptResult["changes"][number][] = [];
+
+    for (let index = 0; index < changes.length; index += 2) {
+      const claimedChange = changes[index];
+      const transferChange = changes[index + 1];
+      if (!claimedChange || !transferChange) {
+        throw new Error("Merkl claim Receipt requires complete Claimed/Transfer pairs");
+      }
+      const claimed = decodeClaimed(claimedChange);
+      if (claimed.amount === 0n) throw new Error("Merkl claim Receipt rejects zero-amount claims");
+      if (account !== undefined && !sameAddress(account, claimed.user)) {
+        throw new Error("Merkl claim Receipt saw Claimed events for different users");
+      }
+      account = getAddress(claimed.user);
+      const tokenKey = claimed.token.toLowerCase();
+      if (seenTokens.has(tokenKey)) {
+        throw new Error(`Merkl claim Receipt saw duplicate Claimed evidence for ${claimed.token}`);
+      }
+      seenTokens.add(tokenKey);
+
+      const transfer = decodeRewardTransfer(transferChange, claimed.token);
+      if (!sameAddress(transfer.from, MERKL_DISTRIBUTOR_ADDRESS)) {
+        throw new Error("Merkl claim Receipt requires Transfer sender to be the Distributor");
+      }
+      if (!sameAddress(transfer.to, claimed.user)) {
+        throw new Error("Merkl claim Receipt requires Transfer recipient to equal Claimed.user");
+      }
+      if (transfer.value !== claimed.amount) {
+        throw new Error("Merkl claim Receipt requires Transfer value to equal Claimed.amount");
+      }
+
+      const reward = { token: getAddress(claimed.token), amount: claimed.amount.toString() };
+      rewards.push(reward);
+      parsed.push({
+        kind: "change",
+        change: claimedChange,
+        data: { operation: "claim", account, ...reward },
+        text: `Merkl Claim: ${reward.amount} of ${reward.token} paid by ${MERKL_DISTRIBUTOR_ADDRESS} to ${account}`,
+      });
+      parsed.push(this.erc20.changesReceipt([transferChange]));
+    }
+
+    if (!account) throw new Error("Merkl claim Receipt has no self-claim account evidence");
+    const outcome: MerklClaimOutcome = { operation: "claim", account, rewards };
+    return {
+      kind: "receipt",
+      outcome,
+      text: `Merkl Claim: ${rewards.length} reward token(s) paid to ${account}`,
+      changes: parsed,
+    };
+  }
+
+  async #readRewardState(
+    account: AddressValue,
+    token: AddressValue,
+    defaultRecipient: AddressValue,
+  ): Promise<RewardOnchainState> {
+    const [claim, tokenRecipient] = await Promise.all([
+      this.distributor.read.claimed([account, token]),
+      this.distributor.read.claimRecipient([account, token]),
+    ]);
+    const effectiveRecipient = !sameAddress(tokenRecipient, ZERO_ADDRESS)
+      ? tokenRecipient
+      : !sameAddress(defaultRecipient, ZERO_ADDRESS)
+        ? defaultRecipient
+        : account;
+    return { onchainClaimedAmount: claim[0], effectiveRecipient: getAddress(effectiveRecipient) };
+  }
+}
+
+export function merklLeaf(
+  account: AddressValue,
+  token: AddressValue,
+  cumulativeAmount: bigint,
+): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [{ type: "address" }, { type: "address" }, { type: "uint256" }],
+      [account, token, cumulativeAmount],
+    ),
+  );
+}
+
+export function verifyMerklProof(
+  account: AddressValue,
+  token: AddressValue,
+  cumulativeAmount: bigint,
+  proofs: readonly Hex[],
+  root: Hex,
+): boolean {
+  let current = merklLeaf(account, token, cumulativeAmount);
+  for (const proof of proofs) {
+    current =
+      BigInt(current) < BigInt(proof)
+        ? keccak256(concatHex([current, proof]))
+        : keccak256(concatHex([proof, current]));
+  }
+  return sameHex(current, root);
+}
+
+function queryReward(
+  account: AddressValue,
+  merkleRoot: Hex,
+  candidate: MerklRewardCandidate,
+  state: RewardOnchainState,
+): MerklReward {
+  const claimable =
+    candidate.cumulativeAmount > state.onchainClaimedAmount
+      ? candidate.cumulativeAmount - state.onchainClaimedAmount
+      : 0n;
+  let unavailableReason: string | undefined;
+  if (sameHex(merkleRoot, ZERO_ROOT)) unavailableReason = "Distributor has no active Merkle root.";
+  else if (!sameHex(candidate.root, merkleRoot))
+    unavailableReason = "API proof targets a stale Merkle root.";
+  else if (candidate.cumulativeAmount < state.onchainClaimedAmount) {
+    unavailableReason = "API cumulative amount is behind the on-chain claimed amount.";
+  } else if (claimable === 0n) unavailableReason = "No newly claimable reward is available.";
+  else if (candidate.proofs.length === 0) unavailableReason = "API did not provide a Merkle proof.";
+  else if (!sameAddress(state.effectiveRecipient, account)) {
+    unavailableReason = `On-chain recipient mapping redirects this token to ${state.effectiveRecipient}.`;
+  }
+
+  return {
+    token: candidate.token,
+    cumulativeAmount: candidate.cumulativeAmount.toString(),
+    apiClaimedAmount: candidate.apiClaimedAmount.toString(),
+    onchainClaimedAmount: state.onchainClaimedAmount.toString(),
+    claimableAmount: claimable.toString(),
+    pendingAmount: candidate.pendingAmount.toString(),
+    proofLength: candidate.proofs.length,
+    effectiveRecipient: state.effectiveRecipient,
+    claimableNow: unavailableReason === undefined,
+    ...(unavailableReason ? { unavailableReason } : {}),
+    breakdowns: candidate.breakdowns,
+  };
+}
+
+function decodeClaimed(change: Change) {
+  if (change.kind !== "event" || !sameAddress(change.address, MERKL_DISTRIBUTOR_ADDRESS)) {
+    throw new Error("Merkl claim Receipt requires Claimed emitted by the fixed Distributor");
+  }
+  try {
+    const decoded = decodeEventLog({
+      abi: distributorAbi,
+      eventName: "Claimed",
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+    return decoded.args;
+  } catch {
+    throw new Error("Merkl claim Receipt encountered malformed or unsupported Distributor event");
+  }
+}
+
+function decodeRewardTransfer(change: Change, token: AddressValue) {
+  if (change.kind !== "event" || !sameAddress(change.address, token)) {
+    throw new Error("Merkl claim Receipt requires Transfer emitted by the claimed token");
+  }
+  try {
+    const decoded = decodeEventLog({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      topics: change.topics as [Hex, ...Hex[]],
+      data: change.data,
+      strict: true,
+    });
+    return decoded.args;
+  } catch {
+    throw new Error("Merkl claim Receipt encountered malformed or unsupported token event");
+  }
+}
+
+function sameAddress(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function sameHex(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}

--- a/packages/protocols/merkl/src/adapter.ts
+++ b/packages/protocols/merkl/src/adapter.ts
@@ -118,9 +118,9 @@ export class MerklProtocol {
     verb: "claim",
     params: claimParams,
     receipt: "claimReceipt",
-    // The claim is inflow-only. Registry currently rejects an empty risk list
-    // and core has no accepted fundIn label; follow the aPriori claim precedent
-    // until the framework gains a semantically correct inflow label.
+    // The claim is inflow-only. fundOut is a temporary Registry-compatible
+    // placeholder; the maintainer-approved representation is tracked in #164:
+    // https://github.com/nishuzumi/moss/issues/164
     risk: ["fundOut"],
     tags: ["rewards", "merkle", "batch-claim", "incentives"],
   })
@@ -316,8 +316,17 @@ function queryReward(
   else if (candidate.cumulativeAmount < state.onchainClaimedAmount) {
     unavailableReason = "API cumulative amount is behind the on-chain claimed amount.";
   } else if (claimable === 0n) unavailableReason = "No newly claimable reward is available.";
-  else if (candidate.proofs.length === 0) unavailableReason = "API did not provide a Merkle proof.";
-  else if (!sameAddress(state.effectiveRecipient, account)) {
+  else if (
+    !verifyMerklProof(
+      account,
+      candidate.token,
+      candidate.cumulativeAmount,
+      candidate.proofs,
+      merkleRoot,
+    )
+  ) {
+    unavailableReason = "API proof does not match the active Merkle root.";
+  } else if (!sameAddress(state.effectiveRecipient, account)) {
     unavailableReason = `On-chain recipient mapping redirects this token to ${state.effectiveRecipient}.`;
   }
 

--- a/packages/protocols/merkl/src/adapter.ts
+++ b/packages/protocols/merkl/src/adapter.ts
@@ -118,10 +118,7 @@ export class MerklProtocol {
     verb: "claim",
     params: claimParams,
     receipt: "claimReceipt",
-    // The claim is inflow-only. fundOut is a temporary Registry-compatible
-    // placeholder; the maintainer-approved representation is tracked in #164:
-    // https://github.com/nishuzumi/moss/issues/164
-    risk: ["fundOut"],
+    risk: [],
     tags: ["rewards", "merkle", "batch-claim", "incentives"],
   })
   async claim(params: InferParams<typeof claimParams>, ctx: ActionCtx) {

--- a/packages/protocols/merkl/src/api.ts
+++ b/packages/protocols/merkl/src/api.ts
@@ -9,6 +9,8 @@ const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 4_000_000;
 const MAX_REWARD_RECORDS = 128;
 const MAX_BREAKDOWNS_PER_REWARD = 512;
+const MAX_PROOF_LENGTH = 256;
+const UINT208_MAX = 2n ** 208n - 1n;
 const UINT256_MAX = 2n ** 256n - 1n;
 
 export async function fetchMerklRewardCandidates(
@@ -21,33 +23,44 @@ export async function fetchMerklRewardCandidates(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-  let response: Response;
   try {
-    response = await fetch(url, { signal: controller.signal });
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw new Error(`Merkl rewards request timed out after ${REQUEST_TIMEOUT_MS}ms`);
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted) throw requestTimeoutError();
+      throw new Error(`Merkl rewards request failed: ${errorMessage(error)}`);
     }
-    throw new Error(`Merkl rewards request failed: ${errorMessage(error)}`);
+
+    if (!response.ok) {
+      throw new Error(
+        `Merkl rewards request failed with HTTP ${response.status}; retry after checking api.merkl.xyz status`,
+      );
+    }
+
+    let body: string;
+    try {
+      body = await readBoundedResponse(response);
+    } catch (error) {
+      if (controller.signal.aborted) throw requestTimeoutError();
+      if (error instanceof Error && error.message.startsWith("Merkl rewards response exceeds")) {
+        throw error;
+      }
+      throw new Error(`Merkl rewards response body could not be read: ${errorMessage(error)}`);
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(body);
+    } catch (error) {
+      throw new Error(`Merkl rewards response is not valid JSON: ${errorMessage(error)}`);
+    }
+
+    return parseMerklRewardsResponse(payload, account);
   } finally {
+    // Covers fetch, status handling, the complete streamed body, and JSON parsing.
     clearTimeout(timeout);
   }
-
-  if (!response.ok) {
-    throw new Error(
-      `Merkl rewards request failed with HTTP ${response.status}; retry after checking api.merkl.xyz status`,
-    );
-  }
-
-  let payload: unknown;
-  try {
-    payload = JSON.parse(await readBoundedResponse(response));
-  } catch (error) {
-    if (error instanceof Error && error.message.startsWith("Merkl rewards response")) throw error;
-    throw new Error(`Merkl rewards response is not valid JSON: ${errorMessage(error)}`);
-  }
-
-  return parseMerklRewardsResponse(payload, account);
 }
 
 export function parseMerklRewardsResponse(
@@ -96,7 +109,7 @@ function parseReward(value: unknown, account: AddressValue, index: number): Merk
   const token = record(reward.token, `${path}.token`);
   parseChainId(token.chainId, `${path}.token.chainId`);
   const tokenAddress = parseAddress(token.address, `${path}.token.address`);
-  const cumulativeAmount = parseUnsignedInteger(reward.amount, `${path}.amount`);
+  const cumulativeAmount = parseCumulativeAmount(reward.amount, `${path}.amount`);
   const apiClaimedAmount = parseUnsignedInteger(reward.claimed, `${path}.claimed`);
   const pendingAmount = parseUnsignedInteger(reward.pending, `${path}.pending`);
   if (apiClaimedAmount > cumulativeAmount) {
@@ -105,12 +118,12 @@ function parseReward(value: unknown, account: AddressValue, index: number): Merk
 
   const root = parseBytes32(reward.root, `${path}.root`);
   if (!Array.isArray(reward.proofs)) throw schemaError(`${path}.proofs must be an array`);
+  if (reward.proofs.length > MAX_PROOF_LENGTH) {
+    throw schemaError(`${path}.proofs count exceeds ${MAX_PROOF_LENGTH}`);
+  }
   const proofs = reward.proofs.map((proof, proofIndex) =>
     parseBytes32(proof, `${path}.proofs[${proofIndex}]`),
   );
-  if (cumulativeAmount > 0n && proofs.length === 0) {
-    throw schemaError(`${path}.proofs must not be empty for a positive cumulative amount`);
-  }
 
   return {
     root,
@@ -150,6 +163,8 @@ function parseBreakdowns(
     ) {
       throw schemaError(`${path}.opportunityId must be an unsigned integer string`);
     }
+    // Breakdown values are API metadata and never enter Distributor.claim;
+    // keep their honest uint256 range distinct from reward.amount's uint208 bound.
     const amount = parseUnsignedInteger(breakdown.amount, `${path}.amount`);
     const claimed = parseUnsignedInteger(breakdown.claimed, `${path}.claimed`);
     const pending = parseUnsignedInteger(breakdown.pending, `${path}.pending`);
@@ -229,6 +244,14 @@ function parseUnsignedInteger(value: unknown, path: string): bigint {
   return parsed;
 }
 
+function parseCumulativeAmount(value: unknown, path: string): bigint {
+  const parsed = parseUnsignedInteger(value, path);
+  if (parsed > UINT208_MAX) {
+    throw schemaError(`${path} exceeds the Distributor uint208 cumulative amount limit`);
+  }
+  return parsed;
+}
+
 function record(value: unknown, path: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw schemaError(`${path} must be an object`);
@@ -246,4 +269,8 @@ function schemaError(detail: string): Error {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function requestTimeoutError(): Error {
+  return new Error(`Merkl rewards request timed out after ${REQUEST_TIMEOUT_MS}ms`);
 }

--- a/packages/protocols/merkl/src/api.ts
+++ b/packages/protocols/merkl/src/api.ts
@@ -1,0 +1,249 @@
+import type { AddressValue, Hex } from "@themoss/core";
+import { getAddress, isAddress } from "viem";
+import type { MerklRewardBreakdown, MerklRewardCandidate } from "./types.js";
+
+export const MERKL_API_URL = "https://api.merkl.xyz";
+export const MERKL_CHAIN_ID = 143;
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 4_000_000;
+const MAX_REWARD_RECORDS = 128;
+const MAX_BREAKDOWNS_PER_REWARD = 512;
+const UINT256_MAX = 2n ** 256n - 1n;
+
+export async function fetchMerklRewardCandidates(
+  account: AddressValue,
+  options: { reload: boolean },
+): Promise<readonly MerklRewardCandidate[]> {
+  const query = new URLSearchParams({ chainId: String(MERKL_CHAIN_ID) });
+  if (options.reload) query.set("reloadChainId", String(MERKL_CHAIN_ID));
+  const url = `${MERKL_API_URL}/v4/users/${account}/rewards?${query}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`Merkl rewards request timed out after ${REQUEST_TIMEOUT_MS}ms`);
+    }
+    throw new Error(`Merkl rewards request failed: ${errorMessage(error)}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Merkl rewards request failed with HTTP ${response.status}; retry after checking api.merkl.xyz status`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(await readBoundedResponse(response));
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Merkl rewards response")) throw error;
+    throw new Error(`Merkl rewards response is not valid JSON: ${errorMessage(error)}`);
+  }
+
+  return parseMerklRewardsResponse(payload, account);
+}
+
+export function parseMerklRewardsResponse(
+  payload: unknown,
+  account: AddressValue,
+): readonly MerklRewardCandidate[] {
+  if (!Array.isArray(payload)) throw schemaError("top level must be an array");
+  if (payload.length > 1) throw schemaError("expected at most one chain result for chainId=143");
+  if (payload.length === 0) return [];
+
+  const chainResult = record(payload[0], "chain result");
+  const chain = record(chainResult.chain, "chain result.chain");
+  parseChainId(chain.id, "chain result.chain.id");
+
+  if (!Array.isArray(chainResult.rewards)) {
+    throw schemaError("chain result.rewards must be an array");
+  }
+  if (chainResult.rewards.length > MAX_REWARD_RECORDS) {
+    throw schemaError(`reward count exceeds ${MAX_REWARD_RECORDS}`);
+  }
+
+  const candidates = chainResult.rewards.map((value, index) => parseReward(value, account, index));
+  const tokens = new Set<string>();
+  let root: string | undefined;
+  for (const candidate of candidates) {
+    const token = candidate.token.toLowerCase();
+    if (tokens.has(token)) throw schemaError(`duplicate token record ${candidate.token}`);
+    tokens.add(token);
+    if (root !== undefined && root !== candidate.root.toLowerCase()) {
+      throw schemaError("reward records disagree on the Merkle root");
+    }
+    root = candidate.root.toLowerCase();
+  }
+  return candidates;
+}
+
+function parseReward(value: unknown, account: AddressValue, index: number): MerklRewardCandidate {
+  const path = `chain result.rewards[${index}]`;
+  const reward = record(value, path);
+  parseChainId(reward.distributionChainId, `${path}.distributionChainId`);
+  const recipient = parseAddress(reward.recipient, `${path}.recipient`);
+  if (!sameAddress(recipient, account)) {
+    throw schemaError(`${path}.recipient does not match requested account ${account}`);
+  }
+
+  const token = record(reward.token, `${path}.token`);
+  parseChainId(token.chainId, `${path}.token.chainId`);
+  const tokenAddress = parseAddress(token.address, `${path}.token.address`);
+  const cumulativeAmount = parseUnsignedInteger(reward.amount, `${path}.amount`);
+  const apiClaimedAmount = parseUnsignedInteger(reward.claimed, `${path}.claimed`);
+  const pendingAmount = parseUnsignedInteger(reward.pending, `${path}.pending`);
+  if (apiClaimedAmount > cumulativeAmount) {
+    throw schemaError(`${path}.claimed exceeds cumulative amount`);
+  }
+
+  const root = parseBytes32(reward.root, `${path}.root`);
+  if (!Array.isArray(reward.proofs)) throw schemaError(`${path}.proofs must be an array`);
+  const proofs = reward.proofs.map((proof, proofIndex) =>
+    parseBytes32(proof, `${path}.proofs[${proofIndex}]`),
+  );
+  if (cumulativeAmount > 0n && proofs.length === 0) {
+    throw schemaError(`${path}.proofs must not be empty for a positive cumulative amount`);
+  }
+
+  return {
+    root,
+    recipient,
+    token: tokenAddress,
+    cumulativeAmount,
+    apiClaimedAmount,
+    pendingAmount,
+    proofs,
+    breakdowns: parseBreakdowns(reward.breakdowns, path, root),
+  };
+}
+
+function parseBreakdowns(
+  value: unknown,
+  rewardPath: string,
+  expectedRoot: Hex,
+): readonly MerklRewardBreakdown[] {
+  if (!Array.isArray(value)) throw schemaError(`${rewardPath}.breakdowns must be an array`);
+  if (value.length > MAX_BREAKDOWNS_PER_REWARD) {
+    throw schemaError(`${rewardPath}.breakdowns count exceeds ${MAX_BREAKDOWNS_PER_REWARD}`);
+  }
+  return value.map((entry, index) => {
+    const path = `${rewardPath}.breakdowns[${index}]`;
+    const breakdown = record(entry, path);
+    parseChainId(breakdown.distributionChainId, `${path}.distributionChainId`);
+    const root = parseBytes32(breakdown.root, `${path}.root`);
+    if (root.toLowerCase() !== expectedRoot.toLowerCase()) {
+      throw schemaError(`${path}.root does not match its reward root`);
+    }
+    if (typeof breakdown.reason !== "string" || breakdown.reason.length === 0) {
+      throw schemaError(`${path}.reason must be a non-empty string`);
+    }
+    if (
+      typeof breakdown.opportunityId !== "string" ||
+      !/^(?:0|[1-9]\d*)$/.test(breakdown.opportunityId)
+    ) {
+      throw schemaError(`${path}.opportunityId must be an unsigned integer string`);
+    }
+    const amount = parseUnsignedInteger(breakdown.amount, `${path}.amount`);
+    const claimed = parseUnsignedInteger(breakdown.claimed, `${path}.claimed`);
+    const pending = parseUnsignedInteger(breakdown.pending, `${path}.pending`);
+    if (claimed > amount) throw schemaError(`${path}.claimed exceeds amount`);
+    return {
+      reason: breakdown.reason,
+      amount: amount.toString(),
+      claimed: claimed.toString(),
+      pending: pending.toString(),
+      campaignId: parseBytes32(breakdown.campaignId, `${path}.campaignId`),
+      opportunityId: breakdown.opportunityId,
+    };
+  });
+}
+
+async function readBoundedResponse(response: Response): Promise<string> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const length = Number(contentLength);
+    if (Number.isFinite(length) && length > MAX_RESPONSE_BYTES) {
+      throw new Error(`Merkl rewards response exceeds ${MAX_RESPONSE_BYTES} bytes`);
+    }
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_RESPONSE_BYTES) {
+      throw new Error(`Merkl rewards response exceeds ${MAX_RESPONSE_BYTES} bytes`);
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > MAX_RESPONSE_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error(`Merkl rewards response exceeds ${MAX_RESPONSE_BYTES} bytes`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseChainId(value: unknown, path: string): void {
+  if (value !== MERKL_CHAIN_ID) throw schemaError(`${path} must equal ${MERKL_CHAIN_ID}`);
+}
+
+function parseAddress(value: unknown, path: string): AddressValue {
+  if (typeof value !== "string" || !isAddress(value, { strict: false })) {
+    throw schemaError(`${path} must be a 20-byte EVM address`);
+  }
+  return getAddress(value);
+}
+
+function parseBytes32(value: unknown, path: string): Hex {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    throw schemaError(`${path} must be a 32-byte hex value`);
+  }
+  return value as Hex;
+}
+
+function parseUnsignedInteger(value: unknown, path: string): bigint {
+  if (typeof value !== "string" || !/^(?:0|[1-9]\d*)$/.test(value)) {
+    throw schemaError(`${path} must be an unsigned integer string`);
+  }
+  const parsed = BigInt(value);
+  if (parsed > UINT256_MAX) throw schemaError(`${path} exceeds uint256`);
+  return parsed;
+}
+
+function record(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw schemaError(`${path} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function sameAddress(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function schemaError(detail: string): Error {
+  return new Error(`Merkl rewards API schema error: ${detail}`);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/protocols/merkl/src/index.ts
+++ b/packages/protocols/merkl/src/index.ts
@@ -1,0 +1,16 @@
+export { distributorAbi } from "./abis/distributor.js";
+export {
+  MAX_MERKL_CLAIM_TOKENS,
+  MERKL_DISTRIBUTOR_ADDRESS,
+  MERKL_DISTRIBUTOR_IMPLEMENTATION,
+  MerklProtocol,
+  merklLeaf,
+  verifyMerklProof,
+} from "./adapter.js";
+export { MERKL_API_URL, MERKL_CHAIN_ID } from "./api.js";
+export type {
+  MerklClaimOutcome,
+  MerklReward,
+  MerklRewardBreakdown,
+  MerklRewardsResult,
+} from "./types.js";

--- a/packages/protocols/merkl/src/types.ts
+++ b/packages/protocols/merkl/src/types.ts
@@ -1,0 +1,50 @@
+import type { AddressValue, Hex } from "@themoss/core";
+
+export type MerklRewardBreakdown = {
+  reason: string;
+  amount: string;
+  claimed: string;
+  pending: string;
+  campaignId: Hex;
+  opportunityId: string;
+};
+
+export type MerklReward = {
+  token: AddressValue;
+  cumulativeAmount: string;
+  apiClaimedAmount: string;
+  onchainClaimedAmount: string;
+  claimableAmount: string;
+  pendingAmount: string;
+  proofLength: number;
+  effectiveRecipient: AddressValue;
+  claimableNow: boolean;
+  unavailableReason?: string;
+  breakdowns: readonly MerklRewardBreakdown[];
+};
+
+export type MerklRewardsResult = {
+  account: AddressValue;
+  merkleRoot: Hex;
+  rewards: readonly MerklReward[];
+};
+
+export type MerklClaimOutcome = {
+  operation: "claim";
+  account: AddressValue;
+  rewards: readonly {
+    token: AddressValue;
+    amount: string;
+  }[];
+};
+
+export type MerklRewardCandidate = {
+  root: Hex;
+  recipient: AddressValue;
+  token: AddressValue;
+  cumulativeAmount: bigint;
+  apiClaimedAmount: bigint;
+  pendingAmount: bigint;
+  proofs: readonly Hex[];
+  breakdowns: readonly MerklRewardBreakdown[];
+};

--- a/packages/protocols/merkl/test-online/abi-explorer.test.ts
+++ b/packages/protocols/merkl/test-online/abi-explorer.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Keyed explorer cross-check for the full Merkl Distributor implementation
+ * ABI (ADR 0007). The normal package suite independently checks the proxy,
+ * implementation, bytecode hashes, required selectors/topics, and live reads.
+ */
+import { readFileSync } from "node:fs";
+import {
+  compareDeployedAbi,
+  ERC1967_IMPLEMENTATION_SLOT,
+  erc1967ImplementationAddress,
+  fetchAbi,
+} from "@themoss/abi-tools";
+import { createRuntime } from "@themoss/core";
+import { type Address, getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { distributorAbi } from "../src/abis/distributor.js";
+import { MERKL_DISTRIBUTOR_ADDRESS } from "../src/adapter.js";
+
+interface AbiManifest {
+  distributor: {
+    proxy: Address;
+    implementation: Address;
+    allowedExplorerOnly: string[];
+  };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
+) as AbiManifest;
+const key = process.env.MONADSCAN_API_KEY;
+
+describe("Merkl ABI explorer cross-check", () => {
+  it("requires MONADSCAN_API_KEY", () => {
+    expect(key, "MONADSCAN_API_KEY must be set for pnpm test:abi:online").toBeTruthy();
+  });
+
+  it("pins the proxy and active implementation", { timeout: 60_000 }, async () => {
+    const runtime = await createRuntime();
+    expect(getAddress(manifest.distributor.proxy)).toBe(getAddress(MERKL_DISTRIBUTOR_ADDRESS));
+    const slot = await runtime.client.getStorageAt({
+      address: manifest.distributor.proxy,
+      slot: ERC1967_IMPLEMENTATION_SLOT,
+    });
+    expect(getAddress(erc1967ImplementationAddress(slot))).toBe(
+      getAddress(manifest.distributor.implementation),
+    );
+  });
+
+  it("matches the explorer-verified implementation ABI", { timeout: 120_000 }, async () => {
+    const explorerAbi = await fetchAbi(manifest.distributor.implementation, key ?? "");
+    expect(
+      compareDeployedAbi(distributorAbi, explorerAbi, {
+        allowedActualOnly: manifest.distributor.allowedExplorerOnly,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/protocols/merkl/test-online/deployment.test.ts
+++ b/packages/protocols/merkl/test-online/deployment.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { ERC1967_IMPLEMENTATION_SLOT, erc1967ImplementationAddress } from "@themoss/abi-tools";
+import { createRuntime } from "@themoss/core";
+import {
+  type Address,
+  getAddress,
+  type Hex,
+  keccak256,
+  toEventSelector,
+  toFunctionSelector,
+} from "viem";
+import { describe, expect, it } from "vitest";
+import { distributorAbi } from "../src/abis/distributor.js";
+import { MERKL_DISTRIBUTOR_ADDRESS, MERKL_DISTRIBUTOR_IMPLEMENTATION } from "../src/adapter.js";
+
+interface AbiManifest {
+  distributor: {
+    proxy: Address;
+    implementation: Address;
+    proxyRuntimeCodeHash: Hex;
+    implementationRuntimeCodeHash: Hex;
+  };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
+) as AbiManifest;
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Merkl Distributor deployment", () => {
+  it("pins the fixed proxy, implementation relationship, and runtime bytecode", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    expect(await runtime.client.getChainId()).toBe(143);
+    expect(getAddress(manifest.distributor.proxy)).toBe(getAddress(MERKL_DISTRIBUTOR_ADDRESS));
+    expect(getAddress(manifest.distributor.implementation)).toBe(
+      getAddress(MERKL_DISTRIBUTOR_IMPLEMENTATION),
+    );
+
+    const [slot, proxyCode, implementationCode] = await Promise.all([
+      runtime.client.getStorageAt({
+        address: manifest.distributor.proxy,
+        slot: ERC1967_IMPLEMENTATION_SLOT,
+      }),
+      runtime.client.getCode({ address: manifest.distributor.proxy }),
+      runtime.client.getCode({ address: manifest.distributor.implementation }),
+    ]);
+    expect(getAddress(erc1967ImplementationAddress(slot))).toBe(
+      getAddress(manifest.distributor.implementation),
+    );
+    expect(proxyCode).toBeDefined();
+    expect(implementationCode).toBeDefined();
+    expect(keccak256(proxyCode as Hex)).toBe(manifest.distributor.proxyRuntimeCodeHash);
+    expect(keccak256(implementationCode as Hex)).toBe(
+      manifest.distributor.implementationRuntimeCodeHash,
+    );
+  });
+
+  it("keeps the required read, claim, and event surface deployed", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    const code = await runtime.client.getCode({ address: manifest.distributor.implementation });
+    expect(code).toBeDefined();
+
+    const signatures = [
+      "claim(address[],address[],uint256[],bytes32[][])",
+      "getMerkleRoot()",
+      "claimed(address,address)",
+      "claimRecipient(address,address)",
+    ] as const;
+    for (const signature of signatures) {
+      expect(code?.toLowerCase()).toContain(toFunctionSelector(signature).slice(2).toLowerCase());
+    }
+    expect(code?.toLowerCase()).toContain(
+      toEventSelector("Claimed(address,address,uint256)").slice(2).toLowerCase(),
+    );
+
+    const root = await runtime.client.readContract({
+      address: manifest.distributor.proxy,
+      abi: distributorAbi,
+      functionName: "getMerkleRoot",
+    });
+    expect(root).toMatch(/^0x[0-9a-fA-F]{64}$/);
+    expect(BigInt(root)).toBeGreaterThan(0n);
+  });
+});

--- a/packages/protocols/merkl/test-online/live-mainnet.test.ts
+++ b/packages/protocols/merkl/test-online/live-mainnet.test.ts
@@ -1,0 +1,70 @@
+import { createRuntime, Registry } from "@themoss/core";
+import { createTraceSimulator } from "@themoss/simulator";
+import { getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { type MerklClaimOutcome, MerklProtocol, type MerklRewardsResult } from "../src/index.js";
+
+// Public, high-activity Merkl beneficiary. Override both values together when
+// its reward is claimed or its active proof changes between CI runs.
+const ACCOUNT = getAddress(
+  process.env.MERKL_LIVE_ACCOUNT ?? "0x461549c73FFfB676860A0E49F5DaABEcf4E8D2d7",
+);
+const TOKEN = getAddress(
+  process.env.MERKL_LIVE_TOKEN ?? "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A",
+);
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("Merkl live Monad mainnet self-claim", () => {
+  it("builds and simulates a positive claim with exhaustive ordered evidence", {
+    timeout: 240_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    expect(await runtime.client.getChainId()).toBe(143);
+    const registry = new Registry(runtime).use(MerklProtocol);
+
+    const query = await registry.action("merkl", "rewards", ACCOUNT, { account: ACCOUNT });
+    if (query.kind !== "query") throw new Error("expected merkl.rewards Query result");
+    const rewards = query.data as MerklRewardsResult;
+    const selected = rewards.rewards.find(
+      (reward) => reward.token.toLowerCase() === TOKEN.toLowerCase(),
+    );
+    if (!selected?.claimableNow || BigInt(selected.claimableAmount) <= 0n) {
+      throw new Error(
+        `Merkl live fixture ${ACCOUNT}/${TOKEN} is no longer positively claimable; ` +
+          "replace MERKL_LIVE_ACCOUNT and MERKL_LIVE_TOKEN with a current public reward",
+      );
+    }
+
+    const capability = await registry.action("merkl", "claim", ACCOUNT, { tokens: [TOKEN] });
+    if (capability.kind !== "capability") throw new Error("expected merkl.claim Capability");
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => registry.parseReceipt(node, changes),
+    }).simulate(capability);
+
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.results).toHaveLength(1);
+    const result = outcome.results[0];
+    expect(result?.warnings).toEqual([]);
+    expect(result?.changes).toHaveLength(2);
+    expect(result?.changes?.map((change) => change.kind)).toEqual(["event", "event"]);
+    expect(
+      result?.changes?.map((change) =>
+        change.kind === "event" ? change.address.toLowerCase() : undefined,
+      ),
+    ).toEqual(["0x3ef3d8ba38ebe18db133cec108f4d14ce00dd9ae", TOKEN.toLowerCase()]);
+    const receipt = result?.receipt;
+    expect(receipt?.changes).toHaveLength(result?.changes?.length ?? -1);
+    const receiptOutcome = receipt?.outcome as MerklClaimOutcome | undefined;
+    expect(receiptOutcome).toMatchObject({ operation: "claim", account: ACCOUNT });
+    expect(receiptOutcome?.rewards).toHaveLength(1);
+    expect(receiptOutcome?.rewards[0]?.token).toBe(TOKEN);
+    expect(BigInt(receiptOutcome?.rewards[0]?.amount ?? "0")).toBeGreaterThan(0n);
+
+    console.log({
+      account: ACCOUNT,
+      token: TOKEN,
+      claimableAmount: selected.claimableAmount,
+      changes: result?.changes,
+      receipt: receiptOutcome,
+    });
+  });
+});

--- a/packages/protocols/merkl/test/abis.test.ts
+++ b/packages/protocols/merkl/test/abis.test.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { type RenderAbiModuleOptions, renderAbiModule } from "@themoss/abi-tools";
+import { toEventSelector, toFunctionSelector } from "viem";
+import { describe, expect, it } from "vitest";
+import { DISTRIBUTOR_ABI_SOURCE } from "../scripts/abis.js";
+import { distributorAbi } from "../src/abis/distributor.js";
+import { MERKL_DISTRIBUTOR_ADDRESS, MERKL_DISTRIBUTOR_IMPLEMENTATION } from "../src/adapter.js";
+
+interface Manifest {
+  distributor: { proxy: string; implementation: string };
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
+) as Manifest;
+
+describe("Merkl explorer ABI derivation", () => {
+  it("is byte-exact renderer output from the recorded explorer source", () => {
+    const committed = readFileSync(new URL("../src/abis/distributor.ts", import.meta.url), "utf8");
+    const retrieved = /^\/\/ {3}Retrieved: (\d{4}-\d{2}-\d{2}) \(UTC\)$/m.exec(committed)?.[1];
+    const literal = /^export const \w+Abi = (\[[\s\S]*\]) as const;$/m.exec(committed)?.[1];
+    expect(retrieved).toBeDefined();
+    expect(literal).toBeDefined();
+    const abi = JSON.parse(literal as string) as RenderAbiModuleOptions["abi"];
+    expect(createHash("sha256").update(JSON.stringify(abi)).digest("hex")).toBe(
+      DISTRIBUTOR_ABI_SOURCE.abiSha256,
+    );
+    expect(committed).toBe(
+      renderAbiModule({
+        exportName: DISTRIBUTOR_ABI_SOURCE.exportName,
+        address: DISTRIBUTOR_ABI_SOURCE.address,
+        abi,
+        retrievedAt: new Date(`${retrieved}T00:00:00Z`),
+      }),
+    );
+  });
+
+  it("pins the protocol proxy and explorer-verified implementation", () => {
+    expect(manifest.distributor.proxy).toBe(MERKL_DISTRIBUTOR_ADDRESS);
+    expect(manifest.distributor.implementation).toBe(MERKL_DISTRIBUTOR_IMPLEMENTATION);
+    expect(DISTRIBUTOR_ABI_SOURCE.address).toBe(MERKL_DISTRIBUTOR_IMPLEMENTATION);
+  });
+
+  it("contains the complete required deployed claim surface", () => {
+    for (const functionName of ["claim", "getMerkleRoot", "claimed", "claimRecipient"]) {
+      const item = distributorAbi.find(
+        (entry) => entry.type === "function" && "name" in entry && entry.name === functionName,
+      );
+      expect(item, `missing ${functionName}`).toBeDefined();
+      expect(
+        toFunctionSelector(item as Extract<(typeof distributorAbi)[number], { type: "function" }>),
+      ).toMatch(/^0x[0-9a-f]{8}$/);
+    }
+    const claimed = distributorAbi.find(
+      (entry) => entry.type === "event" && "name" in entry && entry.name === "Claimed",
+    );
+    expect(
+      toEventSelector(claimed as Extract<(typeof distributorAbi)[number], { type: "event" }>),
+    ).toBe("0xf7a40077ff7a04c7e61f6f26fb13774259ddf1b6bce9ecf26a8276cdd3992683");
+    expect(distributorAbi).toHaveLength(73);
+  });
+});

--- a/packages/protocols/merkl/test/adapter.test.ts
+++ b/packages/protocols/merkl/test/adapter.test.ts
@@ -17,7 +17,7 @@ import {
 } from "viem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { distributorAbi } from "../src/abis/distributor.js";
-import { parseMerklRewardsResponse } from "../src/api.js";
+import { fetchMerklRewardCandidates, parseMerklRewardsResponse } from "../src/api.js";
 import {
   MAX_MERKL_CLAIM_TOKENS,
   MERKL_DISTRIBUTOR_ADDRESS,
@@ -36,8 +36,12 @@ const LEAF_A = merklLeaf(ACCOUNT, TOKEN_A, AMOUNT_A);
 const LEAF_B = merklLeaf(ACCOUNT, TOKEN_B, AMOUNT_B);
 const ROOT = hashPair(LEAF_A, LEAF_B);
 const WRONG_ROOT = `0x${"99".repeat(32)}` as Hex;
+const UINT208_MAX = 2n ** 208n - 1n;
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 function hashPair(a: Hex, b: Hex): Hex {
   return BigInt(a) < BigInt(b) ? keccak256(concatHex([a, b])) : keccak256(concatHex([b, a]));
@@ -76,6 +80,14 @@ function reward(
 
 function payload(rewards = [reward(TOKEN_A, AMOUNT_A.toString(), [LEAF_B])]) {
   return [{ chain: { id: 143, name: "Monad" }, rewards }];
+}
+
+function rewardAtRoot(token: string, amount: string, proof: readonly Hex[], root: Hex) {
+  const candidate = reward(token, amount, proof, { root });
+  return {
+    ...candidate,
+    breakdowns: candidate.breakdowns.map((breakdown) => ({ ...breakdown, root })),
+  };
 }
 
 interface OfflineOptions {
@@ -166,10 +178,10 @@ describe("Merkl API validation", () => {
     ).toThrow(/does not match/);
   });
 
-  it("rejects duplicate tokens and empty proofs for positive rewards", () => {
-    expect(() => parseMerklRewardsResponse(payload([reward(TOKEN_A, "100", [])]), ACCOUNT)).toThrow(
-      /must not be empty/,
-    );
+  it("accepts empty proofs as candidates and rejects duplicate tokens", () => {
+    expect(
+      parseMerklRewardsResponse(payload([reward(TOKEN_A, "100", [])]), ACCOUNT)[0]?.proofs,
+    ).toEqual([]);
     expect(() =>
       parseMerklRewardsResponse(
         payload([reward(TOKEN_A, "100", [LEAF_B]), reward(TOKEN_A.toLowerCase(), "100", [LEAF_B])]),
@@ -191,6 +203,66 @@ describe("Merkl API validation", () => {
         ACCOUNT,
       ),
     ).toThrow(/does not match its reward root/);
+  });
+
+  it("bounds proof length before parsing proof nodes", () => {
+    expect(() =>
+      parseMerklRewardsResponse(
+        payload([
+          reward(
+            TOKEN_A,
+            "100",
+            Array.from({ length: 257 }, () => LEAF_B),
+          ),
+        ]),
+        ACCOUNT,
+      ),
+    ).toThrow(/proofs count exceeds 256/);
+  });
+
+  it("accepts the uint208 cumulative maximum and rejects the next value", () => {
+    expect(
+      parseMerklRewardsResponse(
+        payload([reward(TOKEN_A, UINT208_MAX.toString(), [LEAF_B])]),
+        ACCOUNT,
+      )[0]?.cumulativeAmount,
+    ).toBe(UINT208_MAX);
+    expect(() =>
+      parseMerklRewardsResponse(
+        payload([reward(TOKEN_A, (UINT208_MAX + 1n).toString(), [LEAF_B])]),
+        ACCOUNT,
+      ),
+    ).toThrow(/uint208 cumulative amount limit/);
+  });
+});
+
+describe("Merkl API request lifecycle", () => {
+  it("times out while a response body stalls after headers", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: string | URL | Request, init?: RequestInit) => {
+        const signal = init?.signal;
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            signal?.addEventListener(
+              "abort",
+              () => controller.error(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          },
+        });
+        return Promise.resolve(new Response(body, { status: 200 }));
+      }),
+    );
+
+    const result = fetchMerklRewardCandidates(ACCOUNT, { reload: false }).catch(
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    await expect(result).resolves.toMatchObject({
+      message: "Merkl rewards request timed out after 10000ms",
+    });
   });
 });
 
@@ -245,6 +317,63 @@ describe("merkl.rewards", () => {
         ],
       },
     });
+  });
+
+  it("rejects a non-empty API proof that does not verify against the active root", async () => {
+    const { registry } = offline({
+      apiPayload: payload([reward(TOKEN_A, AMOUNT_A.toString(), [WRONG_ROOT])]),
+    });
+    const result = await registry.action("merkl", "rewards", ACCOUNT, { account: ACCOUNT });
+    expect(result).toMatchObject({
+      kind: "query",
+      data: {
+        rewards: [
+          {
+            claimableAmount: AMOUNT_A.toString(),
+            proofLength: 1,
+            claimableNow: false,
+            unavailableReason: "API proof does not match the active Merkle root.",
+          },
+        ],
+      },
+    });
+  });
+
+  it("accepts an empty proof when the leaf is the active single-leaf root", async () => {
+    const apiPayload = payload([rewardAtRoot(TOKEN_A, AMOUNT_A.toString(), [], LEAF_A)]);
+    const { registry } = offline({ apiPayload, root: LEAF_A });
+    const result = await registry.action("merkl", "rewards", ACCOUNT, { account: ACCOUNT });
+    expect(result).toMatchObject({
+      kind: "query",
+      data: { rewards: [{ proofLength: 0, claimableNow: true }] },
+    });
+
+    const { capability } = await claimCapability({ apiPayload, root: LEAF_A });
+    const [transaction] = flattenCapabilityTree(capability);
+    const decoded = decodeFunctionData({
+      abi: distributorAbi,
+      data: transaction?.transaction.data as Hex,
+    });
+    expect(decoded.args?.[3]).toEqual([[]]);
+  });
+
+  it("rejects an empty proof when the leaf differs from the active root", async () => {
+    const apiPayload = payload([reward(TOKEN_A, AMOUNT_A.toString(), [])]);
+    const { registry } = offline({ apiPayload });
+    const result = await registry.action("merkl", "rewards", ACCOUNT, { account: ACCOUNT });
+    expect(result).toMatchObject({
+      kind: "query",
+      data: {
+        rewards: [
+          {
+            proofLength: 0,
+            claimableNow: false,
+            unavailableReason: "API proof does not match the active Merkle root.",
+          },
+        ],
+      },
+    });
+    await expect(claimCapability({ apiPayload })).rejects.toThrow(/proof does not match/);
   });
 });
 
@@ -345,6 +474,7 @@ describe("merkl.claim construction", () => {
       { proof: [LEAF_B] },
       { recipient: OTHER },
       { distributor: OTHER },
+      { calldata: "0x" },
     ]) {
       await expect(
         registry.action("merkl", "claim", ACCOUNT, { tokens: [TOKEN_A], ...extra }),

--- a/packages/protocols/merkl/test/adapter.test.ts
+++ b/packages/protocols/merkl/test/adapter.test.ts
@@ -524,6 +524,14 @@ function leafChange(entry: ReceiptResult["changes"][number] | undefined): Change
   return entry.kind === "change" ? entry.change : leafChange(entry.changes[0]);
 }
 
+// Mirrors the MCP layer's receiptTexts projection: the ordered leaf text
+// strings exposed to Agents, including nested dependency Receipts.
+function flattenReceiptTexts(receipt: ReceiptResult): string[] {
+  return receipt.changes.flatMap((entry) =>
+    entry.kind === "change" ? [entry.text] : flattenReceiptTexts(entry),
+  );
+}
+
 describe("Merkl claim Receipt evidence", () => {
   it("parses a valid single-token claim with original identity and Package label", async () => {
     const { registry, capability } = await claimCapability();
@@ -541,6 +549,11 @@ describe("Merkl claim Receipt evidence", () => {
     expect(receipt.changes[0]).toMatchObject({
       text: expect.stringContaining("Package(Merkl:Distributor)"),
     });
+
+    const claimText = `Merkl Claim: 60 of ${TOKEN_A} paid by Package(Merkl:Distributor) to ${ACCOUNT}`;
+    const transferText = `ERC20 Transfer: 60 ${TOKEN_A} from Package(Merkl:Distributor) to ${ACCOUNT}`;
+    expect(receipt.text).toBe(`Merkl Claim: 1 reward token(s) paid to ${ACCOUNT}`);
+    expect(flattenReceiptTexts(receipt)).toEqual([claimText, transferText]);
   });
 
   it("preserves observed multi-token execution order", async () => {

--- a/packages/protocols/merkl/test/adapter.test.ts
+++ b/packages/protocols/merkl/test/adapter.test.ts
@@ -1,0 +1,568 @@
+import {
+  type Change,
+  flattenCapabilityTree,
+  type Hex,
+  type MossRuntime,
+  type ReceiptResult,
+  Registry,
+} from "@themoss/core";
+import { ERC20Abi } from "@themoss/erc";
+import {
+  concatHex,
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  getAddress,
+  keccak256,
+} from "viem";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { distributorAbi } from "../src/abis/distributor.js";
+import { parseMerklRewardsResponse } from "../src/api.js";
+import {
+  MAX_MERKL_CLAIM_TOKENS,
+  MERKL_DISTRIBUTOR_ADDRESS,
+  MerklProtocol,
+  merklLeaf,
+} from "../src/index.js";
+
+const ACCOUNT = getAddress("0x461549c73FFfB676860A0E49F5DaABEcf4E8D2d7");
+const OTHER = getAddress("0xdddddddddddddddddddddddddddddddddddddddd");
+const TOKEN_A = getAddress("0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A");
+const TOKEN_B = getAddress("0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a");
+const ZERO = getAddress("0x0000000000000000000000000000000000000000");
+const AMOUNT_A = 100n;
+const AMOUNT_B = 200n;
+const LEAF_A = merklLeaf(ACCOUNT, TOKEN_A, AMOUNT_A);
+const LEAF_B = merklLeaf(ACCOUNT, TOKEN_B, AMOUNT_B);
+const ROOT = hashPair(LEAF_A, LEAF_B);
+const WRONG_ROOT = `0x${"99".repeat(32)}` as Hex;
+
+afterEach(() => vi.unstubAllGlobals());
+
+function hashPair(a: Hex, b: Hex): Hex {
+  return BigInt(a) < BigInt(b) ? keccak256(concatHex([a, b])) : keccak256(concatHex([b, a]));
+}
+
+function reward(
+  token: string,
+  amount: string,
+  proof: readonly Hex[],
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    root: ROOT,
+    distributionChainId: 143,
+    recipient: ACCOUNT,
+    amount,
+    claimed: "0",
+    pending: "3",
+    proofs: proof,
+    token: { chainId: 143, address: token, decimals: 18, symbol: "TEST" },
+    breakdowns: [
+      {
+        root: ROOT,
+        distributionChainId: 143,
+        reason: "fixture",
+        amount,
+        claimed: "0",
+        pending: "3",
+        campaignId: `0x${"11".repeat(32)}`,
+        opportunityId: "1",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function payload(rewards = [reward(TOKEN_A, AMOUNT_A.toString(), [LEAF_B])]) {
+  return [{ chain: { id: 143, name: "Monad" }, rewards }];
+}
+
+interface OfflineOptions {
+  apiPayload?: unknown;
+  root?: Hex;
+  claimed?: Readonly<Record<string, bigint>>;
+  tokenRecipients?: Readonly<Record<string, string>>;
+  defaultRecipient?: string;
+  fetchError?: Error;
+}
+
+function offline(options: OfflineOptions = {}) {
+  const root = options.root ?? ROOT;
+  const fetchMock = options.fetchError
+    ? vi.fn().mockRejectedValue(options.fetchError)
+    : vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify(options.apiPayload ?? payload()), { status: 200 }),
+        );
+  vi.stubGlobal("fetch", fetchMock);
+  const readContract = vi.fn(
+    async (request: { functionName: string; args?: readonly unknown[] }) => {
+      switch (request.functionName) {
+        case "getMerkleRoot":
+          return root;
+        case "claimed": {
+          const token = String(request.args?.[1]).toLowerCase();
+          return [options.claimed?.[token] ?? 0n, 0, root] as const;
+        }
+        case "claimRecipient": {
+          const token = String(request.args?.[1]).toLowerCase();
+          if (token === ZERO.toLowerCase()) return getAddress(options.defaultRecipient ?? ZERO);
+          return getAddress(options.tokenRecipients?.[token] ?? ZERO);
+        }
+        default:
+          throw new Error(`unexpected read ${request.functionName}`);
+      }
+    },
+  );
+  const runtime = {
+    rpcUrl: "http://offline",
+    client: { readContract } as unknown as MossRuntime["client"],
+  };
+  return { registry: new Registry(runtime).use(MerklProtocol), readContract, fetchMock };
+}
+
+async function claimCapability(options: OfflineOptions = {}, tokens = [TOKEN_A]) {
+  const { registry, ...rest } = offline(options);
+  const capability = await registry.action("merkl", "claim", ACCOUNT, { tokens });
+  if (capability.kind !== "capability") throw new Error("expected Capability");
+  return { registry, capability, ...rest };
+}
+
+describe("Merkl API validation", () => {
+  it("parses a real-shaped Monad response and campaign breakdown", () => {
+    const [candidate] = parseMerklRewardsResponse(payload(), ACCOUNT);
+    expect(candidate).toMatchObject({
+      token: TOKEN_A,
+      cumulativeAmount: AMOUNT_A,
+      pendingAmount: 3n,
+    });
+    expect(candidate?.breakdowns[0]).toMatchObject({ reason: "fixture", amount: "100" });
+  });
+
+  it("rejects malformed top-level and wrong-chain responses", () => {
+    expect(() => parseMerklRewardsResponse({}, ACCOUNT)).toThrow(/top level/);
+    const wrong = payload();
+    (wrong[0] as { chain: { id: number } }).chain.id = 1;
+    expect(() => parseMerklRewardsResponse(wrong, ACCOUNT)).toThrow(/must equal 143/);
+  });
+
+  it("rejects invalid addresses, amounts, proofs, and inconsistent recipients", () => {
+    expect(() =>
+      parseMerklRewardsResponse(payload([reward("bad", "100", [LEAF_B])]), ACCOUNT),
+    ).toThrow(/token.address/);
+    expect(() =>
+      parseMerklRewardsResponse(payload([reward(TOKEN_A, "1.5", [LEAF_B])]), ACCOUNT),
+    ).toThrow(/unsigned integer/);
+    expect(() =>
+      parseMerklRewardsResponse(payload([reward(TOKEN_A, "100", ["0x01" as Hex])]), ACCOUNT),
+    ).toThrow(/32-byte/);
+    expect(() =>
+      parseMerklRewardsResponse(
+        payload([reward(TOKEN_A, "100", [LEAF_B], { recipient: OTHER })]),
+        ACCOUNT,
+      ),
+    ).toThrow(/does not match/);
+  });
+
+  it("rejects duplicate tokens and empty proofs for positive rewards", () => {
+    expect(() => parseMerklRewardsResponse(payload([reward(TOKEN_A, "100", [])]), ACCOUNT)).toThrow(
+      /must not be empty/,
+    );
+    expect(() =>
+      parseMerklRewardsResponse(
+        payload([reward(TOKEN_A, "100", [LEAF_B]), reward(TOKEN_A.toLowerCase(), "100", [LEAF_B])]),
+        ACCOUNT,
+      ),
+    ).toThrow(/duplicate token/);
+    expect(() =>
+      parseMerklRewardsResponse(
+        payload([
+          reward(TOKEN_A, "100", [LEAF_B], {
+            breakdowns: [
+              {
+                ...reward(TOKEN_A, "100", [LEAF_B]).breakdowns[0],
+                root: WRONG_ROOT,
+              },
+            ],
+          }),
+        ]),
+        ACCOUNT,
+      ),
+    ).toThrow(/does not match its reward root/);
+  });
+});
+
+describe("merkl.rewards", () => {
+  it("cross-checks API totals with on-chain claimed state and recipient", async () => {
+    const { registry } = offline({ claimed: { [TOKEN_A.toLowerCase()]: 40n } });
+    const result = await registry.action("merkl", "rewards", OTHER, { account: ACCOUNT });
+    expect(result).toMatchObject({
+      kind: "query",
+      data: {
+        account: ACCOUNT,
+        merkleRoot: ROOT,
+        rewards: [
+          {
+            token: TOKEN_A,
+            cumulativeAmount: "100",
+            apiClaimedAmount: "0",
+            onchainClaimedAmount: "40",
+            claimableAmount: "60",
+            pendingAmount: "3",
+            proofLength: 1,
+            effectiveRecipient: ACCOUNT,
+            claimableNow: true,
+          },
+        ],
+      },
+    });
+  });
+
+  it("keeps pending-only rewards separate and non-claimable", async () => {
+    const pendingOnly = reward(TOKEN_A, "0", [], { pending: "9", breakdowns: [] });
+    const { registry } = offline({ apiPayload: payload([pendingOnly]) });
+    const result = await registry.action("merkl", "rewards", ACCOUNT, { account: ACCOUNT });
+    expect(result).toMatchObject({
+      kind: "query",
+      data: { rewards: [{ claimableAmount: "0", pendingAmount: "9", claimableNow: false }] },
+    });
+  });
+
+  it("uses on-chain claimed state even when it is ahead of the API", async () => {
+    const { registry } = offline({ claimed: { [TOKEN_A.toLowerCase()]: 101n } });
+    const result = await registry.action("merkl", "rewards", ACCOUNT, { account: ACCOUNT });
+    expect(result).toMatchObject({
+      kind: "query",
+      data: {
+        rewards: [
+          {
+            claimableAmount: "0",
+            claimableNow: false,
+            unavailableReason: expect.stringContaining("behind"),
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe("merkl.claim construction", () => {
+  it("uses ActionCtx.account, cumulative amounts, requested order, and one fixed transaction", async () => {
+    const apiPayload = payload([
+      reward(TOKEN_A, AMOUNT_A.toString(), [LEAF_B]),
+      reward(TOKEN_B, AMOUNT_B.toString(), [LEAF_A]),
+    ]);
+    const { capability, fetchMock } = await claimCapability({ apiPayload }, [TOKEN_B, TOKEN_A]);
+    const flattened = flattenCapabilityTree(capability);
+    expect(flattened).toHaveLength(1);
+    expect(flattened[0]?.transaction.to).toBe(MERKL_DISTRIBUTOR_ADDRESS);
+    const decoded = decodeFunctionData({
+      abi: distributorAbi,
+      data: flattened[0]?.transaction.data as Hex,
+    });
+    expect(decoded.functionName).toBe("claim");
+    expect(decoded.args).toEqual([
+      [ACCOUNT, ACCOUNT],
+      [TOKEN_B, TOKEN_A],
+      [AMOUNT_B, AMOUNT_A],
+      [[LEAF_A], [LEAF_B]],
+    ]);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("reloadChainId=143");
+  });
+
+  it("rejects missing selected tokens, duplicate requests, and oversized batches", async () => {
+    const { registry } = offline();
+    await expect(registry.action("merkl", "claim", ACCOUNT, { tokens: [] })).rejects.toThrow();
+    await expect(registry.action("merkl", "claim", ACCOUNT, { tokens: [TOKEN_B] })).rejects.toThrow(
+      /no current reward record/,
+    );
+    await expect(
+      registry.action("merkl", "claim", ACCOUNT, { tokens: [TOKEN_A, TOKEN_A.toLowerCase()] }),
+    ).rejects.toThrow(/unique/);
+    const many = Array.from(
+      { length: MAX_MERKL_CLAIM_TOKENS + 1 },
+      (_, index) => `0x${index.toString(16).padStart(40, "0")}`,
+    );
+    await expect(registry.action("merkl", "claim", ACCOUNT, { tokens: many })).rejects.toThrow();
+  });
+
+  it("rejects non-positive increments, empty active roots, and proof mismatches", async () => {
+    await expect(
+      claimCapability({ claimed: { [TOKEN_A.toLowerCase()]: AMOUNT_A } }),
+    ).rejects.toThrow(/no positive incremental/);
+    await expect(
+      claimCapability({ claimed: { [TOKEN_A.toLowerCase()]: AMOUNT_A + 1n } }),
+    ).rejects.toThrow(/no positive incremental/);
+    await expect(claimCapability({ root: `0x${"00".repeat(32)}` as Hex })).rejects.toThrow(
+      /no active Merkle root/,
+    );
+    await expect(claimCapability({ root: WRONG_ROOT })).rejects.toThrow(
+      /does not match active root/,
+    );
+    const invalidReward = reward(TOKEN_A, AMOUNT_A.toString(), [WRONG_ROOT], {
+      root: WRONG_ROOT,
+    });
+    const invalid = payload([
+      {
+        ...invalidReward,
+        breakdowns: invalidReward.breakdowns.map((breakdown) => ({
+          ...breakdown,
+          root: WRONG_ROOT,
+        })),
+      },
+    ]);
+    await expect(claimCapability({ apiPayload: invalid, root: WRONG_ROOT })).rejects.toThrow(
+      /proof does not match/,
+    );
+  });
+
+  it("rejects token-specific and default redirections but accepts explicit self-recipient", async () => {
+    await expect(
+      claimCapability({ tokenRecipients: { [TOKEN_A.toLowerCase()]: OTHER } }),
+    ).rejects.toThrow(/redirects claims/);
+    await expect(claimCapability({ defaultRecipient: OTHER })).rejects.toThrow(/redirects claims/);
+    await expect(
+      claimCapability({ tokenRecipients: { [TOKEN_A.toLowerCase()]: ACCOUNT } }),
+    ).resolves.toBeDefined();
+  });
+
+  it("surfaces API and network failures", async () => {
+    await expect(claimCapability({ apiPayload: { drifted: true } })).rejects.toThrow(
+      /schema error/,
+    );
+    await expect(claimCapability({ fetchError: new Error("offline") })).rejects.toThrow(
+      /request failed: offline/,
+    );
+  });
+
+  it("rejects unsupported raw construction fields", async () => {
+    const { registry } = offline();
+    for (const extra of [
+      { user: OTHER },
+      { amount: "1" },
+      { proof: [LEAF_B] },
+      { recipient: OTHER },
+      { distributor: OTHER },
+    ]) {
+      await expect(
+        registry.action("merkl", "claim", ACCOUNT, { tokens: [TOKEN_A], ...extra }),
+      ).rejects.toThrow(/unrecognized/i);
+    }
+  });
+});
+
+function claimedEvent(
+  user = ACCOUNT,
+  token = TOKEN_A,
+  amount = 60n,
+  emitter = MERKL_DISTRIBUTOR_ADDRESS,
+): Change {
+  return {
+    kind: "event",
+    address: emitter,
+    topics: encodeEventTopics({
+      abi: distributorAbi,
+      eventName: "Claimed",
+      args: { user, token },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function transferEvent(
+  from = MERKL_DISTRIBUTOR_ADDRESS,
+  to = ACCOUNT,
+  amount = 60n,
+  emitter = TOKEN_A,
+): Change {
+  return {
+    kind: "event",
+    address: emitter,
+    topics: encodeEventTopics({
+      abi: ERC20Abi,
+      eventName: "Transfer",
+      args: { from, to },
+    }) as readonly Hex[],
+    data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+  };
+}
+
+function leafChange(entry: ReceiptResult["changes"][number] | undefined): Change {
+  if (!entry) throw new Error("missing Receipt entry");
+  return entry.kind === "change" ? entry.change : leafChange(entry.changes[0]);
+}
+
+describe("Merkl claim Receipt evidence", () => {
+  it("parses a valid single-token claim with original identity and Package label", async () => {
+    const { registry, capability } = await claimCapability();
+    const changes = [claimedEvent(), transferEvent()];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toEqual({
+      operation: "claim",
+      account: ACCOUNT,
+      rewards: [{ token: TOKEN_A, amount: "60" }],
+    });
+    expect(receipt.changes).toHaveLength(changes.length);
+    changes.forEach((change, index) => {
+      expect(leafChange(receipt.changes[index])).toBe(change);
+    });
+    expect(receipt.changes[0]).toMatchObject({
+      text: expect.stringContaining("Package(Merkl:Distributor)"),
+    });
+  });
+
+  it("preserves observed multi-token execution order", async () => {
+    const { registry, capability } = await claimCapability();
+    const changes = [
+      claimedEvent(ACCOUNT, TOKEN_B, 7n),
+      transferEvent(MERKL_DISTRIBUTOR_ADDRESS, ACCOUNT, 7n, TOKEN_B),
+      claimedEvent(ACCOUNT, TOKEN_A, 9n),
+      transferEvent(MERKL_DISTRIBUTOR_ADDRESS, ACCOUNT, 9n, TOKEN_A),
+    ];
+    const receipt = registry.parseReceipt(capability, changes);
+    expect(receipt.outcome).toEqual({
+      operation: "claim",
+      account: ACCOUNT,
+      rewards: [
+        { token: TOKEN_B, amount: "7" },
+        { token: TOKEN_A, amount: "9" },
+      ],
+    });
+    changes.forEach((change, index) => {
+      expect(leafChange(receipt.changes[index])).toBe(change);
+    });
+  });
+
+  it("rejects forged emitters, wrong actors, endpoints, amounts, and zero claims", async () => {
+    const { registry, capability } = await claimCapability();
+    expect(() =>
+      registry.parseReceipt(capability, [
+        claimedEvent(ACCOUNT, TOKEN_A, 60n, OTHER),
+        transferEvent(),
+      ]),
+    ).toThrow(/fixed Distributor/);
+    expect(() =>
+      registry.parseReceipt(capability, [
+        claimedEvent(),
+        transferEvent(MERKL_DISTRIBUTOR_ADDRESS, ACCOUNT, 60n, TOKEN_B),
+      ]),
+    ).toThrow(/claimed token/);
+    expect(() => registry.parseReceipt(capability, [claimedEvent(OTHER), transferEvent()])).toThrow(
+      /recipient/,
+    );
+    expect(() => registry.parseReceipt(capability, [claimedEvent(), transferEvent(OTHER)])).toThrow(
+      /sender/,
+    );
+    expect(() =>
+      registry.parseReceipt(capability, [
+        claimedEvent(),
+        transferEvent(MERKL_DISTRIBUTOR_ADDRESS, OTHER),
+      ]),
+    ).toThrow(/recipient/);
+    expect(() =>
+      registry.parseReceipt(capability, [
+        claimedEvent(),
+        transferEvent(MERKL_DISTRIBUTOR_ADDRESS, ACCOUNT, 61n),
+      ]),
+    ).toThrow(/value/);
+    expect(() =>
+      registry.parseReceipt(capability, [
+        claimedEvent(ACCOUNT, TOKEN_A, 0n),
+        transferEvent(MERKL_DISTRIBUTOR_ADDRESS, ACCOUNT, 0n),
+      ]),
+    ).toThrow(/zero-amount/);
+  });
+
+  it("rejects missing, duplicate, decoy, reordered, malformed, and extra evidence", async () => {
+    const { registry, capability } = await claimCapability();
+    expect(() => registry.parseReceipt(capability, [claimedEvent()])).toThrow(/pair/);
+    expect(() => registry.parseReceipt(capability, [transferEvent()])).toThrow(/pair|Claimed/);
+    expect(() =>
+      registry.parseReceipt(capability, [
+        claimedEvent(),
+        claimedEvent(),
+        transferEvent(),
+        transferEvent(),
+      ]),
+    ).toThrow();
+    expect(() =>
+      registry.parseReceipt(capability, [claimedEvent(), transferEvent(), transferEvent()]),
+    ).toThrow(/pair/);
+    expect(() =>
+      registry.parseReceipt(capability, [
+        claimedEvent(),
+        transferEvent(MERKL_DISTRIBUTOR_ADDRESS, ACCOUNT, 60n, TOKEN_B),
+        transferEvent(),
+      ]),
+    ).toThrow();
+    expect(() => registry.parseReceipt(capability, [transferEvent(), claimedEvent()])).toThrow(
+      /Claimed/,
+    );
+    expect(() =>
+      registry.parseReceipt(capability, [
+        { ...claimedEvent(), data: "0x01" } as Change,
+        transferEvent(),
+      ]),
+    ).toThrow(/malformed/);
+    const approval: Change = {
+      kind: "event",
+      address: TOKEN_A,
+      topics: encodeEventTopics({
+        abi: ERC20Abi,
+        eventName: "Approval",
+        args: { owner: ACCOUNT, spender: OTHER },
+      }) as readonly Hex[],
+      data: encodeAbiParameters([{ type: "uint256" }], [1n]),
+    };
+    expect(() =>
+      registry.parseReceipt(capability, [claimedEvent(), transferEvent(), approval]),
+    ).toThrow(/pair/);
+  });
+});
+
+describe("Merkl metadata and Registry", () => {
+  it("discovers and loads the real Query and Capability contracts", () => {
+    const { registry } = offline();
+    expect(registry.discover({ protocol: "merkl" })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: "merkl",
+          method: "rewards",
+          kind: "query",
+          category: "rewards",
+        }),
+        expect.objectContaining({
+          protocol: "merkl",
+          method: "claim",
+          kind: "capability",
+          verb: "claim",
+          category: "rewards",
+        }),
+      ]),
+    );
+    const [rewards, claim] = registry.load([
+      { protocol: "merkl", method: "rewards" },
+      { protocol: "merkl", method: "claim" },
+    ]);
+    expect(rewards).toMatchObject({
+      params: {
+        account: {
+          description: expect.stringContaining("inspected"),
+          type: { description: expect.stringContaining("20-byte") },
+        },
+      },
+    });
+    expect(claim).toMatchObject({
+      risk: ["fundOut"],
+      tags: ["rewards", "merkle", "batch-claim", "incentives"],
+      params: {
+        tokens: {
+          description: expect.stringContaining("merkl.rewards"),
+          type: { maxItems: MAX_MERKL_CLAIM_TOKENS },
+        },
+      },
+    });
+  });
+});

--- a/packages/protocols/merkl/test/adapter.test.ts
+++ b/packages/protocols/merkl/test/adapter.test.ts
@@ -9,6 +9,7 @@ import {
 import { ERC20Abi } from "@themoss/erc";
 import {
   concatHex,
+  decodeEventLog,
   decodeFunctionData,
   encodeAbiParameters,
   encodeEventTopics,
@@ -532,6 +533,34 @@ function flattenReceiptTexts(receipt: ReceiptResult): string[] {
   );
 }
 
+function receiptMovesAssetsOut(receipt: ReceiptResult, account: string): boolean {
+  return receipt.changes.some((entry) => {
+    if (entry.kind === "receipt") return receiptMovesAssetsOut(entry, account);
+    const change = entry.change;
+    if (change.kind === "nativeTransfer") {
+      return (
+        change.from.toLowerCase() === account.toLowerCase() &&
+        change.to.toLowerCase() !== account.toLowerCase()
+      );
+    }
+    try {
+      const decoded = decodeEventLog({
+        abi: ERC20Abi,
+        topics: change.topics as [Hex, ...Hex[]],
+        data: change.data,
+        strict: true,
+      });
+      return (
+        decoded.eventName === "Transfer" &&
+        decoded.args.from.toLowerCase() === account.toLowerCase() &&
+        decoded.args.to.toLowerCase() !== account.toLowerCase()
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
 describe("Merkl claim Receipt evidence", () => {
   it("parses a valid single-token claim with original identity and Package label", async () => {
     const { registry, capability } = await claimCapability();
@@ -554,6 +583,7 @@ describe("Merkl claim Receipt evidence", () => {
     const transferText = `ERC20 Transfer: 60 ${TOKEN_A} from Package(Merkl:Distributor) to ${ACCOUNT}`;
     expect(receipt.text).toBe(`Merkl Claim: 1 reward token(s) paid to ${ACCOUNT}`);
     expect(flattenReceiptTexts(receipt)).toEqual([claimText, transferText]);
+    expect(receiptMovesAssetsOut(receipt, ACCOUNT)).toBe(false);
   });
 
   it("preserves observed multi-token execution order", async () => {
@@ -698,7 +728,7 @@ describe("Merkl metadata and Registry", () => {
       },
     });
     expect(claim).toMatchObject({
-      risk: ["fundOut"],
+      risk: [],
       tags: ["rewards", "merkle", "batch-claim", "incentives"],
       params: {
         tokens: {

--- a/packages/protocols/merkl/test/types.fixture.ts
+++ b/packages/protocols/merkl/test/types.fixture.ts
@@ -1,0 +1,51 @@
+import type { ActionCtx, AddressValue, ProtocolRef } from "@themoss/core";
+import type { MerklClaimOutcome, MerklProtocol, MerklRewardsResult } from "../src/index.js";
+
+declare const merkl: MerklProtocol;
+declare const ctx: ActionCtx;
+declare const dependency: ProtocolRef<MerklProtocol>;
+
+const TOKEN = "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A" as const;
+const ACCOUNT = "0x461549c73FFfB676860A0E49F5DaABEcf4E8D2d7" as const;
+
+type RewardsParams = Parameters<MerklProtocol["rewards"]>[0];
+type ClaimParams = Parameters<MerklProtocol["claim"]>[0];
+type RewardsResult = Awaited<ReturnType<MerklProtocol["rewards"]>>;
+
+const rewardsParams: RewardsParams = { account: ACCOUNT };
+const claimParams: ClaimParams = { tokens: [TOKEN] };
+merkl.rewards(rewardsParams) satisfies Promise<MerklRewardsResult>;
+merkl.claim(claimParams, ctx);
+merkl.claimReceipt([]).outcome satisfies MerklClaimOutcome;
+dependency.claimReceipt([]).protocol satisfies string;
+
+const result = null as unknown as RewardsResult;
+result.account satisfies AddressValue;
+result.rewards[0]?.token satisfies AddressValue | undefined;
+result.rewards[0]?.claimableAmount satisfies string | undefined;
+
+// @ts-expect-error Query account must be an EVM address.
+void merkl.rewards({ account: "not-an-address" });
+// @ts-expect-error Query account is required.
+void merkl.rewards({});
+// @ts-expect-error Claim token elements must be EVM addresses.
+void merkl.claim({ tokens: [42] }, ctx);
+// @ts-expect-error Claim tokens are required.
+void merkl.claim({}, ctx);
+// @ts-expect-error Acting user comes only from ActionCtx.
+void merkl.claim({ tokens: [TOKEN], user: ACCOUNT }, ctx);
+// @ts-expect-error Amounts are fetched and verified, never Agent input.
+void merkl.claim({ tokens: [TOKEN], amount: "1" }, ctx);
+// @ts-expect-error Proofs are fetched and verified, never Agent input.
+void merkl.claim({ tokens: [TOKEN], proof: [] }, ctx);
+// @ts-expect-error Recipient comes from on-chain state, never Agent input.
+void merkl.claim({ tokens: [TOKEN], recipient: ACCOUNT }, ctx);
+// @ts-expect-error Claim requires ActionCtx.
+void merkl.claim({ tokens: [TOKEN] });
+// @ts-expect-error Receipt outcome is not a rewards Query result.
+merkl.claimReceipt([]).outcome satisfies MerklRewardsResult;
+// @ts-expect-error Dependency references expose methods, not Handles.
+void dependency.distributor;
+
+void rewardsParams;
+void claimParams;

--- a/packages/protocols/merkl/test/types.fixture.ts
+++ b/packages/protocols/merkl/test/types.fixture.ts
@@ -1,4 +1,12 @@
-import type { ActionCtx, AddressValue, ProtocolRef } from "@themoss/core";
+import type {
+  ActionCtx,
+  AddressValue,
+  CapabilitySpec,
+  Handle,
+  Hex,
+  ProtocolRef,
+} from "@themoss/core";
+import type { distributorAbi } from "../src/abis/distributor.js";
 import type { MerklClaimOutcome, MerklProtocol, MerklRewardsResult } from "../src/index.js";
 
 declare const merkl: MerklProtocol;
@@ -7,6 +15,8 @@ declare const dependency: ProtocolRef<MerklProtocol>;
 
 const TOKEN = "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A" as const;
 const ACCOUNT = "0x461549c73FFfB676860A0E49F5DaABEcf4E8D2d7" as const;
+const ZERO = "0x0000000000000000000000000000000000000000" as const;
+const PROOF_NODE = "0x1111111111111111111111111111111111111111111111111111111111111111" as Hex;
 
 type RewardsParams = Parameters<MerklProtocol["rewards"]>[0];
 type ClaimParams = Parameters<MerklProtocol["claim"]>[0];
@@ -19,10 +29,51 @@ merkl.claim(claimParams, ctx);
 merkl.claimReceipt([]).outcome satisfies MerklClaimOutcome;
 dependency.claimReceipt([]).protocol satisfies string;
 
+function distributorHandleFixture(handle: Handle<typeof distributorAbi>) {
+  handle.claim([[ACCOUNT], [TOKEN], [1n], [[PROOF_NODE]]]);
+  handle.read.getMerkleRoot();
+  handle.read.claimed([ACCOUNT, TOKEN]);
+  handle.read.claimRecipient([ACCOUNT, ZERO]);
+  // @ts-expect-error ABI-generic Handles reject unknown Distributor methods.
+  handle.notARealMethod([]);
+  // @ts-expect-error Distributor.claim requires all four ABI arguments.
+  handle.claim([[ACCOUNT], [TOKEN], [1n]]);
+  // @ts-expect-error Distributor.claimRecipient requires two address arguments.
+  handle.read.claimRecipient([ACCOUNT]);
+}
+
 const result = null as unknown as RewardsResult;
 result.account satisfies AddressValue;
 result.rewards[0]?.token satisfies AddressValue | undefined;
 result.rewards[0]?.claimableAmount satisfies string | undefined;
+
+declare function assertClaimSpec(spec: CapabilitySpec<MerklProtocol>): void;
+
+assertClaimSpec({
+  intent: "Claim selected Merkl rewards",
+  verb: "claim",
+  params: {},
+  receipt: "claimReceipt",
+  risk: ["fundOut"],
+});
+
+assertClaimSpec({
+  intent: "Claim selected Merkl rewards",
+  verb: "claim",
+  params: {},
+  // @ts-expect-error Query methods are not valid Receipt bindings.
+  receipt: "rewards",
+  risk: ["fundOut"],
+});
+
+assertClaimSpec({
+  intent: "Claim selected Merkl rewards",
+  verb: "claim",
+  params: {},
+  // @ts-expect-error Receipt bindings must name an existing ReceiptResult method.
+  receipt: "notAReceipt",
+  risk: ["fundOut"],
+});
 
 // @ts-expect-error Query account must be an EVM address.
 void merkl.rewards({ account: "not-an-address" });
@@ -49,3 +100,5 @@ void dependency.distributor;
 
 void rewardsParams;
 void claimParams;
+void distributorHandleFixture;
+void assertClaimSpec;

--- a/packages/protocols/merkl/test/types.fixture.ts
+++ b/packages/protocols/merkl/test/types.fixture.ts
@@ -54,7 +54,7 @@ assertClaimSpec({
   verb: "claim",
   params: {},
   receipt: "claimReceipt",
-  risk: ["fundOut"],
+  risk: [],
 });
 
 assertClaimSpec({
@@ -63,7 +63,7 @@ assertClaimSpec({
   params: {},
   // @ts-expect-error Query methods are not valid Receipt bindings.
   receipt: "rewards",
-  risk: ["fundOut"],
+  risk: [],
 });
 
 assertClaimSpec({
@@ -72,7 +72,7 @@ assertClaimSpec({
   params: {},
   // @ts-expect-error Receipt bindings must name an existing ReceiptResult method.
   receipt: "notAReceipt",
-  risk: ["fundOut"],
+  risk: [],
 });
 
 // @ts-expect-error Query account must be an EVM address.

--- a/packages/protocols/merkl/tsconfig.json
+++ b/packages/protocols/merkl/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "src",
+    "scripts",
+    "test",
+    "test-online",
+    "vitest.config.ts",
+    "vitest.online.config.ts"
+  ]
+}

--- a/packages/protocols/merkl/vitest.config.ts
+++ b/packages/protocols/merkl/vitest.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  esbuild: { target: "es2022" },
+  test: {
+    include: [
+      "test/**/*.test.ts",
+      "test-online/deployment.test.ts",
+      "test-online/live-mainnet.test.ts",
+    ],
+  },
+  resolve: {
+    alias: {
+      "@themoss/core": src("../../core/src/index.ts"),
+      "@themoss/simulator": src("../../simulator/src/index.ts"),
+      "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/system": src("../../system/src/index.ts"),
+      "@themoss/abi-tools": src("../../abi-tools/src/index.ts"),
+    },
+  },
+});

--- a/packages/protocols/merkl/vitest.online.config.ts
+++ b/packages/protocols/merkl/vitest.online.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  esbuild: { target: "es2022" },
+  test: { include: ["test-online/abi-explorer.test.ts"] },
+  resolve: {
+    alias: {
+      "@themoss/core": src("../../core/src/index.ts"),
+      "@themoss/erc": src("../../erc/src/index.ts"),
+      "@themoss/abi-tools": src("../../abi-tools/src/index.ts"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,7 +435,7 @@ importers:
         version: link:../../system
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.23)(tsx@4.23.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.19.0
         version: 4.23.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@themoss/protocol-kuru':
         specifier: workspace:*
         version: link:../protocols/kuru
+      '@themoss/protocol-merkl':
+        specifier: workspace:*
+        version: link:../protocols/merkl
       '@themoss/protocol-monad-cards':
         specifier: workspace:*
         version: link:../protocols/monad-cards
@@ -399,6 +402,40 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.23)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/merkl:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@themoss/erc':
+        specifier: workspace:*
+        version: link:../../erc
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/abi-tools':
+        specifier: workspace:*
+        version: link:../../abi-tools
+      '@themoss/simulator':
+        specifier: workspace:*
+        version: link:../../simulator
+      '@themoss/system':
+        specifier: workspace:*
+        version: link:../../system
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.16)(tsx@4.23.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.19.0
         version: 4.23.0


### PR DESCRIPTION
## What and why

Add a first-class Merkl rewards Protocol package for Monad mainnet. Agents can discover an account's Merkl rewards with an on-chain cross-check, select 1-16 reward tokens, build one unsigned self-claim transaction, simulate it, and receive an exhaustive typed Receipt proving the actual payout.

## Replacement / prior review provenance

This is the canonical replacement for #173. That PR closed when its source fork was accidentally deleted; the contribution was not intentionally withdrawn and was not rejected.

GitHub's preserved pull ref was recovered and verified at exact old head `985ca861220bf572eb319b6900230bdfb8156eea`. `pillowtalk-Qy` completed the first independent audit of that exact head and found no new claim/Receipt evidence blocker. The two original commits were replayed with their original attribution, then refreshed against current main.

Replacement for #173.

## Current-main refresh

This branch is based on `e958f7f40c12c3ba514d93a18b02bed7eb8cdca0`, the latest `upstream/main` fetched before this refresh.

Differences from the previously audited head:

- resolved the README and MCP integration against the current Aave, Clober, Kintsu, Morpho, Pendle, and Uniswap composition;
- added Merkl to the current bilingual README package-order regression contract;
- added exact root and ordered leaf Receipt text-projection coverage for Agent-facing MCP output;
- repaired the Merkl lockfile importer from the stale PostCSS `8.5.16` tsup peer snapshot to current main's existing PostCSS `8.5.23` snapshot;
- rebased onto Core #190 support for explicitly authored empty risk lists, switched Merkl claim metadata to `risk: []`, removed the temporary placeholder, and added a Receipt assertion that no Change moves assets out of the account;
- re-ran current keyless deployment, ABI derivation, live simulation, full workspace, MCP composition, and package-order checks.

Merkl claim/query/Receipt execution semantics remain unchanged from audited head `985ca86`. This refresh changes the Registry metadata to the Core-approved `risk: []`, removes the old compatibility placeholder, and adds a no-outbound-asset Receipt assertion; the Distributor proxy, implementation, ABI, bytecode hashes, safety boundaries, Query, Capability, and Receipt parser remain unchanged and were re-verified live.

## Adapter surface

- Query: `merkl.rewards({ account })`
- Capability: `merkl.claim({ tokens })`
- Typed Receipt: `{ operation: "claim", account, rewards: [{ token, amount }] }`

The Capability accepts only an ordered list of 1-16 unique reward-token addresses. It owns exactly one direct unsigned `Distributor.claim` transaction and requires no approval.

## Safety boundaries

- **Self-claim only:** every claim user is `ActionCtx.account`; the Agent cannot inject a user, Distributor, recipient, cumulative amount, proof, or calldata.
- **API candidate, on-chain authority:** the Merkl API supplies fresh candidates (`reloadChainId=143` for construction), while the active root, claimed amount, and effective recipient are read from the Distributor.
- **Local proof verification:** both Query and construction verify `keccak256(abi.encode(user, token, cumulativeAmount))` with sorted proof pairs. A valid single-leaf empty proof is accepted only when the leaf equals the active root.
- **Amount semantics:** the cumulative API amount is supplied to `claim`; the positive incremental payout is `cumulative - onchain claimed`. Pending rewards never enter calldata, and cumulative values are bounded to `uint208`.
- **Recipient enforcement:** token-specific, then account-wide, then self fallback is resolved exactly like the deployed Distributor. Any redirect away from the acting account is rejected.
- **Receipt evidence:** each reward must appear as the exact ordered pair `Distributor.Claimed(user, token, incrementalAmount)` then `token.Transfer(Distributor, user, incrementalAmount)`. Emitters, parties, token, amount, identity, length, and order are authenticated; malformed, duplicate, missing, reordered, decoy, ambiguous, and unexplained Changes fail closed.

Excluded scope remains claims for other users, operator controls, recipient configuration, `claimWithRecipient`, callbacks, swaps, vault deposits, campaign/admin/dispute/tree/governance operations, cross-chain claims, and arbitrary Distributor addresses.

## ABI/deployment provenance

- Distributor ERC-1967/UUPS proxy: `0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae`
- Active implementation: `0x3f0fa7847b1b2e4515a93e05b29f115d9bb51d85`
- Proxy runtime hash: `0x1663c7ebc964dfa69a98528bccf3431438c5149fbabb8313d33374df61f3985a`
- Implementation runtime hash: `0x9c2edb9dffd093d12e7361203d857bf6d1bd208fcc1aeff7a8b6ac73323a04e7`

The live keyless deployment suite re-read the EIP-1967 implementation slot, matched both bytecode hashes, checked required selectors and the `Claimed` topic, and read a non-zero active root. The committed 73-entry ABI remains deterministically rendered from the explorer-verified implementation and protected against hand edits.

## Current RiskLabel treatment

The claim is inflow-only. Core #190 now allows an explicitly authored empty risk list while keeping the field required, so Merkl uses `risk: []` because no current closed-set label accurately describes this inflow-only operation. The Receipt test retains relevant Changes and asserts that no asset leaves the acting account, as required by #164. No Core changes are included in this PR.

## Current-main integration

- adds `@themoss/protocol-merkl` to the default MCP Registry composition;
- validates real `merkl.rewards` discovery/load and `merkl.claim` discovery/load;
- updates both supported-protocol tables and their current package-order regression fixture;
- locks Agent-facing root and ordered leaf Receipt text;
- adds Merkl to the linked changeset group;
- includes minor changesets for `@themoss/protocol-merkl` and `@themoss/mcp-server`.

## Verification

Fresh local results on this exact branch:

- [x] `pnpm install --frozen-lockfile` — passed with pnpm 11.10.0
- [x] `pnpm lint` — 287 files checked
- [x] `pnpm build` — 21/22 workspace projects built (the private root is not a build project)
- [x] `pnpm typecheck` — 21/22 workspace projects passed
- [x] `pnpm test:offline` — 717 passed, 45 expected live skips
- [ ] `pnpm test` — blocked by 5 unrelated Aave Monad live-fixture failures (all Merkl tests and offline tests pass); see the local verification note below
- [x] `pnpm --filter @themoss/protocol-merkl test` — 30/30 passed
- [x] `pnpm --filter @themoss/mcp-server test` — 23/23 passed
- [x] `pnpm audit --prod --audit-level high` — exited 0 with 0 high/critical vulnerabilities; 3 moderate Hono advisories are inherited through the MCP SDK
- [x] `pnpm changeset status --since=upstream/main` — Merkl and MCP server minor bumps
- Local full `pnpm test` reached unrelated Aave mainnet fixture failures (expired address-book quarantine plus no live account for the Aave health/supply/borrow/repay roles); this Merkl-only change did not alter Aave sources.
- `pnpm audit --prod --audit-level high` reported three moderate Hono advisories (<4.13.5) through the MCP SDK; no high or critical advisories were reported, and no dependency changed in this Merkl refresh.
- [x] `git diff --check`

### Live simulation

The unsigned Monad mainnet happy path passed for public account `0x461549c73FFfB676860A0E49F5DaABEcf4E8D2d7` and reward token `0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A`, with incremental claimable amount `49640922692037687136`. It produced one transaction, no halt, zero Warnings, and the exhaustive ordered two-Change `Claimed -> Transfer` Receipt. No signing, broadcasting, private key, or storage mutation occurred.

### Hosted CI

GitHub created [CI run 34684359452](https://github.com/nishuzumi/moss/actions/runs/34684359452) for this refreshed head, but it is `action_required` and no hosted job executed pending maintainer approval. Hosted CI is therefore not claimed as passing.

### ABI-online caveat

`MONADSCAN_API_KEY` was unavailable, so the keyed online ABI comparison was not run. All keyless ABI derivation, proxy/implementation, bytecode, selector, topic, read-surface, and live simulation checks passed.

## AI assistance

OpenAI Codex assisted with recovery, current-main adaptation, and verification. The results above were run against the resulting committed tree.
