### PR TITLE
fix(deps): update nanoid override to 3.3.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   ip-address: 10.3.1
   js-yaml@^3.0.0: 3.15.1
   js-yaml@^4.0.0: 4.3.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   postcss: 8.5.23
 
 importers:
@@ -2055,8 +2055,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3859,7 +3859,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -3976,7 +3976,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,5 +15,5 @@ overrides:
   ip-address: 10.3.1
   "js-yaml@^3.0.0": 3.15.1
   "js-yaml@^4.0.0": 4.3.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   postcss: 8.5.23


### PR DESCRIPTION
## What and why

Addresses the remaining nanoid advisory tracked in #125, following #148.

Updates the existing `nanoid` override from 3.3.17 to 3.3.18 to remediate GHSA-2v37-7h3g-55p8. This is a development-only dependency path; the production audit was already clean. No public API or package behavior changes.

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [ ] Documentation / example
- [x] Tooling / dependency

## Framework and package impact

None. Only the workspace override and corresponding lockfile resolution change.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Changeset: N/A, no user-facing package changes
- [x] Docs and examples: N/A, no API change

### Protocol changes

N/A.

## Evidence

- Frozen install with strict peer checks passed.
- `pnpm why nanoid` reports one resolution at 3.3.18.
- Production audit reports no known vulnerabilities.
- Plain `pnpm audit` reports only the existing development-only esbuild low; the nanoid high is removed.
- Lint checked 270 files with no fixes.
- Build and typecheck passed across the workspace.
- The complete offline and live Monad-mainnet suites passed.