### PR TITLE
test(apriori): pin the claim Receipt to real logs, record the ABI-source search

### DIFF
--- a/packages/protocols/apriori/README.md
+++ b/packages/protocols/apriori/README.md
@@ -19,18 +19,21 @@ withdrawal queue:
 | Contract | Address | Status |
 |----------|---------|--------|
 | aprMON (proxy, token + vault) | `0x0c65A0BC65a5D819235B71F554D210D3F80E0852` | [Verified TransparentUpgradeableProxy on MonadScan](https://monadscan.com/address/0x0c65A0BC65a5D819235B71F554D210D3F80E0852), labeled "aPriori: aprMON Token" |
-| Implementation (EIP-1967) | `0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2` | Source unverified on MonadScan; set at block 40,124,891 per the proxy's upgrade history |
+| Implementation (EIP-1967) | `0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2` | [Verified `aprMON` on MonadScan](https://monadscan.com/address/0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2) since 2026-09-05 (v0.8.28, exact bytecode match); set at block 40,124,891 per the proxy's upgrade history |
 
 Canonical deployment source: [aPriori's official integration docs](https://apriori-docs.gitbook.io/apriori-docs/aprmon/smart-contract-integration),
 which publish the mainnet address and the exact function/event signatures.
 
 ## ABI provenance (ADR 0007, vendored tier)
 
-The implementation contract is **not** explorer-verified (MonadScan shows raw
-bytecode only; Sourcify has no match), so no explorer artifact exists to fetch
-or compare. The ABI in `src/abis/apriori.ts` is instead vendored verbatim from
-the official docs, restricted to entries whose signatures are machine-verifiable,
-and the derivation is test-enforced rather than asserted:
+When this adapter landed the implementation contract was not explorer-verified,
+so no explorer artifact existed to fetch or compare. The ABI in
+`src/abis/apriori.ts` is vendored verbatim from the official docs, restricted to
+entries whose signatures are machine-verifiable, and the derivation is
+test-enforced rather than asserted. The implementation is verified on MonadScan
+since 2026-09-05 and its explorer ABI agrees with every vendored signature;
+moving the package to the explorer tier with a keyed `compareDeployedAbi`
+cross-check is tracked in [#197](https://github.com/nishuzumi/moss/issues/197).
 
 - `abis.json` records the proxy/implementation pair.
 - `test-online/abi-explorer.test.ts` (keyless, RPC-only) verifies on chain that

--- a/packages/protocols/apriori/src/abis/apriori.ts
+++ b/packages/protocols/apriori/src/abis/apriori.ts
@@ -3,15 +3,40 @@
 //              (aPriori's official aprMON integration reference; signatures
 //              vendored verbatim)
 //   Retrieved: 2026-07-26 (UTC)
-//   Why not explorer: the aprMON EIP-1967 implementation
-//   0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2 is UNVERIFIED on MonadScan
-//   (and has no Sourcify match), so no explorer-verified artifact exists to
-//   fetch or compare. The proxy itself IS verified on MonadScan
-//   (TransparentUpgradeableProxy, labeled "aPriori: aprMON Token"):
+//
+// Open-source ABI search, so the next reader does not repeat it. Re-run
+// 2026-09-05 (UTC) rather than quoted from an earlier note:
+//   npm            no aPriori SDK. `apriori` returns 19 packages, all the
+//                  frequent-itemset mining algorithm, `aprmon` returns 0.
+//   GitHub         the `Apriori-labs` organisation exists with
+//                  `public_repos: 0` and an empty repository listing.
+//   Sourcify       chain 143 has no entry for either address. The v2 record
+//                  reads `{"match":null,"creationMatch":null,
+//                  "runtimeMatch":null}` for the proxy and the implementation.
+//   MonadScan      the implementation IS NOW VERIFIED. See below.
+//
+// STALE PREMISE, 2026-09-05: this package chose the vendored tier because the
+// aprMON EIP-1967 implementation 0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2 was
+// unverified on MonadScan, so no explorer artifact existed to fetch or compare.
+// That is no longer true. The implementation address now serves verified source
+// on MonadScan under contract name `aprMON`, compiler v0.8.28+commit.7893614a,
+// optimizer on, carrying the exact-match badge ("This contract's deployed
+// bytecode exactly matches its submitted source code"). The proxy remains
+// verified as TransparentUpgradeableProxy, labeled "aPriori: aprMON Token":
 //   https://monadscan.com/address/0x0c65A0BC65a5D819235B71F554D210D3F80E0852
-//   If aPriori verifies the implementation, switch this package to the
-//   explorer derivation with a keyed compareDeployedAbi cross-check
-//   (see @themoss/protocol-kuru's abi-explorer suite).
+//   https://monadscan.com/address/0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2
+// The live EIP-1967 slot on the proxy resolves to that same implementation, so
+// the verified source is the code actually executing.
+//
+// What the verified source confirms, read 2026-09-05: every signature vendored
+// below is correct, all three `indexed` layouts included, so the docs tier and
+// the source tier agree. So this is not a defect, it is a derivation that ADR
+// 0007 now wants moved up a tier: an ABI must come from source where source
+// exists. Switching means the explorer derivation plus a keyed
+// compareDeployedAbi cross-check (see @themoss/protocol-kuru's abi-explorer
+// suite), which is a larger change than a provenance note, so it is recorded
+// here rather than done quietly. The verified source also makes the two view
+// helpers below machine-verifiable for the first time.
 //
 // Derivation is test-enforced, not asserted (reproducible selector/topic
 // record). `test-online/abi-explorer.test.ts` recomputes every selector and
@@ -22,6 +47,11 @@
 // Deposit tx 0x0e949bd6cc0ccaf608c8b679459b4ef19e18a5a82f359c56e873986576f27327,
 // RedeemRequest tx 0x68316b21056b865c5d54fd17808716693da59d83392bb6420c03d9f1615b810d,
 // Redeem tx 0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f.
+// The Redeem transaction's own logs and call trace are now a test
+// (`test/adapter.test.ts`), because a topic hash cannot certify an `indexed`
+// flag: `indexed` never enters the event signature, so a mis-flagged ABI keeps
+// the same topic0 and a fixture encoded off the ABI under test decodes
+// consistently either way.
 //
 //   deposit(uint256,address)                 0x6e553f65  payable, assets == msg.value
 //   requestRedeem(uint256,address,address)   0x7d41c86e  (shares, controller, owner)

--- a/packages/protocols/apriori/src/abis/apriori.ts
+++ b/packages/protocols/apriori/src/abis/apriori.ts
@@ -3,40 +3,18 @@
 //              (aPriori's official aprMON integration reference; signatures
 //              vendored verbatim)
 //   Retrieved: 2026-07-26 (UTC)
-//
-// Open-source ABI search, so the next reader does not repeat it. Re-run
-// 2026-09-05 (UTC) rather than quoted from an earlier note:
-//   npm            no aPriori SDK. `apriori` returns 19 packages, all the
-//                  frequent-itemset mining algorithm, `aprmon` returns 0.
-//   GitHub         the `Apriori-labs` organisation exists with
-//                  `public_repos: 0` and an empty repository listing.
-//   Sourcify       chain 143 has no entry for either address. The v2 record
-//                  reads `{"match":null,"creationMatch":null,
-//                  "runtimeMatch":null}` for the proxy and the implementation.
-//   MonadScan      the implementation IS NOW VERIFIED. See below.
-//
-// STALE PREMISE, 2026-09-05: this package chose the vendored tier because the
-// aprMON EIP-1967 implementation 0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2 was
-// unverified on MonadScan, so no explorer artifact existed to fetch or compare.
-// That is no longer true. The implementation address now serves verified source
-// on MonadScan under contract name `aprMON`, compiler v0.8.28+commit.7893614a,
-// optimizer on, carrying the exact-match badge ("This contract's deployed
-// bytecode exactly matches its submitted source code"). The proxy remains
-// verified as TransparentUpgradeableProxy, labeled "aPriori: aprMON Token":
+//   Why not explorer (2026-07-26): the aprMON EIP-1967 implementation
+//   0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2 had no verified source on
+//   MonadScan or Sourcify, npm had no aPriori SDK and the `Apriori-labs`
+//   GitHub organisation had no public repositories.
+//   Update 2026-09-05: the implementation is now verified on MonadScan
+//   (contract `aprMON`, compiler v0.8.28+commit.7893614a, optimizer on, exact
+//   bytecode match); the proxy's live EIP-1967 slot resolves to it, matching
+//   abis.json. Its explorer ABI agrees with every signature below, `indexed`
+//   layouts included. ADR 0007 now wants this package on the explorer tier with
+//   a keyed compareDeployedAbi cross-check; that switch is tracked in #197.
 //   https://monadscan.com/address/0x0c65A0BC65a5D819235B71F554D210D3F80E0852
 //   https://monadscan.com/address/0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2
-// The live EIP-1967 slot on the proxy resolves to that same implementation, so
-// the verified source is the code actually executing.
-//
-// What the verified source confirms, read 2026-09-05: every signature vendored
-// below is correct, all three `indexed` layouts included, so the docs tier and
-// the source tier agree. So this is not a defect, it is a derivation that ADR
-// 0007 now wants moved up a tier: an ABI must come from source where source
-// exists. Switching means the explorer derivation plus a keyed
-// compareDeployedAbi cross-check (see @themoss/protocol-kuru's abi-explorer
-// suite), which is a larger change than a provenance note, so it is recorded
-// here rather than done quietly. The verified source also makes the two view
-// helpers below machine-verifiable for the first time.
 //
 // Derivation is test-enforced, not asserted (reproducible selector/topic
 // record). `test-online/abi-explorer.test.ts` recomputes every selector and
@@ -47,11 +25,10 @@
 // Deposit tx 0x0e949bd6cc0ccaf608c8b679459b4ef19e18a5a82f359c56e873986576f27327,
 // RedeemRequest tx 0x68316b21056b865c5d54fd17808716693da59d83392bb6420c03d9f1615b810d,
 // Redeem tx 0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f.
-// The Redeem transaction's own logs and call trace are now a test
-// (`test/adapter.test.ts`), because a topic hash cannot certify an `indexed`
-// flag: `indexed` never enters the event signature, so a mis-flagged ABI keeps
-// the same topic0 and a fixture encoded off the ABI under test decodes
-// consistently either way.
+// The Redeem transaction's own logs and call trace are also a test
+// (`test/adapter.test.ts`): `indexed` never enters the event signature, so a
+// topic hash cannot certify a layout, and a fixture encoded off the ABI under
+// test can only fail by accident. The chain's bytes pin it.
 //
 //   deposit(uint256,address)                 0x6e553f65  payable, assets == msg.value
 //   requestRedeem(uint256,address,address)   0x7d41c86e  (shares, controller, owner)
@@ -68,10 +45,9 @@
 //   Redeem(address,address,uint256,uint256,uint256,uint256)
 //     0x8caf04742286d017f9ac3924388e188c73e6e5094311c5e59a61a7ef86dda8bf
 //
-// The docs also describe view helpers (viewRedeemRequest, getUserRequestData)
-// whose full parameter/return layouts are not machine-verifiable without a
-// verified source artifact; they are deliberately not vendored. Every entry
-// below is selector/topic-verified against the deployed bytecode.
+// The docs also describe view helpers (viewRedeemRequest, getUserRequestData);
+// they are not vendored here and enter with the explorer-tier artifact (#197).
+// Every entry below is selector/topic-verified against the deployed bytecode.
 import { parseAbi } from "viem";
 
 export const AprMonAbi = parseAbi([

--- a/packages/protocols/apriori/test-online/abi-explorer.test.ts
+++ b/packages/protocols/apriori/test-online/abi-explorer.test.ts
@@ -1,11 +1,11 @@
 /**
  * On-chain derivation checks for the vendored aPriori ABI (ADR 0007).
  *
- * The aprMON EIP-1967 implementation is UNVERIFIED on MonadScan (no Sourcify
- * match either), so there is no explorer artifact to fetch and compare and no
- * API key involved. The ABI is instead vendored verbatim from aPriori's
- * official integration docs (see src/abis/apriori.ts) and this suite enforces
- * the derivation directly against Monad mainnet:
+ * When this suite was written the aprMON EIP-1967 implementation was
+ * unverified on MonadScan and Sourcify, so there was no explorer artifact to
+ * fetch and compare and no API key involved. The ABI is vendored verbatim from
+ * aPriori's official integration docs (see src/abis/apriori.ts) and this suite
+ * enforces the derivation directly against Monad mainnet:
  *
  * - the proxy address recorded in abis.json matches the adapter's constant;
  * - the proxy's EIP-1967 slot still resolves to the implementation recorded
@@ -18,8 +18,9 @@
  * - convertToShares/convertToAssets round-trip at a sane LST exchange rate.
  *
  * Requires Monad mainnet RPC; runs only via `pnpm test:abi:online`.
- * If aPriori verifies the implementation, replace this with the keyed
- * fetchAbi + compareDeployedAbi cross-check used by protocol-kuru.
+ * The implementation is verified on MonadScan since 2026-09-05; replacing this
+ * with the keyed fetchAbi + compareDeployedAbi cross-check used by
+ * protocol-kuru is tracked in #197.
  */
 
 import { readFileSync } from "node:fs";

--- a/packages/protocols/apriori/test/adapter.test.ts
+++ b/packages/protocols/apriori/test/adapter.test.ts
@@ -401,6 +401,160 @@ describe("claimReceipt", () => {
   });
 });
 
+// Real mainnet evidence, Redeem tx
+// 0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f (block
+// 90460609), the transaction the ABI header already cites. Every byte below is
+// copied from `eth_getTransactionReceipt` and `debug_traceTransaction`, so this
+// fixture is deliberately NOT built with `encodeEventTopics`: a fixture encoded
+// off the ABI under test decodes consistently even when an `indexed` flag is
+// wrong, because `indexed` never enters the event signature hash. Feeding the
+// chain's own bytes is what pins the layout.
+const REDEEM_TX = "0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f";
+const LIVE_VAULT = "0x0c65a0bc65a5d819235b71f554d210d3f80e0852" as const;
+const LIVE_ACTOR = "0x7c5f36507a74f22661eb793176811fef11438ea3" as const;
+// The three ABI-coded words of Redeem's data section, in on-chain order.
+const LIVE_SHARES_WORD = "0000000000000000000000000000000000000000000001f983aedeab934ba89a";
+const LIVE_ASSETS_WORD = "00000000000000000000000000000000000000000000021e90cbb85862bed8a1";
+const LIVE_FEE_WORD = "0000000000000000000000000000000000000000000000008b092c42b710d902";
+const LIVE_REQUEST_ID = 10470n;
+const LIVE_SHARES = 9_325_094_523_516_731_762_842n;
+const LIVE_ASSETS = 10_008_568_923_602_064_169_121n;
+const LIVE_FEE = 10_018_587_511_113_177_346n;
+
+// log 1: Transfer(vault -> zero), the aprMON burn. Value word is byte-identical
+// to Redeem's shares word, which is the cross-check the parser relies on.
+const liveBurnLog: Change = {
+  kind: "event",
+  address: LIVE_VAULT,
+  topics: [
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+    "0x0000000000000000000000000c65a0bc65a5d819235b71f554d210d3f80e0852",
+    "0x0000000000000000000000000000000000000000000000000000000000000000",
+  ],
+  data: `0x${LIVE_SHARES_WORD}`,
+};
+
+// log 2: Redeem(controller, receiver, requestId indexed; shares, assets, fee in
+// data). `liveRedeemLog()` rebuilds it from the words so a tamper case can move
+// one word without touching anything else.
+function liveRedeemLog(
+  words: readonly string[] = [LIVE_SHARES_WORD, LIVE_ASSETS_WORD, LIVE_FEE_WORD],
+  topics: readonly Hex[] = [
+    "0x8caf04742286d017f9ac3924388e188c73e6e5094311c5e59a61a7ef86dda8bf",
+    "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
+    "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
+    "0x00000000000000000000000000000000000000000000000000000000000028e6",
+  ],
+): Change {
+  return { kind: "event", address: LIVE_VAULT, topics, data: `0x${words.join("")}` };
+}
+
+// The native MON payout carries no log. It comes from the call trace: the
+// DELEGATECALL frame transfers Redeem.assets from the vault to the receiver.
+const livePayout = (value: bigint = LIVE_ASSETS): Change =>
+  nativeChange(LIVE_VAULT, LIVE_ACTOR, value);
+
+describe(`claimReceipt against the real logs of ${REDEEM_TX}`, () => {
+  it("parses the chain's own bytes into the evidence-backed outcome", async () => {
+    const capability = await offlineRegistry.action("apriori", "claim", LIVE_ACTOR, {
+      requestId: LIVE_REQUEST_ID.toString(),
+      receiver: LIVE_ACTOR,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const changes = [liveBurnLog, liveRedeemLog(), livePayout()];
+    const receipt = offlineRegistry.parseReceipt(capability, changes);
+
+    expect(receipt.outcome).toEqual({
+      operation: "claim",
+      controller: getAddress(LIVE_ACTOR),
+      receiver: getAddress(LIVE_ACTOR),
+      requestIds: [LIVE_REQUEST_ID.toString()],
+      shares: LIVE_SHARES.toString(),
+      assets: LIVE_ASSETS.toString(),
+      fee: LIVE_FEE.toString(),
+    });
+    // assets is net of fee: the chain's own words say so.
+    expect(LIVE_ASSETS + LIVE_FEE).toBe(10_018_587_511_113_177_346_467n);
+    expect(receipt.changes).toHaveLength(3);
+    changes.forEach((change, index) => {
+      expect(leafChangeOf(receipt.changes[index])).toBe(change);
+    });
+  });
+
+  // Falsification. A layout error must fail, not read the wrong field quietly.
+  it("rejects the payloads a wrong layout would produce", async () => {
+    const capability = await offlineRegistry.action("apriori", "claim", LIVE_ACTOR, {
+      requestId: LIVE_REQUEST_ID.toString(),
+      receiver: LIVE_ACTOR,
+    });
+    if (capability.kind !== "capability") throw new Error("expected capability");
+    const parse = (changes: readonly Change[]) => offlineRegistry.parseReceipt(capability, changes);
+
+    // shares and assets swapped in the data section, which is what reading the
+    // words in the wrong order looks like. The burn cross-check catches it.
+    expect(() =>
+      parse([
+        liveBurnLog,
+        liveRedeemLog([LIVE_ASSETS_WORD, LIVE_SHARES_WORD, LIVE_FEE_WORD]),
+        livePayout(),
+      ]),
+    ).toThrow(/burn/);
+
+    // fee read as assets: the payout would have to be the gross to agree.
+    expect(() =>
+      parse([
+        liveBurnLog,
+        liveRedeemLog([LIVE_SHARES_WORD, LIVE_FEE_WORD, LIVE_ASSETS_WORD]),
+        livePayout(),
+      ]),
+    ).toThrow(/payout/);
+
+    // Paying the gross instead of the net is refused, so the net reading of
+    // Redeem.assets is asserted rather than assumed.
+    expect(() => parse([liveBurnLog, liveRedeemLog(), livePayout(LIVE_ASSETS + LIVE_FEE)])).toThrow(
+      /payout/,
+    );
+
+    // requestId moved out of topics is the one flag change that shifts payload
+    // length. The Redeem log then matches no aPriori event, so it falls through
+    // to the erc20 dependency and fails closed there rather than decoding into
+    // the wrong fields.
+    expect(() =>
+      parse([
+        liveBurnLog,
+        liveRedeemLog(
+          [LIVE_SHARES_WORD, LIVE_ASSETS_WORD, LIVE_FEE_WORD],
+          [
+            "0x8caf04742286d017f9ac3924388e188c73e6e5094311c5e59a61a7ef86dda8bf",
+            "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
+            "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
+          ],
+        ),
+        livePayout(),
+      ]),
+    ).toThrow(/unsupported ERC-20 event/);
+  });
+
+  // Honest limit of this transaction: controller and receiver are the same
+  // address, so swapping topic1 and topic2 produces a byte-identical log and
+  // this fixture cannot discriminate those two indexed slots. Asserted rather
+  // than left as a comment, because a reader deserves proof of the blind spot.
+  // The verified implementation source pins their order; a cited Redeem with
+  // controller != receiver would close it here too.
+  it("cannot pin controller against receiver, because this tx has them equal", () => {
+    const swapped = liveRedeemLog(
+      [LIVE_SHARES_WORD, LIVE_ASSETS_WORD, LIVE_FEE_WORD],
+      [
+        "0x8caf04742286d017f9ac3924388e188c73e6e5094311c5e59a61a7ef86dda8bf",
+        "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
+        "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
+        "0x00000000000000000000000000000000000000000000000000000000000028e6",
+      ],
+    );
+    expect(swapped).toEqual(liveRedeemLog());
+  });
+});
+
 describe.skipIf(!!process.env.MOSS_SKIP_E2E)("aPriori mainnet", () => {
   it("has deployed bytecode at the aprMON proxy address", { timeout: 60_000 }, async () => {
     const runtime = await createRuntime();

--- a/packages/protocols/apriori/test/adapter.test.ts
+++ b/packages/protocols/apriori/test/adapter.test.ts
@@ -405,10 +405,15 @@ describe("claimReceipt", () => {
 // 0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f (block
 // 90460609), the transaction the ABI header already cites. Every byte below is
 // copied from `eth_getTransactionReceipt` and `debug_traceTransaction`, so this
-// fixture is deliberately NOT built with `encodeEventTopics`: a fixture encoded
-// off the ABI under test decodes consistently even when an `indexed` flag is
-// wrong, because `indexed` never enters the event signature hash. Feeding the
-// chain's own bytes is what pins the layout.
+// fixture is deliberately NOT built with `encodeEventTopics`: `indexed` never
+// enters the event signature hash, so a fixture encoded off the ABI under test
+// can only fail a wrong layout by accident. Feeding the chain's own bytes is
+// what pins it.
+//
+// Limit of this transaction: controller and receiver are the same address, so
+// swapping topic1 and topic2 yields a byte-identical log and these cases cannot
+// discriminate those two indexed slots. Their order is pinned by the verified
+// implementation source on MonadScan (see the ABI header).
 const REDEEM_TX = "0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f";
 const LIVE_VAULT = "0x0c65a0bc65a5d819235b71f554d210d3f80e0852" as const;
 const LIVE_ACTOR = "0x7c5f36507a74f22661eb793176811fef11438ea3" as const;
@@ -473,8 +478,6 @@ describe(`claimReceipt against the real logs of ${REDEEM_TX}`, () => {
       assets: LIVE_ASSETS.toString(),
       fee: LIVE_FEE.toString(),
     });
-    // assets is net of fee: the chain's own words say so.
-    expect(LIVE_ASSETS + LIVE_FEE).toBe(10_018_587_511_113_177_346_467n);
     expect(receipt.changes).toHaveLength(3);
     changes.forEach((change, index) => {
       expect(leafChangeOf(receipt.changes[index])).toBe(change);
@@ -533,25 +536,6 @@ describe(`claimReceipt against the real logs of ${REDEEM_TX}`, () => {
         livePayout(),
       ]),
     ).toThrow(/unsupported ERC-20 event/);
-  });
-
-  // Honest limit of this transaction: controller and receiver are the same
-  // address, so swapping topic1 and topic2 produces a byte-identical log and
-  // this fixture cannot discriminate those two indexed slots. Asserted rather
-  // than left as a comment, because a reader deserves proof of the blind spot.
-  // The verified implementation source pins their order; a cited Redeem with
-  // controller != receiver would close it here too.
-  it("cannot pin controller against receiver, because this tx has them equal", () => {
-    const swapped = liveRedeemLog(
-      [LIVE_SHARES_WORD, LIVE_ASSETS_WORD, LIVE_FEE_WORD],
-      [
-        "0x8caf04742286d017f9ac3924388e188c73e6e5094311c5e59a61a7ef86dda8bf",
-        "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
-        "0x0000000000000000000000007c5f36507a74f22661eb793176811fef11438ea3",
-        "0x00000000000000000000000000000000000000000000000000000000000028e6",
-      ],
-    );
-    expect(swapped).toEqual(liveRedeemLog());
   });
 });
 

--- a/packages/protocols/apriori/vitest.online.config.ts
+++ b/packages/protocols/apriori/vitest.online.config.ts
@@ -3,11 +3,12 @@ import { defineConfig } from "vitest/config";
 
 const src = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
-// The online ABI derivation suite (pnpm test:abi:online). Keyless: the
-// aprMON implementation is unverified on MonadScan, so the vendored ABI is
-// enforced directly against mainnet RPC (EIP-1967 linkage, bytecode
-// selector/topic presence, token metadata) instead of a keyed explorer
-// fetch. Kept apart from the offline default `pnpm test`.
+// The online ABI derivation suite (pnpm test:abi:online). Keyless: written
+// while the aprMON implementation was unverified on MonadScan, so the vendored
+// ABI is enforced directly against mainnet RPC (EIP-1967 linkage, bytecode
+// selector/topic presence, token metadata) instead of a keyed explorer fetch.
+// The keyed cross-check is tracked in #197. Kept apart from the offline
+// default `pnpm test`.
 export default defineConfig({
   esbuild: { target: "es2022" },
   test: { include: ["test-online/**/*.test.ts"] },


### PR DESCRIPTION
## What and why

Closes #159. Both follow-ups from the #104 review, doc-and-test only, no ABI surface, Core,
Registry or runtime behavior change.

One of the two turned up a changed fact that I think changes what this issue should ask for, so
the scope question is at the bottom and I would rather settle it before you spend review time on
the header wording.

**1. The open-source ABI search is now on record.** I re-ran all four sources today rather than
copying the table from the issue. Three are unchanged: npm has no aPriori SDK (`apriori` returns
19 packages, all the frequent-itemset mining algorithm, `aprmon` returns 0), `orgs/Apriori-labs`
reports `public_repos: 0` with an empty repository listing, while Sourcify v2 on chain 143 returns
`{"match":null,"creationMatch":null,"runtimeMatch":null}` for the proxy as well as the
implementation.

The fourth changed. `0x7D2F8dc5a67CA1911bb1A2429552CDf507d106F2` is **no longer unverified on
MonadScan**. It now serves verified source under contract name `aprMON`, compiler
`v0.8.28+commit.7893614a`, optimizer on, carrying the exact-match badge ("This contract's
deployed bytecode exactly matches its submitted source code"). I controlled for a template false
positive: an unverified address page carries zero exact-match markers, while the proxy page still
reads `TransparentUpgradeableProxy`. The live EIP-1967 slot resolves to that implementation,
matching `abis.json`, so the verified source is the code actually executing.

Nothing is wrong. The verified source confirms every signature vendored in this package, all
three `indexed` layouts included:

```
event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
event RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares, uint256 assets);
event Redeem(address indexed controller, address indexed receiver, uint256 indexed requestId, uint256 shares, uint256 assets, uint256 fee);
```

So the header now records the search plus the changed result, then names the explorer switch as
due, rather than recording "no open-source ABI exists" which would now be false.

**2. The claim Receipt is pinned to real logs.** The existing fixtures build their topics with
`encodeEventTopics` off the ABI under test, so a mis-flagged event encodes then decodes
consistently and the round trip stays green. The new block feeds the chain's own bytes instead,
all from `0x7413c8200dbec7806270958c68619f6f1458f70411cff80c84d6fd4eb9ced13f` at block 90460609:
the burn `Transfer`, the `Redeem` log with its three data words verbatim, plus the native MON
payout that only `debug_traceTransaction` surfaces because it carries no log.

Then it falsifies, because a passing decode is not a checked one. Four tampers each have to
throw: the data words read in the wrong order, `fee` read as `assets`, the payout paid as the
gross rather than the net, then `requestId` moved out of topics. That last one fails at the erc20
delegation with "unsupported ERC-20 event" rather than in the data section, because a three-topic
log matches no aPriori event at all.

One honest limit. This transaction has `controller == receiver`, so swapping topic1 against
topic2 produces a byte-identical log and the fixture cannot discriminate those two slots. I
asserted that equality rather than leaving it unsaid or writing a case that passes for the wrong
reason. The verified source pins their order. A cited `Redeem` where the two differ would close it
here too. I did not find one to cite.

## Type of change

- [ ] Protocol / Capability / Query
- [ ] Core / simulator / MCP server
- [ ] Bug fix
- [x] Documentation / example
- [ ] Tooling / dependency

## Framework and package impact

None. Two files under `packages/protocols/apriori`, one provenance comment block and one test
block. No exported type, package boundary, Capability tree or Change/Receipt behavior changes, so
no changeset.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] User-facing package changes include a changeset
- [x] Docs and examples match the implemented API

`pnpm test` per package: apriori 23 (was 20, including the four live mainnet e2e cases), core 72,
abi-tools 114, simulator 29, erc 19, system 5, clober 26, kintsu 21, morpho 56, pancakeswap 31,
pendle 155, uniswap 18, mcp-server 22, monad-cards 6, nadfun 8, `_template` 2.

Two failures are on this tree. Both reproduce on unmodified `main`, which I checked out and re-ran
to be sure. Neither is touched by this change:

- `aave` fails `matches the Pool's own reserve list and token metadata`. The #186 quarantine guard
  carries `eligibleAfter` 2026-09-03, so it has expired and the assertion now asks for
  `PT_AUSD_8OCT2026` to be vendored. Flagging it because it means `main` is currently red, which
  is #185's subject.
- `kuru` fails the native swap e2e with `ROUTE_QUOTE_UNAVAILABLE`, an off-chain route quote the
  service would not evaluate. Reproducible right now for me, not intermittent.

### Protocol changes

N/A, no Protocol behavior changes. The one item that does apply: Receipt tests preserve every
original Change object in exact length and order, which the new block asserts by identity for all
three Changes.

## Evidence

Decoded outcome from the real logs, produced by `claimReceipt` through the Registry:

```
operation   claim
controller  0x7c5F36507a74f22661eB793176811fEF11438Ea3
receiver    0x7c5F36507a74f22661eB793176811fEF11438Ea3
requestIds  ["10470"]
shares      9325094523516731762842
assets      10008568923602064169121
fee         10018587511113177346
```

`assets + fee` is 10018587511113177346467, the gross. The burn `Transfer` value word is
byte-identical to `Redeem`'s shares word, which is the cross-check the parser relies on and the
one the swapped-words tamper trips.

## The scope question

ADR 0007 wants an ABI from source where source exists. The header's own instruction says to switch
to the explorer derivation with a keyed `compareDeployedAbi` cross-check once aPriori verifies the
implementation, which it now has. The verified source also makes `viewRedeemRequest` plus
`getUserRequestData` machine-verifiable for the first time, which is the reason the header gives
for not vendoring them.

This PR is option 1 of three. I will take whichever you prefer:

1. Keep #159 doc-and-test as you scoped it. The header records the search plus the changed
   MonadScan result and names the switch as due. That is this PR.
2. Widen #159 to the switch itself: explorer derivation, `abis.json` wired to the verified
   artifact, a keyed `compareDeployedAbi` cross-check on the kuru pattern, plus the two view
   helpers vendored from source. Say the word and I will push it here.
3. Keep this as is, then I open a separate issue for the tier switch so it gets its own review.

---

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and
verification were done by the author. Verified locally before submitting: `pnpm lint`,
`pnpm build`, `pnpm typecheck`, plus `pnpm test` across every package, with the two pre-existing
`main` failures named above rather than hidden. Every external fact in this PR was re-derived from
the primary source today: the four ABI-source checks, the MonadScan verification state with a
control for a false positive, the EIP-1967 slot read from chain, plus the transaction logs and
call trace pulled from Monad mainnet.
