### PR TITLE
fix(deps): update hono and js-yaml overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,10 @@ settings:
 overrides:
   fast-uri: 3.1.7
   qs: 6.16.0
-  hono: 4.12.34
+  hono: 4.13.7
   ip-address: 10.3.1
-  js-yaml@^3.0.0: 3.15.1
-  js-yaml@^4.0.0: 4.3.1
+  js-yaml@^3.0.0: 3.15.2
+  js-yaml@^4.0.0: 4.3.2
   nanoid: 3.3.18
   postcss: 8.5.23
 
@@ -1235,7 +1235,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.34
+      hono: 4.13.7
 
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
@@ -1899,8 +1899,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.34:
-    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1971,12 +1971,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -2727,7 +2727,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -2996,9 +2996,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@2.0.12(hono@4.12.34)':
+  '@hono/node-server@2.0.12(hono@4.13.7)':
     dependencies:
-      hono: 4.12.34
+      hono: 4.13.7
 
   '@inquirer/external-editor@1.0.3(@types/node@22.20.0)':
     dependencies:
@@ -3039,7 +3039,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.34)
+      '@hono/node-server': 2.0.12(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -3049,7 +3049,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.34
+      hono: 4.13.7
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3735,7 +3735,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.34: {}
+  hono@4.13.7: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -3787,12 +3787,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -4011,7 +4011,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,9 @@ minimumReleaseAge: 1440
 overrides:
   fast-uri: 3.1.7
   qs: 6.16.0
-  hono: 4.12.34
+  hono: 4.13.7
   ip-address: 10.3.1
-  "js-yaml@^3.0.0": 3.15.1
-  "js-yaml@^4.0.0": 4.3.1
+  "js-yaml@^3.0.0": 3.15.2
+  "js-yaml@^4.0.0": 4.3.2
   nanoid: 3.3.18
   postcss: 8.5.23


### PR DESCRIPTION
## What

Follow-up to #191 (and #125) for the advisories published on 2026-09-08, which post-date that PR and its review.

Workspace overrides:

* `hono` 4.12.34 -> **4.13.7** — GHSA-crvj-82cr-hjcx, GHSA-g6gw-c38x-mqfc, GHSA-gqvv-2mrq-wpjv (moderate, first patched in 4.13.5), plus the `hono/jsx` XSS GHSA-hxh3-vqpv-xpqv fixed in 4.13.7. Production path: `@themoss/mcp-server > @modelcontextprotocol/sdk > @hono/node-server@2.0.12` (peer `hono: ^4`).
* `js-yaml@^3.0.0` 3.15.1 -> **3.15.2** and `js-yaml@^4.0.0` 4.3.1 -> **4.3.2** — GHSA-2883-xcg3-v3hh (high; dev-only via `@changesets/cli`).

The lockfile contains only the matching resolution changes (overrides block, three package entries, and the `@hono/node-server(hono@…)` / `@changesets` edges). No source, API, Protocol, or documentation change; changeset N/A per the #188/#191 precedent.

## Verification

* `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm build`, `pnpm typecheck`, `pnpm test:offline`: pass (MCP 22/22).
* `pnpm audit --prod`: **0 advisories**.
* Full audit: only `vitest`/`@vitest/mocker@3.2.6` moderate GHSA-82fw-gwwq-j7x9 (patched in vitest ≥4.1.11 — a major bump that ADR 0001 pins away from; separate decision) and the pre-existing dev-only `esbuild@0.27.7` low.
* Integrity of `hono@4.13.7`, `js-yaml@3.15.2`, `js-yaml@4.3.2` matches the npm registry; all three were published 2026-08-26/2026-09-04, well past `minimumReleaseAge: 1440`.
* `pnpm install --lockfile-only` is a no-op on the regenerated lockfile; `git diff --check` clean.

The hosted `ci` job will stay red on the Aave wall-clock quarantine (#185, #195) exactly as on `main`; that failure is unrelated to this change.
