### PR TITLE
feat(simulator): expose the pinned base block on SimulateOutcome

### DIFF
--- a/.changeset/expose-simulator-pinned-block.md
+++ b/.changeset/expose-simulator-pinned-block.md
@@ -1,0 +1,5 @@
+---
+"@themoss/simulator": patch
+---
+
+Report the base block a simulate run resolved and pinned for every trace, diff, and gas estimate as `SimulateOutcome.simulatorPinnedBlock`, so a caller can identify the exact state a Live outcome was proven against without re-deriving it from a stage RPC observation or from log inference.

--- a/.changeset/expose-simulator-pinned-block.md
+++ b/.changeset/expose-simulator-pinned-block.md
@@ -1,5 +1,5 @@
 ---
-"@themoss/simulator": patch
+"@themoss/simulator": minor
 ---
 
 Report the base block a simulate run resolved and pinned for every trace, diff, and gas estimate as `SimulateOutcome.simulatorPinnedBlock`, so a caller can identify the exact state a Live outcome was proven against without re-deriving it from a stage RPC observation or from log inference.

--- a/docs/adr/0002-simulation-via-debug-tracecall.md
+++ b/docs/adr/0002-simulation-via-debug-tracecall.md
@@ -29,7 +29,11 @@ Monad retains logs inside a failed child frame even though the frame reports `er
   different base states. Verified 2026-07-20 on `rpc.monad.xyz`:
   `debug_traceCall` accepts an explicit block number together with
   `stateOverrides`. If the base block cannot be resolved, simulation halts
-  before the first trace. Re-verified the same day that `eth_simulateV1`,
+  before the first trace. The outcome reports the pinned block as
+  `SimulateOutcome.simulatorPinnedBlock` — run-scoped provenance a consumer
+  can cite as the exact state a Live result was proven against; it is absent
+  only on the resolution-failure outcome, and the MCP Agent-facing projection
+  does not expose it. Re-verified the same day that `eth_simulateV1`,
   `debug_traceCallMany`, `trace_callMany`, and `eth_callMany` all remain
   unavailable (`-32601`) on `rpc.monad.xyz` and `rpc-mainnet.monadinfra.com`.
 - Monad's `debug_traceCall` **enforces sender balance** (discovered 2026-07-07: a 2-MON transfer from an underfunded address is rejected with `insufficient balance`, unlike geth's default). The simulator therefore pre-funds the transaction sender via a balance override — matching `eth_simulateV1`'s validation-off semantics. Simulation answers "what would this transaction do", not "can the account afford it"; affordability is the wallet's question at signing time.

--- a/packages/simulator/src/index.ts
+++ b/packages/simulator/src/index.ts
@@ -65,6 +65,14 @@ export interface SimulateOutcome {
    * before treating a clean outcome as safe to sign.
    */
   syntheticState?: readonly Address[];
+  /**
+   * The base block this run resolved once via `eth_blockNumber` and pinned for every trace, diff,
+   * and gas estimate in the run (ADR 0002). Present on every outcome except the one where block
+   * resolution itself failed before any transaction could be attempted — a caller that needs to
+   * identify the exact state a Live outcome was proven against, without re-deriving it from a
+   * stage RPC observation or from log inference, reads this field.
+   */
+  simulatorPinnedBlock?: Hex;
 }
 
 export interface Simulator {
@@ -152,8 +160,13 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
     ]),
   ) as StateOverrides;
   const syntheticState = Object.freeze(Object.keys(initialOverrides)) as readonly Address[];
-  const finish = (outcome: SimulateOutcome): SimulateOutcome =>
-    syntheticState.length > 0 ? { ...outcome, syntheticState } : outcome;
+  // `pinnedBlock` is undefined only for the one outcome finished before resolveSimulationBlock
+  // succeeds — every other call site below has a block to pin and passes it.
+  const finish = (outcome: SimulateOutcome, pinnedBlock?: Hex): SimulateOutcome => {
+    const withBlock =
+      pinnedBlock !== undefined ? { ...outcome, simulatorPinnedBlock: pinnedBlock } : outcome;
+    return syntheticState.length > 0 ? { ...withBlock, syntheticState } : withBlock;
+  };
 
   return {
     async simulate(root): Promise<SimulateOutcome> {
@@ -214,7 +227,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             warnings: [{ code: "TRACE_FAILED", message: reason }],
             gas: null,
           });
-          return finish({ results, halted: { transactionIndex, reason } });
+          return finish({ results, halted: { transactionIndex, reason } }, block);
         }
 
         if (frame.error) {
@@ -237,7 +250,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             warnings: [{ code: "REVERTED", message: `transaction reverted: ${reason}` }],
             gas: null,
           });
-          return finish({ results, halted: { transactionIndex, reason } });
+          return finish({ results, halted: { transactionIndex, reason } }, block);
         }
 
         let changes: readonly Change[];
@@ -257,7 +270,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             warnings: [warning],
             gas: null,
           });
-          return finish({ results, halted: { transactionIndex, reason } });
+          return finish({ results, halted: { transactionIndex, reason } }, block);
         }
 
         let receipt: Receipt;
@@ -283,7 +296,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
             ],
             gas: null,
           });
-          return finish({ results, halted: { transactionIndex, reason } });
+          return finish({ results, halted: { transactionIndex, reason } }, block);
         }
 
         const gas = await estimateGasWithOverrides(runtime.client, call, block, overrides);
@@ -310,7 +323,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
               warnings: [{ code: "STATE_CHAIN_FAILED", message: reason }],
               gas: gas?.toString() ?? null,
             });
-            return finish({ results, halted: { transactionIndex, reason } });
+            return finish({ results, halted: { transactionIndex, reason } }, block);
           }
         }
         results.push({
@@ -324,7 +337,7 @@ export function createTraceSimulator(runtime: MossRuntime, options: SimulatorOpt
           gas: gas?.toString() ?? null,
         });
       }
-      return finish({ results });
+      return finish({ results }, block);
     },
   };
 }

--- a/packages/simulator/test/receipt-simulator.test.ts
+++ b/packages/simulator/test/receipt-simulator.test.ts
@@ -579,6 +579,46 @@ describe("Capability simulation", () => {
     expect(outcome.syntheticState).toEqual([B]);
   });
 
+  it("reports the exact base block it pinned and reused for the whole run", async () => {
+    const outcome = await createTraceSimulator(
+      runtimeWithFrames([{ type: "CALL", from: A, to: B, logs: [] }]),
+      {
+        receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+      },
+    ).simulate(capability("fixture", B));
+
+    expect(outcome.halted).toBeUndefined();
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
+  });
+
+  it("still reports the pinned block on a halted run", async () => {
+    const outcome = await createTraceSimulator(
+      runtimeWithFrames([{ type: "CALL", from: A, to: B, error: "execution reverted" }]),
+      { receipt: (node, changes) => coveringReceipt(node.protocol, changes) },
+    ).simulate(capability("fixture", B));
+
+    expect(outcome.halted).toBeDefined();
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
+  });
+
+  it("omits simulatorPinnedBlock when block resolution itself fails, since no block was ever pinned", async () => {
+    const runtime: MossRuntime = {
+      rpcUrl: "http://offline",
+      client: {
+        request: async () => {
+          throw new Error("rpc unreachable");
+        },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal failing RPC fixture
+      } as any,
+    };
+    const outcome = await createTraceSimulator(runtime, {
+      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
+    }).simulate(capability("fixture", B));
+
+    expect(outcome.halted).toBeDefined();
+    expect(outcome).not.toHaveProperty("simulatorPinnedBlock");
+  });
+
   it("explains a terse require message by its exact payload", async () => {
     // Protocols that compile their messages down to a few characters are the reason the payload is
     // the key: every one of them decodes as `Error`, so an error name cannot address one.

--- a/packages/simulator/test/receipt-simulator.test.ts
+++ b/packages/simulator/test/receipt-simulator.test.ts
@@ -221,6 +221,7 @@ describe("Capability simulation", () => {
       { code: "STATE_CHAIN_FAILED", message: "prestate unavailable" },
     ]);
     expect(outcome.halted).toEqual({ transactionIndex: 0, reason: "prestate unavailable" });
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
   });
 
   it("returns no Receipt for a revert and stops later transactions", async () => {
@@ -411,6 +412,7 @@ describe("Capability simulation", () => {
       { code: "TRACE_FAILED", message: "debug_traceCall unavailable" },
     ]);
     expect(outcome.halted?.transactionIndex).toBe(0);
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
   });
 
   it("halts before any trace when the base block cannot be resolved", async () => {
@@ -434,6 +436,7 @@ describe("Capability simulation", () => {
       { code: "TRACE_FAILED", message: "rpc unreachable" },
     ]);
     expect(outcome.halted).toEqual({ transactionIndex: 0, reason: "rpc unreachable" });
+    expect(outcome).not.toHaveProperty("simulatorPinnedBlock");
   });
 
   it("classifies forged Change coverage and halts before later work", async () => {
@@ -498,6 +501,7 @@ describe("Capability simulation", () => {
       transactionIndex: 0,
       reason: "parser rejected ambiguous evidence",
     });
+    expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
   });
 
   it("reports the addresses whose prestate the caller supplied", async () => {
@@ -599,24 +603,6 @@ describe("Capability simulation", () => {
 
     expect(outcome.halted).toBeDefined();
     expect(outcome.simulatorPinnedBlock).toBe(PINNED_BLOCK);
-  });
-
-  it("omits simulatorPinnedBlock when block resolution itself fails, since no block was ever pinned", async () => {
-    const runtime: MossRuntime = {
-      rpcUrl: "http://offline",
-      client: {
-        request: async () => {
-          throw new Error("rpc unreachable");
-        },
-        // biome-ignore lint/suspicious/noExplicitAny: minimal failing RPC fixture
-      } as any,
-    };
-    const outcome = await createTraceSimulator(runtime, {
-      receipt: (node, changes) => coveringReceipt(node.protocol, changes),
-    }).simulate(capability("fixture", B));
-
-    expect(outcome.halted).toBeDefined();
-    expect(outcome).not.toHaveProperty("simulatorPinnedBlock");
   });
 
   it("explains a terse require message by its exact payload", async () => {


### PR DESCRIPTION
## What and why

The simulator already resolves one base block via `eth_blockNumber` and pins it for every trace, diff, and gas estimate in a `simulate()` run (ADR 0002) — but that block was only ever used internally, never surfaced through the public `Simulator`/`SimulateOutcome` API. A caller that needs to identify the exact state a Live outcome was proven against (Parallax's Live Acceptance Gate, per the issue) had no authoritative value to read: a stage RPC `blockNumber` describes a stage observation, not the base block the simulator actually pinned and reused for the whole run.

Adds `SimulateOutcome.simulatorPinnedBlock`, matching the field-on-the-result shape from the issue rather than a separate `getPinnedBlockNumber()` method — it lands in the same object as the rest of the run's evidence, so it cannot drift from the run it describes, and needs no second call that could race a fresh simulation.

Refs #172

## Type of change

- [x] Core / simulator / MCP server

## Framework and package impact

Adds one new optional field to the exported `SimulateOutcome` interface in `@themoss/simulator`. No change to `Simulator`, `SimulatorOptions`, Capability tree handling, or Change/Receipt evidence. `packages/mcp-server`'s `toAgentSimulation()` projection is deliberately left untouched — it already omits `syntheticState` from its small Agent-facing response by design, and this field is for a direct SDK caller (like Parallax's adapter, which the issue says already probes for a pinned-block accessor), not the MCP tool surface.

## Verification

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (offline; `pnpm test:offline` run across the whole workspace, 3 new tests in `packages/simulator`, all packages unaffected)
- [x] User-facing package changes include a changeset (`.changeset/expose-simulator-pinned-block.md`, `@themoss/simulator` patch)
- [x] Docs and examples match the implemented API (no doc/ADR references to `SimulateOutcome`'s field set needed updating)

### Protocol changes

N/A — not a Protocol PR.

## Evidence

`simulatorPinnedBlock` is populated from the same `block` already resolved once per run and threaded through every `traceWithCalls`/`traceWithDiff`/`estimateGasWithOverrides` call. It is present on every outcome — success or halted — except the one case where `resolveSimulationBlock` itself fails before any transaction is attempted, since no block was ever pinned there:

```
packages/simulator/test/receipt-simulator.test.ts
✓ reports the exact base block it pinned and reused for the whole run
✓ still reports the pinned block on a halted run
✓ omits simulatorPinnedBlock when block resolution itself fails, since no block was ever pinned
```

`pnpm test:offline` at the repo root: all packages pass, no regressions.