### PR TITLE
feat: add Nad Name Service protocol adapter

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,6 +17,7 @@
       "@themoss/protocol-monad-cards",
       "@themoss/protocol-morpho",
       "@themoss/protocol-nadfun",
+      "@themoss/protocol-nns",
       "@themoss/protocol-pancakeswap",
       "@themoss/protocol-pendle",
       "@themoss/protocol-uniswap",

--- a/.changeset/nns-adapter.md
+++ b/.changeset/nns-adapter.md
@@ -1,0 +1,8 @@
+---
+"@themoss/protocol-nns": minor
+"@themoss/mcp-server": minor
+---
+
+Add the Nad Name Service (NNS) query adapter for Monad mainnet. It exposes
+`primaryName` and `profile` identity lookups through the default MCP
+composition, using the official NNS ABI and canonical deployment address.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Moss currently targets Monad mainnet, chain ID `143`.
 | aPriori | `@themoss/protocol-apriori` | `stake`, `unstake`, `claim` | — |
 | Morpho | `@themoss/protocol-morpho` | `supply`, `withdraw` | `position`, `vaultInfo` |
 | Nad.fun | `@themoss/protocol-nadfun` | — | `quoteBuy`, `quoteSell`, `tokenStatus` |
+| Nad Name Service | `@themoss/protocol-nns` | — | `primaryName`, `profile` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | Pendle | `@themoss/protocol-pendle` | `swap` | `quote`, `markets` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,7 @@ Moss 当前只支持 Monad 主网，chain ID 为 `143`。
 | aPriori | `@themoss/protocol-apriori` | `stake`、`unstake`、`claim` | — |
 | Morpho | `@themoss/protocol-morpho` | `supply`、`withdraw` | `position`、`vaultInfo` |
 | Nad.fun | `@themoss/protocol-nadfun` | — | `quoteBuy`、`quoteSell`、`tokenStatus` |
+| Nad Name Service | `@themoss/protocol-nns` | — | `primaryName`、`profile` |
 | PancakeSwap V2 / V3 | `@themoss/protocol-pancakeswap` | `swap` | `quote` |
 | Monad Cards | `@themoss/protocol-monad-cards` | — | `totalMinted` |
 | Pendle | `@themoss/protocol-pendle` | `swap` | `quote`、`markets` |

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -33,6 +33,7 @@
     "@themoss/protocol-monad-cards": "workspace:*",
     "@themoss/protocol-morpho": "workspace:*",
     "@themoss/protocol-nadfun": "workspace:*",
+    "@themoss/protocol-nns": "workspace:*",
     "@themoss/protocol-pancakeswap": "workspace:*",
     "@themoss/protocol-pendle": "workspace:*",
     "@themoss/protocol-uniswap": "workspace:*",

--- a/packages/mcp-server/src/composition.ts
+++ b/packages/mcp-server/src/composition.ts
@@ -7,6 +7,7 @@ import * as kuru from "@themoss/protocol-kuru";
 import * as monadCards from "@themoss/protocol-monad-cards";
 import * as morpho from "@themoss/protocol-morpho";
 import * as nadfun from "@themoss/protocol-nadfun";
+import * as nns from "@themoss/protocol-nns";
 import * as pancakeswap from "@themoss/protocol-pancakeswap";
 import * as pendle from "@themoss/protocol-pendle";
 import * as uniswap from "@themoss/protocol-uniswap";
@@ -24,6 +25,7 @@ export const defaultProtocolModules = [
   monadCards,
   morpho,
   nadfun,
+  nns,
   pancakeswap,
   pendle,
   uniswap,

--- a/packages/mcp-server/test/composition.test.ts
+++ b/packages/mcp-server/test/composition.test.ts
@@ -11,6 +11,25 @@ describe("default MCP Protocol composition", () => {
     expect(nadfunModule).toBeDefined();
   });
 
+  it("includes the Nad Name Service Protocol module", () => {
+    const nnsModule = defaultProtocolModules.find((module) => "NadNameService" in module);
+
+    expect(nnsModule).toBeDefined();
+  });
+
+  it("discovers Nad Name Service identity Queries through the default composition", () => {
+    const registry = new Registry(runtime).use(...defaultProtocolModules);
+    const discovered = registry.discover({ protocol: "nns" });
+
+    expect(discovered).toHaveLength(2);
+    expect(discovered).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ protocol: "nns", method: "primaryName", kind: "query" }),
+        expect.objectContaining({ protocol: "nns", method: "profile", kind: "query" }),
+      ]),
+    );
+  });
+
   it("discovers and loads Nad.fun Query coordinates through the default composition", () => {
     const registry = new Registry(runtime).use(...defaultProtocolModules);
 

--- a/packages/mcp-server/test/readme.test.ts
+++ b/packages/mcp-server/test/readme.test.ts
@@ -26,6 +26,7 @@ const expectedPackageOrder = [
   "@themoss/protocol-apriori",
   "@themoss/protocol-morpho",
   "@themoss/protocol-nadfun",
+  "@themoss/protocol-nns",
   "@themoss/protocol-pancakeswap",
   "@themoss/protocol-monad-cards",
   "@themoss/protocol-pendle",

--- a/packages/protocols/nns/README.md
+++ b/packages/protocols/nns/README.md
@@ -1,0 +1,87 @@
+# @themoss/protocol-nns
+
+Moss Query Adapter for Nad Name Service (NNS) on Monad mainnet.
+
+## Challenge description
+
+This adapter adds read-only Nad Name Service identity lookups to Moss. Agents
+can discover an address's primary `.nad` name and profile avatar through the
+official NNS contract, with JSON-safe results and no signing or transaction
+execution.
+
+## Supported Queries
+
+### `primaryName`
+
+Reads the primary NNS name for an EVM address.
+
+Returns `{ address, primaryName }`. The name is an empty string when no primary
+name is assigned.
+
+### `profile`
+
+Reads the NNS profile tuple for an EVM address.
+
+Returns `{ address, primaryName, avatar }`. Empty strings are valid for accounts
+without a name or avatar.
+
+## Fixed deployment
+
+Monad mainnet NNS contract:
+
+```text
+0xcc7a1bff8845573dbf0b3b96e25b9b549d4a2ec7
+```
+
+Canonical address source:
+
+```text
+https://github.com/monad-crypto/protocols/blob/main/mainnet/nad_name_service.jsonc
+```
+
+## ABI provenance
+
+The complete official ABI source is vendored verbatim at `abis-src/contract-abi.md`
+from:
+
+```text
+https://docs.nad.domains/developers/contracts/contract-abi.md
+```
+
+`abis-src/VENDOR.json` pins the source URL, retrieval date, and SHA-256. The
+generator extracts the `NadNameService.sol` JSON block from that artifact and
+produces `src/abis/nad-name-service.ts` reproducibly offline:
+
+```bash
+pnpm --filter @themoss/protocol-nns gen:abis
+```
+
+The deployed address is an ERC-1967 proxy. `abis.json` pins the proxy,
+implementation, and implementation bytecode hash. MonadScan currently marks
+the implementation as unverified, so the online suite honestly uses degraded
+verification: it checks the proxy slot, bytecode hash, and the function
+selectors required by Moss. If a key is supplied, it records the expected unverified
+response rather than claiming a semantic ABI comparison:
+
+```bash
+MONADSCAN_API_KEY=... pnpm --filter @themoss/protocol-nns test:abi:online
+```
+
+## Scope and safety
+
+This v1 adapter is query-only. It does not sign or send transactions, expose
+the contract's write functions, call an external HTTP resolver, or infer
+namehashes. Name resolution is intentionally limited to the contract's direct
+address-based read methods.
+
+## Validation
+
+```bash
+pnpm --filter @themoss/protocol-nns build
+pnpm --filter @themoss/protocol-nns typecheck
+pnpm --filter @themoss/protocol-nns test
+pnpm exec biome check packages/protocols/nns
+```
+
+The package test includes the live Monad mainnet suite. Set `MOSS_SKIP_E2E=1`
+to run only offline tests.

--- a/packages/protocols/nns/abis-src/VENDOR.json
+++ b/packages/protocols/nns/abis-src/VENDOR.json
@@ -1,0 +1,7 @@
+{
+  "sourceKind": "docs",
+  "source": "https://docs.nad.domains/developers/contracts/contract-abi.md",
+  "file": "contract-abi.md",
+  "fileSha256": "63060346a0d43fed03f9413eca2090efb40c4dd771c09b52e10246d5d253f743",
+  "retrievedAt": "2026-08-10"
+}

--- a/packages/protocols/nns/abis-src/contract-abi.md
+++ b/packages/protocols/nns/abis-src/contract-abi.md
@@ -1,0 +1,371 @@
+> For the complete documentation index, see [llms.txt](https://docs.nad.domains/llms.txt). Markdown versions of documentation pages are available by appending `.md` to page URLs; this page is available as [Markdown](https://docs.nad.domains/developers/contracts/contract-abi.md).
+
+# Contract ABI
+
+**NadNameService.sol**
+
+```json
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "name": "AttributeSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct IAttributeStorage.Attribute[]",
+        "name": "attributes",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "AttributesSet",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getResolvedAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "nodes",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "getResolvedAddresses",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "node",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IResolvedAddressStorage.ResolvedAddressItem[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getPrimaryNameForAddress",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "addr",
+        "type": "address[]"
+      }
+    ],
+    "name": "getPrimaryNameForAddresses",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "primaryName",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct IPrimaryNameStorage.PrimaryNameItem[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "getNameAttribute",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string[]",
+        "name": "keys",
+        "type": "string[]"
+      }
+    ],
+    "name": "getNameAttributes",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct IAttributeStorage.Attribute[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getNamesOfAddress",
+    "outputs": [
+      {
+        "internalType": "string[]",
+        "name": "",
+        "type": "string[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "name": "setNameAttribute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct IAttributeStorage.Attribute[]",
+        "name": "attributes",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "setNameAttributes",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getProfileForAddress",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "primaryName",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "avatar",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct INadNameService.Profile",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "addrs",
+        "type": "address[]"
+      }
+    ],
+    "name": "getProfilesForAddresses",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "primaryName",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "avatar",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct INadNameService.Profile[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]
+
+```

--- a/packages/protocols/nns/abis.json
+++ b/packages/protocols/nns/abis.json
@@ -1,0 +1,6 @@
+{
+  "proxy": "0xcc7a1bff8845573dbf0b3b96e25b9b549d4a2ec7",
+  "implementation": "0xE1f14F3ffF72E5dacFbA4335BFaF676A1B3F87Cf",
+  "implementationCodeHash": "0xa4a34e5d3f86d3d8e2b2d847c47af7d439191123f3bb21bfeed3fc23d9309ff4",
+  "allowedExplorerOnly": []
+}

--- a/packages/protocols/nns/package.json
+++ b/packages/protocols/nns/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@themoss/protocol-nns",
+  "version": "0.0.0",
+  "description": "Moss Protocol adapter for Nad Name Service identity queries on Monad mainnet",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --sourcemap --clean --target es2022",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run test/ test-online/live-mainnet.test.ts",
+    "gen:abis": "tsx scripts/gen-abis.ts",
+    "test:online": "vitest run test-online/live-mainnet.test.ts",
+    "test:abi:online": "vitest run --config vitest.online.config.ts"
+  },
+  "dependencies": {
+    "@themoss/core": "workspace:*",
+    "viem": "^2.54.3"
+  },
+  "devDependencies": {
+    "@themoss/abi-tools": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.0",
+    "typescript": "~5.9.0",
+    "vitest": "^3.2.6"
+  }
+}

--- a/packages/protocols/nns/scripts/abis.ts
+++ b/packages/protocols/nns/scripts/abis.ts
@@ -1,0 +1,114 @@
+/**
+ * Deterministic ABI provenance pipeline for the official Nad Name Service ABI.
+ * It reads only committed files and never makes a network request.
+ */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface VendorInfo {
+  sourceKind: "docs";
+  source: string;
+  file: string;
+  fileSha256: string;
+  retrievedAt: string;
+}
+
+interface AbiEntry {
+  type?: string;
+  name?: string;
+}
+
+export const REQUIRED_FUNCTIONS = [
+  "getNameAttribute",
+  "getNameAttributes",
+  "getNamesOfAddress",
+  "getPrimaryNameForAddress",
+  "getPrimaryNameForAddresses",
+  "getProfileForAddress",
+  "getProfilesForAddresses",
+  "getResolvedAddress",
+  "getResolvedAddresses",
+  "setNameAttribute",
+  "setNameAttributes",
+] as const;
+
+export const REQUIRED_EVENTS = ["AttributeSet", "AttributesSet"] as const;
+
+export function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function readVendorInfo(packageRoot: string): VendorInfo {
+  const vendor = JSON.parse(
+    readFileSync(join(packageRoot, "abis-src", "VENDOR.json"), "utf8"),
+  ) as VendorInfo;
+
+  if (vendor.sourceKind !== "docs") {
+    throw new Error(`Unsupported NNS ABI source kind: ${vendor.sourceKind}`);
+  }
+  if (!vendor.source.startsWith("https://docs.nad.domains/")) {
+    throw new Error("NNS ABI source must be the official NNS documentation site");
+  }
+  if (!/^[0-9a-f]{64}$/i.test(vendor.fileSha256)) {
+    throw new Error("NNS ABI vendor hash must be a SHA-256 digest");
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(vendor.retrievedAt)) {
+    throw new Error("NNS ABI retrieval date must be an ISO calendar date");
+  }
+
+  return vendor;
+}
+
+export function readAndValidateAbi(packageRoot: string, vendor: VendorInfo): readonly AbiEntry[] {
+  const rawArtifact = readFileSync(join(packageRoot, "abis-src", vendor.file), "utf8");
+  const actualHash = sha256(rawArtifact);
+  if (actualHash !== vendor.fileSha256) {
+    throw new Error(`NNS ABI hash mismatch: expected ${vendor.fileSha256}, received ${actualHash}`);
+  }
+
+  const abiCodeBlock = rawArtifact.match(
+    /\*\*NadNameService\.sol\*\*\r?\n\r?\n```json\r?\n([\s\S]*?)\r?\n```/,
+  )?.[1];
+  if (!abiCodeBlock)
+    throw new Error("NNS ABI documentation artifact has no NadNameService JSON block");
+
+  const abi = JSON.parse(abiCodeBlock) as readonly AbiEntry[];
+  if (!Array.isArray(abi)) throw new Error("NNS ABI must be a JSON array");
+
+  const functions = abi
+    .filter((entry) => entry.type === "function")
+    .map((entry) => entry.name)
+    .sort();
+  const expectedFunctions = [...REQUIRED_FUNCTIONS].sort();
+  if (JSON.stringify(functions) !== JSON.stringify(expectedFunctions)) {
+    throw new Error(`Unexpected NNS function set: ${functions.join(", ")}`);
+  }
+
+  const events = abi
+    .filter((entry) => entry.type === "event")
+    .map((entry) => entry.name)
+    .sort();
+  const expectedEvents = [...REQUIRED_EVENTS].sort();
+  if (JSON.stringify(events) !== JSON.stringify(expectedEvents)) {
+    throw new Error(`Unexpected NNS event set: ${events.join(", ")}`);
+  }
+
+  return abi;
+}
+
+export function generate(packageRoot: string): string {
+  const vendor = readVendorInfo(packageRoot);
+  const abi = readAndValidateAbi(packageRoot, vendor);
+
+  return `// GENERATED FILE - do not edit by hand.
+//   regenerate offline from abis-src/: pnpm gen:abis
+// ABI origin: official Nad Name Service documentation (ADR 0007)
+//   source:   ${vendor.source}
+//   artifact: ${vendor.file} - verbatim in ../abis-src/
+//   file:     sha256 ${vendor.fileSha256}
+//   retrieved: ${vendor.retrievedAt} (UTC)
+
+export const NadNameServiceAbi = ${JSON.stringify(abi, null, 2)} as const;
+`;
+}

--- a/packages/protocols/nns/scripts/gen-abis.ts
+++ b/packages/protocols/nns/scripts/gen-abis.ts
@@ -1,0 +1,10 @@
+/** Offline regeneration of src/abis/nad-name-service.ts. */
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generate } from "./abis.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+writeFileSync(join(packageRoot, "src", "abis", "nad-name-service.ts"), generate(packageRoot));
+console.log("regenerated src/abis/nad-name-service.ts from abis-src/ (offline)");

--- a/packages/protocols/nns/src/abis/nad-name-service.ts
+++ b/packages/protocols/nns/src/abis/nad-name-service.ts
@@ -1,0 +1,370 @@
+// GENERATED FILE - do not edit by hand.
+//   regenerate offline from abis-src/: pnpm gen:abis
+// ABI origin: official Nad Name Service documentation (ADR 0007)
+//   source:   https://docs.nad.domains/developers/contracts/contract-abi.md
+//   artifact: contract-abi.md - verbatim in ../abis-src/
+//   file:     sha256 63060346a0d43fed03f9413eca2090efb40c4dd771c09b52e10246d5d253f743
+//   retrieved: 2026-08-10 (UTC)
+
+export const NadNameServiceAbi = [
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "name": "AttributeSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct IAttributeStorage.Attribute[]",
+        "name": "attributes",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "AttributesSet",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getResolvedAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "nodes",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "getResolvedAddresses",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "node",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IResolvedAddressStorage.ResolvedAddressItem[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getPrimaryNameForAddress",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "addr",
+        "type": "address[]"
+      }
+    ],
+    "name": "getPrimaryNameForAddresses",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "primaryName",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct IPrimaryNameStorage.PrimaryNameItem[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "getNameAttribute",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string[]",
+        "name": "keys",
+        "type": "string[]"
+      }
+    ],
+    "name": "getNameAttributes",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct IAttributeStorage.Attribute[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getNamesOfAddress",
+    "outputs": [
+      {
+        "internalType": "string[]",
+        "name": "",
+        "type": "string[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
+      }
+    ],
+    "name": "setNameAttribute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "node",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct IAttributeStorage.Attribute[]",
+        "name": "attributes",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "setNameAttributes",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getProfileForAddress",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "primaryName",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "avatar",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct INadNameService.Profile",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "addrs",
+        "type": "address[]"
+      }
+    ],
+    "name": "getProfilesForAddresses",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "primaryName",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "avatar",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct INadNameService.Profile[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+] as const;

--- a/packages/protocols/nns/src/adapter.ts
+++ b/packages/protocols/nns/src/adapter.ts
@@ -1,0 +1,75 @@
+import {
+  Address,
+  type AddressValue,
+  type Handle,
+  type InferParams,
+  type ParamsSpec,
+  Protocol,
+  Query,
+} from "@themoss/core";
+import { getAddress } from "viem";
+import { NadNameServiceAbi } from "./abis/nad-name-service.js";
+
+// Nad Name Service on Monad mainnet.
+// Canonical address source:
+// https://github.com/monad-crypto/protocols/blob/main/mainnet/nad_name_service.jsonc
+export const NAD_NAME_SERVICE_ADDRESS: AddressValue = "0xcc7a1bff8845573dbf0b3b96e25b9b549d4a2ec7";
+
+const addressParams = {
+  address: {
+    type: Address,
+    description: "Address whose Nad Name Service identity is queried.",
+  },
+} satisfies ParamsSpec;
+
+export interface NadNameServicePrimaryName {
+  address: AddressValue;
+  primaryName: string;
+}
+
+export interface NadNameServiceProfile extends NadNameServicePrimaryName {
+  avatar: string;
+}
+
+@Protocol({
+  name: "nns",
+  category: "token",
+  description: "Nad Name Service identity lookups on Monad mainnet.",
+  contracts: {
+    nns: {
+      abi: NadNameServiceAbi,
+      addr: NAD_NAME_SERVICE_ADDRESS,
+    },
+  },
+})
+export class NadNameService {
+  declare nns: Handle<typeof NadNameServiceAbi>;
+
+  @Query({
+    intent: "Read the primary Nad Name Service name for an address",
+    params: addressParams,
+    tags: ["identity", "name-service"],
+  })
+  async primaryName(params: InferParams<typeof addressParams>): Promise<NadNameServicePrimaryName> {
+    const primaryName = await this.nns.read.getPrimaryNameForAddress([params.address]);
+    return { address: params.address, primaryName };
+  }
+
+  @Query({
+    intent: "Read a Nad Name Service profile for an address",
+    params: addressParams,
+    tags: ["identity", "name-service"],
+  })
+  async profile(params: InferParams<typeof addressParams>): Promise<NadNameServiceProfile> {
+    const profile = await this.nns.read.getProfileForAddress([params.address]);
+    const returnedAddress = Array.isArray(profile) ? profile[0] : profile.addr;
+    if (getAddress(returnedAddress) !== getAddress(params.address)) {
+      throw new Error(
+        `NNS profile returned address ${returnedAddress} for requested address ${params.address}`,
+      );
+    }
+    const primaryName = Array.isArray(profile) ? profile[1] : profile.primaryName;
+    const avatar = Array.isArray(profile) ? profile[2] : profile.avatar;
+    return { address: params.address, primaryName, avatar };
+  }
+}

--- a/packages/protocols/nns/src/index.ts
+++ b/packages/protocols/nns/src/index.ts
@@ -1,0 +1,7 @@
+export { NadNameServiceAbi } from "./abis/nad-name-service.js";
+export {
+  NAD_NAME_SERVICE_ADDRESS,
+  NadNameService,
+  type NadNameServicePrimaryName,
+  type NadNameServiceProfile,
+} from "./adapter.js";

--- a/packages/protocols/nns/test-online/abi-explorer.test.ts
+++ b/packages/protocols/nns/test-online/abi-explorer.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Honest degraded verification for the Nad Name Service proxy (ADR 0007).
+ *
+ * MonadScan currently reports the pinned implementation as unverified, so this
+ * suite deliberately does not claim an explorer ABI semantic comparison. It
+ * keeps the upgrade/code-hash tripwires and checks that every function selector
+ * used by Moss is represented in the deployed implementation bytecode.
+ */
+import { readFileSync } from "node:fs";
+import {
+  ERC1967_IMPLEMENTATION_SLOT,
+  erc1967ImplementationAddress,
+  fetchAbi,
+} from "@themoss/abi-tools";
+import { createRuntime } from "@themoss/core";
+import { type Abi, type Address, getAddress, keccak256, toFunctionSelector } from "viem";
+import { describe, expect, it } from "vitest";
+import { REQUIRED_FUNCTIONS } from "../scripts/abis.js";
+import { NadNameServiceAbi } from "../src/abis/nad-name-service.js";
+import { NAD_NAME_SERVICE_ADDRESS } from "../src/index.js";
+
+interface AbiManifest {
+  proxy: Address;
+  implementation: Address;
+  implementationCodeHash: `0x${string}`;
+}
+
+const manifest = JSON.parse(
+  readFileSync(new URL("../abis.json", import.meta.url), "utf8"),
+) as AbiManifest;
+
+describe("NNS ABI degraded verification", () => {
+  it("pins the proxy used by the adapter", () => {
+    expect(getAddress(manifest.proxy)).toBe(getAddress(NAD_NAME_SERVICE_ADDRESS));
+  });
+
+  it("proxy still points at the recorded implementation and bytecode", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    const slot = await runtime.client.getStorageAt({
+      address: manifest.proxy,
+      slot: ERC1967_IMPLEMENTATION_SLOT,
+    });
+    expect(getAddress(erc1967ImplementationAddress(slot))).toBe(
+      getAddress(manifest.implementation),
+    );
+
+    const code = await runtime.client.getCode({ address: manifest.implementation });
+    expect(code).toBeDefined();
+    expect(code).not.toBe("0x");
+    if (!code) throw new Error("NNS implementation has no deployed bytecode");
+    expect(keccak256(code)).toBe(manifest.implementationCodeHash);
+  });
+
+  it("deployed bytecode exposes every Moss-required function selector", {
+    timeout: 60_000,
+  }, async () => {
+    const runtime = await createRuntime();
+    const code = await runtime.client.getCode({ address: manifest.implementation });
+    expect(code).toBeDefined();
+    expect(code).not.toBe("0x");
+    const haystack = (code ?? "0x").toLowerCase();
+    const abi = NadNameServiceAbi as Abi;
+
+    for (const name of REQUIRED_FUNCTIONS) {
+      const item = abi.find(
+        (entry) => entry.type === "function" && "name" in entry && entry.name === name,
+      );
+      if (item?.type !== "function")
+        throw new Error(`required NNS function ${name} is missing from ABI`);
+      expect(haystack, `selector for ${name} missing from implementation`).toContain(
+        toFunctionSelector(item).slice(2).toLowerCase(),
+      );
+    }
+  });
+
+  it("records MonadScan's current unverified status instead of claiming semantic comparison", {
+    timeout: 120_000,
+  }, async () => {
+    const key = process.env.MONADSCAN_API_KEY;
+    if (!key) return;
+    await expect(fetchAbi(manifest.implementation, key)).rejects.toThrow(
+      /Contract source code not verified/i,
+    );
+  });
+});

--- a/packages/protocols/nns/test-online/live-mainnet.test.ts
+++ b/packages/protocols/nns/test-online/live-mainnet.test.ts
@@ -1,0 +1,61 @@
+import { defaultRpcUrl, type MossRuntime, Registry } from "@themoss/core";
+import { createPublicClient, getAddress, http } from "viem";
+import { describe, expect, it } from "vitest";
+import {
+  NAD_NAME_SERVICE_ADDRESS,
+  NadNameService,
+  type NadNameServicePrimaryName,
+  type NadNameServiceProfile,
+} from "../src/index.js";
+
+const RPC_URL = defaultRpcUrl();
+const SAMPLE_ADDRESS = getAddress(
+  process.env.NNS_SAMPLE_ADDRESS ?? "0xcccccccccccccccccccccccccccccccccccccccc",
+);
+
+function queryData<T>(result: Awaited<ReturnType<Registry["action"]>>): T {
+  if (result.kind !== "query") throw new Error("Expected a Query result");
+  return result.data as T;
+}
+
+describe.skipIf(!!process.env.MOSS_SKIP_E2E)("NNS live Monad mainnet", () => {
+  it("verifies deployment and executes both read-only identity Queries", {
+    timeout: 60_000,
+  }, async () => {
+    const client = createPublicClient({
+      transport: http(RPC_URL, { timeout: 30_000, retryCount: 2 }),
+    });
+
+    expect(await client.getChainId()).toBe(143);
+    expect(await client.getCode({ address: NAD_NAME_SERVICE_ADDRESS })).not.toBe("0x");
+
+    const runtime = { rpcUrl: RPC_URL, client } satisfies MossRuntime;
+    const registry = new Registry(runtime).use(NadNameService);
+
+    expect(registry.discover({ protocol: "nns" })).toHaveLength(2);
+
+    const primaryName = queryData<NadNameServicePrimaryName>(
+      await registry.action("nns", "primaryName", SAMPLE_ADDRESS, { address: SAMPLE_ADDRESS }),
+    );
+    const profile = queryData<NadNameServiceProfile>(
+      await registry.action("nns", "profile", SAMPLE_ADDRESS, { address: SAMPLE_ADDRESS }),
+    );
+
+    expect(primaryName.address).toBe(SAMPLE_ADDRESS);
+    expect(typeof primaryName.primaryName).toBe("string");
+    expect(profile).toMatchObject({
+      address: SAMPLE_ADDRESS,
+      primaryName: expect.any(String),
+      avatar: expect.any(String),
+    });
+    expect(() => JSON.stringify({ primaryName, profile })).not.toThrow();
+
+    console.log({
+      chainId: 143,
+      contract: NAD_NAME_SERVICE_ADDRESS,
+      address: SAMPLE_ADDRESS,
+      primaryName,
+      profile,
+    });
+  });
+});

--- a/packages/protocols/nns/test/abis.test.ts
+++ b/packages/protocols/nns/test/abis.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+import { generate, readAndValidateAbi, readVendorInfo } from "../scripts/abis.js";
+import { NAD_NAME_SERVICE_ADDRESS } from "../src/index.js";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("Nad Name Service ABI provenance", () => {
+  it("pins the official source, hash, and complete ABI", () => {
+    const vendor = readVendorInfo(packageRoot);
+    const deployment = JSON.parse(readFileSync(join(packageRoot, "abis.json"), "utf8")) as {
+      proxy: string;
+      implementation: string;
+      implementationCodeHash: string;
+      allowedExplorerOnly: string[];
+    };
+
+    expect(vendor).toMatchObject({
+      sourceKind: "docs",
+      source: "https://docs.nad.domains/developers/contracts/contract-abi.md",
+      file: "contract-abi.md",
+    });
+    expect(vendor.fileSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(deployment).toMatchObject({
+      proxy: NAD_NAME_SERVICE_ADDRESS,
+      implementation: "0xE1f14F3ffF72E5dacFbA4335BFaF676A1B3F87Cf",
+      implementationCodeHash: "0xa4a34e5d3f86d3d8e2b2d847c47af7d439191123f3bb21bfeed3fc23d9309ff4",
+      allowedExplorerOnly: [],
+    });
+    expect(getAddress(deployment.proxy)).toBe(getAddress(NAD_NAME_SERVICE_ADDRESS));
+    expect(readAndValidateAbi(packageRoot, vendor)).toHaveLength(13);
+  });
+
+  it("derives the committed ABI module byte-for-byte", () => {
+    const committed = readFileSync(join(packageRoot, "src", "abis", "nad-name-service.ts"), "utf8");
+    expect(committed).toBe(generate(packageRoot));
+  });
+});

--- a/packages/protocols/nns/test/adapter.test.ts
+++ b/packages/protocols/nns/test/adapter.test.ts
@@ -1,0 +1,160 @@
+import { type AddressValue, type MossRuntime, Registry } from "@themoss/core";
+import { getAddress } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { NAD_NAME_SERVICE_ADDRESS, NadNameService } from "../src/index.js";
+
+const ACCOUNT = getAddress("0xcccccccccccccccccccccccccccccccccccccccc");
+
+interface ReadContractRequest {
+  address: AddressValue;
+  functionName: string;
+  args?: readonly unknown[];
+}
+
+function offlineRegistry() {
+  const readContract = vi.fn(async (request: ReadContractRequest): Promise<unknown> => {
+    expect(request.address).toBe(NAD_NAME_SERVICE_ADDRESS);
+
+    switch (request.functionName) {
+      case "getPrimaryNameForAddress":
+        expect(request.args).toEqual([ACCOUNT]);
+        return "salmo.nad";
+      case "getProfileForAddress":
+        expect(request.args).toEqual([ACCOUNT]);
+        return { addr: ACCOUNT, primaryName: "salmo.nad", avatar: "ipfs://avatar" };
+      default:
+        throw new Error(`Unexpected readContract function ${request.functionName}`);
+    }
+  });
+
+  const runtime = {
+    rpcUrl: "http://offline",
+    client: { readContract } as unknown as MossRuntime["client"],
+  };
+
+  return { registry: new Registry(runtime).use(NadNameService), readContract };
+}
+
+describe("NadNameService", () => {
+  it("discovers self-describing identity Queries", () => {
+    const { registry } = offlineRegistry();
+    const coordinates = registry.discover({ protocol: "nns" });
+
+    expect(coordinates).toHaveLength(2);
+    expect(coordinates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: "nns",
+          method: "primaryName",
+          kind: "query",
+          category: "token",
+          tags: ["identity", "name-service"],
+        }),
+        expect.objectContaining({
+          protocol: "nns",
+          method: "profile",
+          kind: "query",
+          category: "token",
+          tags: ["identity", "name-service"],
+        }),
+      ]),
+    );
+
+    expect(registry.load([{ protocol: "nns", method: "profile" }])).toMatchObject([
+      {
+        params: {
+          address: {
+            description: "Address whose Nad Name Service identity is queried.",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("reads a primary name and preserves the requested address", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    const result = await registry.action("nns", "primaryName", ACCOUNT, { address: ACCOUNT });
+
+    expect(result).toEqual({
+      kind: "query",
+      protocol: "nns",
+      method: "primaryName",
+      data: { address: ACCOUNT, primaryName: "salmo.nad" },
+    });
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: NAD_NAME_SERVICE_ADDRESS,
+        functionName: "getPrimaryNameForAddress",
+        args: [ACCOUNT],
+      }),
+    );
+  });
+
+  it("normalizes the on-chain profile tuple into JSON-safe fields", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    const result = await registry.action("nns", "profile", ACCOUNT, { address: ACCOUNT });
+
+    expect(result).toEqual({
+      kind: "query",
+      protocol: "nns",
+      method: "profile",
+      data: {
+        address: ACCOUNT,
+        primaryName: "salmo.nad",
+        avatar: "ipfs://avatar",
+      },
+    });
+    expect(() => JSON.stringify(result)).not.toThrow();
+    expect(readContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "getProfileForAddress",
+        args: [ACCOUNT],
+      }),
+    );
+  });
+
+  it("also accepts a positional tuple profile from a lower-level mock client", async () => {
+    const { registry, readContract } = offlineRegistry();
+    readContract.mockImplementationOnce(async () => [ACCOUNT, "salmo.nad", "ipfs://avatar"]);
+
+    const result = await registry.action("nns", "profile", ACCOUNT, { address: ACCOUNT });
+
+    expect(result).toMatchObject({
+      kind: "query",
+      data: { address: ACCOUNT, primaryName: "salmo.nad", avatar: "ipfs://avatar" },
+    });
+  });
+
+  it.each([
+    [
+      "an object profile",
+      {
+        addr: "0x1111111111111111111111111111111111111111",
+        primaryName: "salmo.nad",
+        avatar: "ipfs://avatar",
+      },
+    ],
+    [
+      "a positional tuple profile",
+      ["0x1111111111111111111111111111111111111111", "salmo.nad", "ipfs://avatar"],
+    ],
+  ])("fails closed when %s belongs to another address", async (_shape, profile) => {
+    const { registry, readContract } = offlineRegistry();
+    readContract.mockImplementationOnce(async () => profile);
+
+    await expect(registry.action("nns", "profile", ACCOUNT, { address: ACCOUNT })).rejects.toThrow(
+      /returned address/i,
+    );
+  });
+
+  it("rejects invalid addresses before an RPC read", async () => {
+    const { registry, readContract } = offlineRegistry();
+
+    await expect(
+      registry.action("nns", "primaryName", ACCOUNT, { address: "not-an-address" }),
+    ).rejects.toThrow();
+    expect(readContract).not.toHaveBeenCalled();
+  });
+});

--- a/packages/protocols/nns/test/types.fixture.ts
+++ b/packages/protocols/nns/test/types.fixture.ts
@@ -1,0 +1,11 @@
+import type { AddressValue } from "@themoss/core";
+import type { NadNameService } from "../src/index.js";
+
+const validAddress: AddressValue = "0xcccccccccccccccccccccccccccccccccccccccc";
+const adapter = null as unknown as NadNameService;
+
+adapter.primaryName({ address: validAddress });
+adapter.profile({ address: validAddress });
+
+// @ts-expect-error Query parameters must contain a 20-byte hexadecimal address.
+adapter.primaryName({ address: "not-an-address" });

--- a/packages/protocols/nns/tsconfig.json
+++ b/packages/protocols/nns/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test", "test-online", "scripts"]
+}

--- a/packages/protocols/nns/vitest.config.ts
+++ b/packages/protocols/nns/vitest.config.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: { target: "es2022" },
+  test: {
+    include: ["test/**/*.test.ts", "test-online/live-mainnet.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@themoss/abi-tools": fileURLToPath(new URL("../../abi-tools/src/index.ts", import.meta.url)),
+      "@themoss/core": fileURLToPath(new URL("../../core/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/protocols/nns/vitest.online.config.ts
+++ b/packages/protocols/nns/vitest.online.config.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  esbuild: { target: "es2022" },
+  test: { include: ["test-online/abi-explorer.test.ts"] },
+  resolve: {
+    alias: {
+      "@themoss/abi-tools": src("../../abi-tools/src/index.ts"),
+      "@themoss/core": src("../../core/src/index.ts"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       '@themoss/protocol-nadfun':
         specifier: workspace:*
         version: link:../protocols/nadfun
+      '@themoss/protocol-nns':
+        specifier: workspace:*
+        version: link:../protocols/nns
       '@themoss/protocol-pancakeswap':
         specifier: workspace:*
         version: link:../protocols/pancakeswap
@@ -471,6 +474,31 @@ importers:
         version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
 
   packages/protocols/nadfun:
+    dependencies:
+      '@themoss/core':
+        specifier: workspace:*
+        version: link:../../core
+      viem:
+        specifier: ^2.54.3
+        version: 2.54.3(typescript@5.9.3)(zod@4.4.3)
+    devDependencies:
+      '@themoss/abi-tools':
+        specifier: workspace:*
+        version: link:../../abi-tools
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.23)(tsx@4.23.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@22.20.0)(tsx@4.23.0)
+
+  packages/protocols/nns:
     dependencies:
       '@themoss/core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- Reapply the NNS adapter additively on current main, preserving current protocol packages and security checks.
- Add read-only primaryName/profile Queries to the default MCP composition.
- Vendor the official NNS ABI verbatim and generate it deterministically offline.
- Replace the non-executable explorer semantic gate with honest ADR 0007 degraded verification: proxy slot, implementation bytecode hash, required Moss selectors, and explicit unverified MonadScan status.
- Move viem to runtime dependencies for the protocol package.

## Verification

- pnpm install --frozen-lockfile
- pnpm build
- pnpm typecheck
- pnpm test:offline
- NNS ABI online deployment-evidence suite (4/4)
- MCP server tests
- Biome check .